### PR TITLE
[Crypto] Use stronger rand for key generation [rpcserver]

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -560,6 +560,14 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]],
  [ AC_MSG_RESULT(no)]
 )
 
+AC_MSG_CHECKING(for getentropy via random.h)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>
+ #include <sys/random.h>]],
+ [[ getentropy(nullptr, 32) ]])],
+ [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_GETENTROPY_RAND, 1,[Define this symbol if the BSD getentropy system call is available with sys/random.h]) ],
+ [ AC_MSG_RESULT(no)]
+)
+
 AC_MSG_CHECKING(for sysctl KERN_ARND)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
   #include <sys/sysctl.h>]],

--- a/configure.ac
+++ b/configure.ac
@@ -514,6 +514,14 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/socket.h>]],
  [ AC_MSG_RESULT(no)]
 )
 
+dnl Check for MSG_DONTWAIT
+AC_MSG_CHECKING(for MSG_DONTWAIT)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/socket.h>]],
+ [[ int f = MSG_DONTWAIT; ]])],
+ [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_MSG_DONTWAIT, 1,[Define this symbol if you have MSG_DONTWAIT]) ],
+ [ AC_MSG_RESULT(no)]
+)
+
 AC_SEARCH_LIBS([clock_gettime],[rt])
 
 AC_MSG_CHECKING([for visibility attribute])

--- a/configure.ac
+++ b/configure.ac
@@ -535,6 +535,32 @@ AC_LINK_IFELSE([AC_LANG_SOURCE([
   ]
 )
 
+# Check for different ways of gathering OS randomness
+AC_MSG_CHECKING(for Linux getrandom syscall)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>
+  #include <sys/syscall.h>
+  #include <linux/random.h>]],
+ [[ syscall(SYS_getrandom, nullptr, 32, 0); ]])],
+ [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_SYS_GETRANDOM, 1,[Define this symbol if the Linux getrandom system call is available]) ],
+ [ AC_MSG_RESULT(no)]
+)
+
+AC_MSG_CHECKING(for getentropy)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]],
+ [[ getentropy(nullptr, 32) ]])],
+ [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_GETENTROPY, 1,[Define this symbol if the BSD getentropy system call is available]) ],
+ [ AC_MSG_RESULT(no)]
+)
+
+AC_MSG_CHECKING(for sysctl KERN_ARND)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
+  #include <sys/sysctl.h>]],
+ [[ static const int name[2] = {CTL_KERN, KERN_ARND};
+    sysctl(name, 2, nullptr, nullptr, nullptr, 0); ]])],
+ [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_SYSCTL_ARND, 1,[Define this symbol if the BSD sysctl(KERN_ARND) is available]) ],
+ [ AC_MSG_RESULT(no)]
+)
+
 if test x$use_reduce_exports != xno; then
   AX_CHECK_COMPILE_FLAG([-fvisibility=hidden],[RE_CXXFLAGS="-fvisibility=hidden"],
   [

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -292,6 +292,8 @@ crypto_libbitcoin_crypto_a_SOURCES = \
   crypto/sha1.cpp \
   crypto/sha256.cpp \
   crypto/sha512.cpp \
+  crypto/chacha20.h \
+  crypto/chacha20.cpp \
   crypto/hmac_sha256.cpp \
   crypto/rfc6979_hmac_sha256.cpp \
   crypto/hmac_sha512.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -66,6 +66,7 @@ BITCOIN_TESTS =\
   test/sigopcount_tests.cpp \
   test/skiplist_tests.cpp \
   test/test_dapscoin.cpp \
+  test/test_random.h \
   test/timedata_tests.cpp \
   test/torcontrol_tests.cpp \
   test/transaction_tests.cpp \

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -355,8 +355,8 @@ CAddrInfo CAddrMan::Select_()
             int nKBucket = GetRandInt(ADDRMAN_TRIED_BUCKET_COUNT);
             int nKBucketPos = GetRandInt(ADDRMAN_BUCKET_SIZE);
             while (vvTried[nKBucket][nKBucketPos] == -1) {
-                nKBucket = (nKBucket + insecure_rand.rand32()) % ADDRMAN_TRIED_BUCKET_COUNT;
-                nKBucketPos = (nKBucketPos + insecure_rand.rand32()) % ADDRMAN_BUCKET_SIZE;
+                nKBucket = (nKBucket + insecure_rand.randbits(ADDRMAN_TRIED_BUCKET_COUNT_LOG2)) % ADDRMAN_TRIED_BUCKET_COUNT;
+                nKBucketPos = (nKBucketPos + insecure_rand.randbits(ADDRMAN_BUCKET_SIZE_LOG2)) % ADDRMAN_BUCKET_SIZE;
             }
             int nId = vvTried[nKBucket][nKBucketPos];
             assert(mapInfo.count(nId) == 1);
@@ -372,8 +372,8 @@ CAddrInfo CAddrMan::Select_()
             int nUBucket = GetRandInt(ADDRMAN_NEW_BUCKET_COUNT);
             int nUBucketPos = GetRandInt(ADDRMAN_BUCKET_SIZE);
             while (vvNew[nUBucket][nUBucketPos] == -1) {
-                nUBucket = (nUBucket + insecure_rand.rand32()) % ADDRMAN_NEW_BUCKET_COUNT;
-                nUBucketPos = (nUBucketPos + insecure_rand.rand32()) % ADDRMAN_BUCKET_SIZE;
+                nUBucket = (nUBucket + insecure_rand.randbits(ADDRMAN_NEW_BUCKET_COUNT_LOG2)) % ADDRMAN_NEW_BUCKET_COUNT;
+                nUBucketPos = (nUBucketPos + insecure_rand.randbits(ADDRMAN_BUCKET_SIZE_LOG2)) % ADDRMAN_BUCKET_SIZE;
             }
             int nId = vvNew[nUBucket][nUBucketPos];
             assert(mapInfo.count(nId) == 1);

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -355,8 +355,8 @@ CAddrInfo CAddrMan::Select_()
             int nKBucket = GetRandInt(ADDRMAN_TRIED_BUCKET_COUNT);
             int nKBucketPos = GetRandInt(ADDRMAN_BUCKET_SIZE);
             while (vvTried[nKBucket][nKBucketPos] == -1) {
-                nKBucket = (nKBucket + insecure_rand()) % ADDRMAN_TRIED_BUCKET_COUNT;
-                nKBucketPos = (nKBucketPos + insecure_rand()) % ADDRMAN_BUCKET_SIZE;
+                nKBucket = (nKBucket + insecure_rand.rand32()) % ADDRMAN_TRIED_BUCKET_COUNT;
+                nKBucketPos = (nKBucketPos + insecure_rand.rand32()) % ADDRMAN_BUCKET_SIZE;
             }
             int nId = vvTried[nKBucket][nKBucketPos];
             assert(mapInfo.count(nId) == 1);
@@ -372,8 +372,8 @@ CAddrInfo CAddrMan::Select_()
             int nUBucket = GetRandInt(ADDRMAN_NEW_BUCKET_COUNT);
             int nUBucketPos = GetRandInt(ADDRMAN_BUCKET_SIZE);
             while (vvNew[nUBucket][nUBucketPos] == -1) {
-                nUBucket = (nUBucket + insecure_rand()) % ADDRMAN_NEW_BUCKET_COUNT;
-                nUBucketPos = (nUBucketPos + insecure_rand()) % ADDRMAN_BUCKET_SIZE;
+                nUBucket = (nUBucket + insecure_rand.rand32()) % ADDRMAN_NEW_BUCKET_COUNT;
+                nUBucketPos = (nUBucketPos + insecure_rand.rand32()) % ADDRMAN_BUCKET_SIZE;
             }
             int nId = vvNew[nUBucket][nUBucketPos];
             assert(mapInfo.count(nId) == 1);

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -132,13 +132,13 @@ public:
  */
 
 //! total number of buckets for tried addresses
-#define ADDRMAN_TRIED_BUCKET_COUNT 256
+#define ADDRMAN_TRIED_BUCKET_COUNT_LOG2 8
 
 //! total number of buckets for new addresses
-#define ADDRMAN_NEW_BUCKET_COUNT 1024
+#define ADDRMAN_NEW_BUCKET_COUNT_LOG2 10
 
 //! maximum allowed number of entries in buckets for new and tried addresses
-#define ADDRMAN_BUCKET_SIZE 64
+#define ADDRMAN_BUCKET_SIZE_LOG2 6
 
 //! over how many buckets entries with tried addresses from a single group (/16 for IPv4) are spread
 #define ADDRMAN_TRIED_BUCKETS_PER_GROUP 8
@@ -166,6 +166,11 @@ public:
 
 //! the maximum number of nodes to return in a getaddr call
 #define ADDRMAN_GETADDR_MAX 2500
+
+//! Convenience
+#define ADDRMAN_TRIED_BUCKET_COUNT (1 << ADDRMAN_TRIED_BUCKET_COUNT_LOG2)
+#define ADDRMAN_NEW_BUCKET_COUNT (1 << ADDRMAN_NEW_BUCKET_COUNT_LOG2)
+#define ADDRMAN_BUCKET_SIZE (1 << ADDRMAN_BUCKET_SIZE_LOG2)
 
 /** 
  * Stochastical (IP) address manager 

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -207,6 +207,9 @@ private:
     int64_t nLastGood;
 
 protected:
+    //! Source of random numbers for randomization in inner loops
+    FastRandomContext insecure_rand;
+
     //! Find an entry.
     CAddrInfo* Find(const CNetAddr& addr, int* pnId = NULL);
 

--- a/src/crypto/chacha20.cpp
+++ b/src/crypto/chacha20.cpp
@@ -1,0 +1,180 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Based on the public domain implementation 'merged' by D. J. Bernstein
+// See https://cr.yp.to/chacha.html.
+
+#include "crypto/common.h"
+#include "crypto/chacha20.h"
+
+#include <string.h>
+
+constexpr static inline uint32_t rotl32(uint32_t v, int c) { return (v << c) | (v >> (32 - c)); }
+
+#define QUARTERROUND(a,b,c,d) \
+  a += b; d = rotl32(d ^ a, 16); \
+  c += d; b = rotl32(b ^ c, 12); \
+  a += b; d = rotl32(d ^ a, 8); \
+  c += d; b = rotl32(b ^ c, 7);
+
+static const unsigned char sigma[] = "expand 32-byte k";
+static const unsigned char tau[] = "expand 16-byte k";
+
+void ChaCha20::SetKey(const unsigned char* k, size_t keylen)
+{
+    const unsigned char *constants;
+
+    input[4] = ReadLE32(k + 0);
+    input[5] = ReadLE32(k + 4);
+    input[6] = ReadLE32(k + 8);
+    input[7] = ReadLE32(k + 12);
+    if (keylen == 32) { /* recommended */
+        k += 16;
+        constants = sigma;
+    } else { /* keylen == 16 */
+        constants = tau;
+    }
+    input[8] = ReadLE32(k + 0);
+    input[9] = ReadLE32(k + 4);
+    input[10] = ReadLE32(k + 8);
+    input[11] = ReadLE32(k + 12);
+    input[0] = ReadLE32(constants + 0);
+    input[1] = ReadLE32(constants + 4);
+    input[2] = ReadLE32(constants + 8);
+    input[3] = ReadLE32(constants + 12);
+    input[12] = 0;
+    input[13] = 0;
+    input[14] = 0;
+    input[15] = 0;
+}
+
+ChaCha20::ChaCha20()
+{
+    memset(input, 0, sizeof(input));
+}
+
+ChaCha20::ChaCha20(const unsigned char* k, size_t keylen)
+{
+    SetKey(k, keylen);
+}
+
+void ChaCha20::SetIV(uint64_t iv)
+{
+    input[14] = iv;
+    input[15] = iv >> 32;
+}
+
+void ChaCha20::Seek(uint64_t pos)
+{
+    input[12] = pos;
+    input[13] = pos >> 32;
+}
+
+void ChaCha20::Output(unsigned char* c, size_t bytes)
+{
+    uint32_t x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15;
+    uint32_t j0, j1, j2, j3, j4, j5, j6, j7, j8, j9, j10, j11, j12, j13, j14, j15;
+    unsigned char *ctarget = NULL;
+    unsigned char tmp[64];
+    unsigned int i;
+
+    if (!bytes) return;
+
+    j0 = input[0];
+    j1 = input[1];
+    j2 = input[2];
+    j3 = input[3];
+    j4 = input[4];
+    j5 = input[5];
+    j6 = input[6];
+    j7 = input[7];
+    j8 = input[8];
+    j9 = input[9];
+    j10 = input[10];
+    j11 = input[11];
+    j12 = input[12];
+    j13 = input[13];
+    j14 = input[14];
+    j15 = input[15];
+
+    for (;;) {
+        if (bytes < 64) {
+            ctarget = c;
+            c = tmp;
+        }
+        x0 = j0;
+        x1 = j1;
+        x2 = j2;
+        x3 = j3;
+        x4 = j4;
+        x5 = j5;
+        x6 = j6;
+        x7 = j7;
+        x8 = j8;
+        x9 = j9;
+        x10 = j10;
+        x11 = j11;
+        x12 = j12;
+        x13 = j13;
+        x14 = j14;
+        x15 = j15;
+        for (i = 20;i > 0;i -= 2) {
+            QUARTERROUND( x0, x4, x8,x12)
+            QUARTERROUND( x1, x5, x9,x13)
+            QUARTERROUND( x2, x6,x10,x14)
+            QUARTERROUND( x3, x7,x11,x15)
+            QUARTERROUND( x0, x5,x10,x15)
+            QUARTERROUND( x1, x6,x11,x12)
+            QUARTERROUND( x2, x7, x8,x13)
+            QUARTERROUND( x3, x4, x9,x14)
+        }
+        x0 += j0;
+        x1 += j1;
+        x2 += j2;
+        x3 += j3;
+        x4 += j4;
+        x5 += j5;
+        x6 += j6;
+        x7 += j7;
+        x8 += j8;
+        x9 += j9;
+        x10 += j10;
+        x11 += j11;
+        x12 += j12;
+        x13 += j13;
+        x14 += j14;
+        x15 += j15;
+
+        ++j12;
+        if (!j12) ++j13;
+
+        WriteLE32(c + 0, x0);
+        WriteLE32(c + 4, x1);
+        WriteLE32(c + 8, x2);
+        WriteLE32(c + 12, x3);
+        WriteLE32(c + 16, x4);
+        WriteLE32(c + 20, x5);
+        WriteLE32(c + 24, x6);
+        WriteLE32(c + 28, x7);
+        WriteLE32(c + 32, x8);
+        WriteLE32(c + 36, x9);
+        WriteLE32(c + 40, x10);
+        WriteLE32(c + 44, x11);
+        WriteLE32(c + 48, x12);
+        WriteLE32(c + 52, x13);
+        WriteLE32(c + 56, x14);
+        WriteLE32(c + 60, x15);
+
+        if (bytes <= 64) {
+            if (bytes < 64) {
+                for (i = 0;i < bytes;++i) ctarget[i] = c[i];
+            }
+            input[12] = j12;
+            input[13] = j13;
+            return;
+        }
+        bytes -= 64;
+        c += 64;
+    }
+}

--- a/src/crypto/chacha20.cpp
+++ b/src/crypto/chacha20.cpp
@@ -73,105 +73,53 @@ void ChaCha20::Seek(uint64_t pos)
 
 void ChaCha20::Output(unsigned char* c, size_t bytes)
 {
-    uint32_t x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15;
-    uint32_t j0, j1, j2, j3, j4, j5, j6, j7, j8, j9, j10, j11, j12, j13, j14, j15;
-    unsigned char *ctarget = NULL;
+    uint32_t x[16];
+    uint32_t j[16];
+    unsigned char *ctarget = nullptr;
     unsigned char tmp[64];
     unsigned int i;
 
     if (!bytes) return;
 
-    j0 = input[0];
-    j1 = input[1];
-    j2 = input[2];
-    j3 = input[3];
-    j4 = input[4];
-    j5 = input[5];
-    j6 = input[6];
-    j7 = input[7];
-    j8 = input[8];
-    j9 = input[9];
-    j10 = input[10];
-    j11 = input[11];
-    j12 = input[12];
-    j13 = input[13];
-    j14 = input[14];
-    j15 = input[15];
+    for (uint32_t i=0; i<16; i++) {
+        j[i] = input[i];
+    }
 
     for (;;) {
         if (bytes < 64) {
             ctarget = c;
             c = tmp;
         }
-        x0 = j0;
-        x1 = j1;
-        x2 = j2;
-        x3 = j3;
-        x4 = j4;
-        x5 = j5;
-        x6 = j6;
-        x7 = j7;
-        x8 = j8;
-        x9 = j9;
-        x10 = j10;
-        x11 = j11;
-        x12 = j12;
-        x13 = j13;
-        x14 = j14;
-        x15 = j15;
-        for (i = 20;i > 0;i -= 2) {
-            QUARTERROUND( x0, x4, x8,x12)
-            QUARTERROUND( x1, x5, x9,x13)
-            QUARTERROUND( x2, x6,x10,x14)
-            QUARTERROUND( x3, x7,x11,x15)
-            QUARTERROUND( x0, x5,x10,x15)
-            QUARTERROUND( x1, x6,x11,x12)
-            QUARTERROUND( x2, x7, x8,x13)
-            QUARTERROUND( x3, x4, x9,x14)
+        for (uint32_t i=0; i<16; i++) {
+            x[i] = j[i];
         }
-        x0 += j0;
-        x1 += j1;
-        x2 += j2;
-        x3 += j3;
-        x4 += j4;
-        x5 += j5;
-        x6 += j6;
-        x7 += j7;
-        x8 += j8;
-        x9 += j9;
-        x10 += j10;
-        x11 += j11;
-        x12 += j12;
-        x13 += j13;
-        x14 += j14;
-        x15 += j15;
+        for (i = 20;i > 0;i -= 2) {
+            QUARTERROUND( x[0], x[4], x[8],x[12])
+            QUARTERROUND( x[1], x[5], x[9],x[13])
+            QUARTERROUND( x[2], x[6],x[10],x[14])
+            QUARTERROUND( x[3], x[7],x[11],x[15])
+            QUARTERROUND( x[0], x[5],x[10],x[15])
+            QUARTERROUND( x[1], x[6],x[11],x[12])
+            QUARTERROUND( x[2], x[7], x[8],x[13])
+            QUARTERROUND( x[3], x[4], x[9],x[14])
+        }
+        for (uint32_t i=0; i<16; i++) {
+            x[i] += j[i];
+        }
 
-        ++j12;
-        if (!j12) ++j13;
+        ++j[12];
+        if (!j[12]) ++j[13];
 
-        WriteLE32(c + 0, x0);
-        WriteLE32(c + 4, x1);
-        WriteLE32(c + 8, x2);
-        WriteLE32(c + 12, x3);
-        WriteLE32(c + 16, x4);
-        WriteLE32(c + 20, x5);
-        WriteLE32(c + 24, x6);
-        WriteLE32(c + 28, x7);
-        WriteLE32(c + 32, x8);
-        WriteLE32(c + 36, x9);
-        WriteLE32(c + 40, x10);
-        WriteLE32(c + 44, x11);
-        WriteLE32(c + 48, x12);
-        WriteLE32(c + 52, x13);
-        WriteLE32(c + 56, x14);
-        WriteLE32(c + 60, x15);
+        for (uint32_t i=0; i<16; i++) {
+            WriteLE32(c + 4*i, x[i]);
+        }
 
         if (bytes <= 64) {
             if (bytes < 64) {
                 for (i = 0;i < bytes;++i) ctarget[i] = c[i];
             }
-            input[12] = j12;
-            input[13] = j13;
+            input[12] = j[12];
+            input[13] = j[13];
             return;
         }
         bytes -= 64;

--- a/src/crypto/chacha20.h
+++ b/src/crypto/chacha20.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CRYPTO_CHACHA20_H
+#define BITCOIN_CRYPTO_CHACHA20_H
+
+#include <stdint.h>
+#include <stdlib.h>
+
+/** A PRNG class for ChaCha20. */
+class ChaCha20
+{
+private:
+    uint32_t input[16];
+
+public:
+    ChaCha20();
+    ChaCha20(const unsigned char* key, size_t keylen);
+    void SetKey(const unsigned char* key, size_t keylen);
+    void SetIV(uint64_t iv);
+    void Seek(uint64_t pos);
+    void Output(unsigned char* output, size_t bytes);
+};
+
+#endif // BITCOIN_CRYPTO_CHACHA20_H

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -113,4 +113,25 @@ void static inline WriteBE64(unsigned char* ptr, uint64_t x)
 #endif
 }
 
+/** Return the smallest number n such that (x >> n) == 0 (or 64 if the highest bit in x is set. */
+uint64_t static inline CountBits(uint64_t x)
+{
+#ifdef HAVE_DECL___BUILTIN_CLZL
+    if (sizeof(unsigned long) >= sizeof(uint64_t)) {
+        return x ? 8 * sizeof(unsigned long) - __builtin_clzl(x) : 0;
+    }
+#endif
+#ifdef HAVE_DECL___BUILTIN_CLZLL
+    if (sizeof(unsigned long long) >= sizeof(uint64_t)) {
+        return x ? 8 * sizeof(unsigned long long) - __builtin_clzll(x) : 0;
+    }
+#endif
+    int ret = 0;
+    while (x) {
+        x >>= 1;
+        ++ret;
+    }
+    return ret;
+}
+
 #endif // BITCOIN_CRYPTO_COMMON_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -719,8 +719,14 @@ bool InitSanityCheck(void)
                   "information, visit https://en.bitcoin.it/wiki/OpenSSL_and_EC_Libraries");
         return false;
     }
+
     if (!glibc_sanity_test() || !glibcxx_sanity_test())
         return false;
+
+    if (!Random_SanityCheck()) {
+        InitError("OS cryptographic RNG sanity check failure. Aborting.");
+        return false;
+    }
 
     return true;
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1046,6 +1046,8 @@ bool AppInit2(bool isDaemon)
 
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log
 
+    RandomInit();
+
     // Sanity check
     if (!InitSanityCheck())
         return InitError(_("Initialization sanity check failed. DAPS is shutting down."));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1616,8 +1616,6 @@ bool AppInit2(bool isDaemon)
 
         if (fFirstRun) {
             // Create new keyUser and set as default key
-            RandAddSeedPerfmon();
-
             if (!pwalletMain->IsHDEnabled()) {
                 if (!isDaemon) {
                     uiInterface.ShowRecoveryDialog();
@@ -1896,8 +1894,6 @@ bool AppInit2(bool isDaemon)
 
     if (!strErrors.str().empty())
         return InitError(strErrors.str());
-
-    RandAddSeedPerfmon();
 
     //// debug print
     LogPrintf("mapBlockIndex.size() = %u\n", mapBlockIndex.size());

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -39,9 +39,8 @@ bool CKey::Check(const unsigned char* vch)
 
 void CKey::MakeNewKey(bool fCompressedIn)
 {
-    RandAddSeedPerfmon();
     do {
-        GetRandBytes(vch, sizeof(vch));
+        GetStrongRandBytes(vch, sizeof(vch));
     } while (!Check(vch));
     fValid = true;
     fCompressed = fCompressedIn;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5726,7 +5726,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     CNodeState* state = State(pfrom->GetId());
     if (state == NULL)
         return false;
-    RandAddSeedPerfmon();
     if (fDebug)
         LogPrintf("received: %s (%u bytes) peer=%d, chainheight=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->id, chainActive.Height());
     if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5492,7 +5492,6 @@ bool static AlreadyHave(const CInv& inv)
     return true;
 }
 
-
 void static ProcessGetData(CNode* pfrom)
 {
     AssertLockNotHeld(cs_main);
@@ -5800,11 +5799,12 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             // Advertise our address
             if (fListen && !IsInitialBlockDownload()) {
                 CAddress addr = GetLocalAddress(&pfrom->addr);
+                FastRandomContext insecure_rand;
                 if (addr.IsRoutable()) {
-                    pfrom->PushAddress(addr);
+                    pfrom->PushAddress(addr, insecure_rand);
                 } else if (IsPeerAddrLocalGood(pfrom)) {
                     addr.SetIP(pfrom->addrLocal);
-                    pfrom->PushAddress(addr);
+                    pfrom->PushAddress(addr, insecure_rand);
                 }
             }
 
@@ -5895,9 +5895,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                         mapMix.insert(make_pair(hashKey, pnode));
                     }
                     int nRelayNodes = fReachable ? 2 : 1; // limited relaying of addresses outside our network(s)
+                    FastRandomContext insecure_rand;
                     for (multimap<uint256, CNode*>::iterator mi = mapMix.begin();
-                         mi != mapMix.end() && nRelayNodes-- > 0; ++mi)
-                        ((*mi).second)->PushAddress(addr);
+                        mi != mapMix.end() && nRelayNodes-- > 0; ++mi)
+                        ((*mi).second)->PushAddress(addr, insecure_rand);
                 }
             }
             // Do not store addresses outside our network
@@ -6332,8 +6333,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     else if ((strCommand == "getaddr") && (pfrom->fInbound)) {
         pfrom->vAddrToSend.clear();
         vector<CAddress> vAddr = addrman.GetAddr();
+        FastRandomContext insecure_rand;
         for (const CAddress& addr : vAddr)
-            pfrom->PushAddress(addr);
+            pfrom->PushAddress(addr, insecure_rand);
     } else if (strCommand == "mempool") {
         LOCK2(cs_main, pfrom->cs_filter);
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -237,7 +237,8 @@ void AdvertiseLocal(CNode* pnode)
         }
         if (addrLocal.IsRoutable()) {
             LogPrintf("AdvertiseLocal: advertising address %s\n", addrLocal.ToString());
-            pnode->PushAddress(addrLocal);
+            FastRandomContext insecure_rand;
+            pnode->PushAddress(addrLocal, insecure_rand);
         }
     }
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -236,7 +236,7 @@ void AdvertiseLocal(CNode* pnode)
             addrLocal.SetIP(pnode->addrLocal);
         }
         if (addrLocal.IsRoutable()) {
-            LogPrintf("AdvertiseLocal: advertising address %s\n", addrLocal.ToString());
+            LogPrintf("%s: advertising address %s\n", __func__, addrLocal.ToString());
             FastRandomContext insecure_rand;
             pnode->PushAddress(addrLocal, insecure_rand);
         }

--- a/src/net.h
+++ b/src/net.h
@@ -453,7 +453,7 @@ public:
         // after addresses were pushed.
         if (addr.IsValid() && !setAddrKnown.count(addr)) {
             if (vAddrToSend.size() >= MAX_ADDR_TO_SEND) {
-                vAddrToSend[insecure_rand.rand32() % vAddrToSend.size()] = _addr;
+                vAddrToSend[insecure_rand.randrange(vAddrToSend.size())] = _addr;
             } else {
                 vAddrToSend.push_back(addr);
             }

--- a/src/net.h
+++ b/src/net.h
@@ -446,14 +446,14 @@ public:
         setAddrKnown.insert(addr);
     }
 
-    void PushAddress(const CAddress& addr)
+    void PushAddress(const CAddress& _addr, FastRandomContext &insecure_rand)
     {
         // Known checking here is only to save space from duplicates.
         // SendMessages will filter it again for knowns that were added
         // after addresses were pushed.
         if (addr.IsValid() && !setAddrKnown.count(addr)) {
             if (vAddrToSend.size() >= MAX_ADDR_TO_SEND) {
-                vAddrToSend[insecure_rand() % vAddrToSend.size()] = addr;
+                vAddrToSend[insecure_rand.rand32() % vAddrToSend.size()] = _addr;
             } else {
                 vAddrToSend.push_back(addr);
             }

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -16,6 +16,8 @@
 #include "util.h"
 #include "utilstrencodings.h"
 
+#include <atomic>
+
 #ifdef HAVE_GETADDRINFO_A
 #include <netdb.h>
 #endif

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -601,8 +601,8 @@ static bool ConnectThroughProxy(const proxyType &proxy, const std::string strDes
     // do socks negotiation
     if (proxy.randomize_credentials) {
         ProxyCredentials random_auth;
-        random_auth.username = strprintf("%i", insecure_rand());
-        random_auth.password = strprintf("%i", insecure_rand());
+        static std::atomic_int counter;
+        random_auth.username = random_auth.password = strprintf("%i", counter++);
         if (!Socks5(strDest, (unsigned short)port, &random_auth, hSocket))
             return false;
     } else {

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -102,6 +102,28 @@ static void RandAddSeedPerfmon()
 #endif
 }
 
+#ifndef WIN32
+/** Fallback: get 32 bytes of system entropy from /dev/urandom. The most
+ * compatible way to get cryptographic randomness on UNIX-ish platforms.
+ */
+void GetDevURandom(unsigned char *ent32)
+{
+    int f = open("/dev/urandom", O_RDONLY);
+    if (f == -1) {
+        RandFailure();
+    }
+    int have = 0;
+    do {
+        ssize_t n = read(f, ent32 + have, NUM_OS_RANDOM_BYTES - have);
+        if (n <= 0 || n + have > NUM_OS_RANDOM_BYTES) {
+            RandFailure();
+        }
+        have += n;
+    } while (have < NUM_OS_RANDOM_BYTES);
+    close(f);
+}
+#endif
+
 /** Get 32 bytes of system entropy. */
 void GetOSRand(unsigned char *ent32)
 {
@@ -122,8 +144,17 @@ void GetOSRand(unsigned char *ent32)
      * will always return as many bytes as requested and will not be
      * interrupted by signals."
      */
-    if (syscall(SYS_getrandom, ent32, NUM_OS_RANDOM_BYTES, 0) != NUM_OS_RANDOM_BYTES) {
-        RandFailure();
+    int rv = syscall(SYS_getrandom, ent32, NUM_OS_RANDOM_BYTES, 0);
+    if (rv != NUM_OS_RANDOM_BYTES) {
+        if (rv < 0 && errno == ENOSYS) {
+            /* Fallback for kernel <3.17: the return value will be -1 and errno
+             * ENOSYS if the syscall is not available, in that case fall back
+             * to /dev/urandom.
+             */
+            GetDevURandom(ent32);
+        } else {
+            RandFailure();
+        }
     }
 #elif defined(HAVE_GETENTROPY)
     /* On OpenBSD this can return up to 256 bytes of entropy, will return an
@@ -150,19 +181,7 @@ void GetOSRand(unsigned char *ent32)
     /* Fall back to /dev/urandom if there is no specific method implemented to
      * get system entropy for this OS.
      */
-    int f = open("/dev/urandom", O_RDONLY);
-    if (f == -1) {
-        RandFailure();
-    }
-    int have = 0;
-    do {
-        ssize_t n = read(f, ent32 + have, NUM_OS_RANDOM_BYTES - have);
-        if (n <= 0 || n + have > NUM_OS_RANDOM_BYTES) {
-            RandFailure();
-        }
-        have += n;
-    } while (have < NUM_OS_RANDOM_BYTES);
-    close(f);
+    GetDevURandom(ent32);
 #endif
 }
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -255,23 +255,21 @@ uint256 GetRandHash()
     return hash;
 }
 
-uint32_t insecure_rand_Rz = 11;
-uint32_t insecure_rand_Rw = 11;
-void seed_insecure_rand(bool fDeterministic)
+FastRandomContext::FastRandomContext(bool fDeterministic)
 {
     // The seed values have some unlikely fixed points which we avoid.
     if (fDeterministic) {
-        insecure_rand_Rz = insecure_rand_Rw = 11;
+        Rz = Rw = 11;
     } else {
         uint32_t tmp;
         do {
             GetRandBytes((unsigned char*)&tmp, 4);
         } while (tmp == 0 || tmp == 0x9068ffffU);
-        insecure_rand_Rz = tmp;
+        Rz = tmp;
         do {
             GetRandBytes((unsigned char*)&tmp, 4);
         } while (tmp == 0 || tmp == 0x464fffffU);
-        insecure_rand_Rw = tmp;
+        Rw = tmp;
     }
 }
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -240,3 +240,34 @@ void seed_insecure_rand(bool fDeterministic)
         insecure_rand_Rw = tmp;
     }
 }
+
+bool Random_SanityCheck()
+{
+    /* This does not measure the quality of randomness, but it does test that
+     * OSRandom() overwrites all 32 bytes of the output given a maximum
+     * number of tries.
+     */
+    static const ssize_t MAX_TRIES = 1024;
+    uint8_t data[NUM_OS_RANDOM_BYTES];
+    bool overwritten[NUM_OS_RANDOM_BYTES] = {}; /* Tracks which bytes have been overwritten at least once */
+    int num_overwritten;
+    int tries = 0;
+    /* Loop until all bytes have been overwritten at least once, or max number tries reached */
+    do {
+        memset(data, 0, NUM_OS_RANDOM_BYTES);
+        GetOSRand(data);
+        for (int x=0; x < NUM_OS_RANDOM_BYTES; ++x) {
+            overwritten[x] |= (data[x] != 0);
+        }
+
+        num_overwritten = 0;
+        for (int x=0; x < NUM_OS_RANDOM_BYTES; ++x) {
+            if (overwritten[x]) {
+                num_overwritten += 1;
+            }
+        }
+
+        tries += 1;
+    } while (num_overwritten < NUM_OS_RANDOM_BYTES && tries < MAX_TRIES);
+    return (num_overwritten == NUM_OS_RANDOM_BYTES); /* If this failed, bailed out after too many tries */
+}

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -255,22 +255,16 @@ uint256 GetRandHash()
     return hash;
 }
 
-FastRandomContext::FastRandomContext(bool fDeterministic)
+void FastRandomContext::RandomSeed()
 {
-    // The seed values have some unlikely fixed points which we avoid.
-    if (fDeterministic) {
-        Rz = Rw = 11;
-    } else {
-        uint32_t tmp;
-        do {
-            GetRandBytes((unsigned char*)&tmp, 4);
-        } while (tmp == 0 || tmp == 0x9068ffffU);
-        Rz = tmp;
-        do {
-            GetRandBytes((unsigned char*)&tmp, 4);
-        } while (tmp == 0 || tmp == 0x464fffffU);
-        Rw = tmp;
-    }
+    uint256 seed = GetRandHash();
+    rng.SetKey(seed.begin(), 32);
+    requires_seed = false;
+}
+
+FastRandomContext::FastRandomContext(const uint256& seed) : requires_seed(false), bytebuf_size(0), bitbuf_size(0)
+{
+    rng.SetKey(seed.begin(), 32);
 }
 
 bool Random_SanityCheck()
@@ -302,4 +296,13 @@ bool Random_SanityCheck()
         tries += 1;
     } while (num_overwritten < NUM_OS_RANDOM_BYTES && tries < MAX_TRIES);
     return (num_overwritten == NUM_OS_RANDOM_BYTES); /* If this failed, bailed out after too many tries */
+}
+
+FastRandomContext::FastRandomContext(bool fDeterministic) : requires_seed(!fDeterministic), bytebuf_size(0), bitbuf_size(0)
+{
+    if (!fDeterministic) {
+        return;
+    }
+    uint256 seed;
+    rng.SetKey(seed.begin(), 32);
 }

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -40,6 +40,7 @@
 #include <mutex>
 
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
+#include <atomic>
 #include <cpuid.h>
 #endif
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -43,10 +43,10 @@
 #include <openssl/err.h>
 #include <openssl/rand.h>
 
-static void RandFailure()
+[[noreturn]] static void RandFailure()
 {
     LogPrintf("Failed to read randomness, aborting\n");
-    abort();
+    std::abort();
 }
 
 static inline int64_t GetPerformanceCounter()

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -16,6 +16,7 @@
 
 #include <stdlib.h>
 #include <limits>
+#include <chrono>
 
 #ifndef WIN32
 #include <sys/time.h>
@@ -45,15 +46,22 @@ static void RandFailure()
 
 static inline int64_t GetPerformanceCounter()
 {
-    int64_t nCounter = 0;
-#ifdef WIN32
-    QueryPerformanceCounter((LARGE_INTEGER*)&nCounter);
+    // Read the hardware time stamp counter when available.
+    // See https://en.wikipedia.org/wiki/Time_Stamp_Counter for more information.
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
+    return __rdtsc();
+#elif !defined(_MSC_VER) && defined(__i386__)
+    uint64_t r = 0;
+    __asm__ volatile ("rdtsc" : "=A"(r)); // Constrain the r variable to the eax:edx pair.
+    return r;
+#elif !defined(_MSC_VER) && (defined(__x86_64__) || defined(__amd64__))
+    uint64_t r1 = 0, r2 = 0;
+    __asm__ volatile ("rdtsc" : "=a"(r1), "=d"(r2)); // Constrain r1 to rax and r2 to rdx.
+    return (r2 << 32) | r1;
 #else
-    timeval t;
-    gettimeofday(&t, NULL);
-    nCounter = (int64_t)(t.tv_sec * 1000000 + t.tv_usec);
+    // Fall back to using C++11 clock (usually microsecond or nanosecond precision)
+    return std::chrono::high_resolution_clock::now().time_since_epoch().count();
 #endif
-    return nCounter;
 }
 
 void RandAddSeed()

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -14,6 +14,7 @@
 #include "util.h"             // for LogPrint()
 #include "utilstrencodings.h" // for GetTime()
 
+#include <stdlib.h>
 #include <limits>
 
 #ifndef WIN32
@@ -23,6 +24,12 @@
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
+
+static void RandFailure()
+{
+    LogPrintf("Failed to read randomness, aborting\n");
+    abort();
+}
 
 static inline int64_t GetPerformanceCounter()
 {
@@ -91,17 +98,25 @@ static void GetOSRand(unsigned char *ent32)
 #ifdef WIN32
     HCRYPTPROV hProvider;
     int ret = CryptAcquireContextW(&hProvider, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT);
-    assert(ret);
+    if (!ret) {
+        RandFailure();
+    }
     ret = CryptGenRandom(hProvider, 32, ent32);
-    assert(ret);
+    if (!ret) {
+        RandFailure();
+    }
     CryptReleaseContext(hProvider, 0);
 #else
     int f = open("/dev/urandom", O_RDONLY);
-    assert(f != -1);
+    if (f == -1) {
+        RandFailure();
+    }
     int have = 0;
     do {
         ssize_t n = read(f, ent32 + have, 32 - have);
-        assert(n > 0 && n <= 32 - have);
+        if (n <= 0 || n + have > 32) {
+            RandFailure();
+        }
         have += n;
     } while (have < 32);
     close(f);
@@ -111,8 +126,7 @@ static void GetOSRand(unsigned char *ent32)
 void GetRandBytes(unsigned char* buf, int num)
 {
     if (RAND_bytes(buf, num) != 1) {
-        LogPrintf("%s: OpenSSL RAND_bytes() failed with error: %s\n", __func__, ERR_error_string(ERR_get_error(), NULL));
-        assert(false);
+        RandFailure();
     }
 }
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -305,6 +305,26 @@ void FastRandomContext::RandomSeed()
     requires_seed = false;
 }
 
+uint256 FastRandomContext::rand256()
+{
+    if (bytebuf_size < 32) {
+        FillByteBuffer();
+    }
+    uint256 ret;
+    memcpy(ret.begin(), bytebuf + 64 - bytebuf_size, 32);
+    bytebuf_size -= 32;
+    return ret;
+}
+
+std::vector<unsigned char> FastRandomContext::randbytes(size_t len)
+{
+    std::vector<unsigned char> ret(len);
+    if (len > 0) {
+        rng.Output(&ret[0], len);
+    }
+    return ret;
+}
+
 FastRandomContext::FastRandomContext(const uint256& seed) : requires_seed(false), bytebuf_size(0), bitbuf_size(0)
 {
     rng.SetKey(seed.begin(), 32);

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -460,6 +460,20 @@ FastRandomContext::FastRandomContext(bool fDeterministic) : requires_seed(!fDete
     rng.SetKey(seed.begin(), 32);
 }
 
+FastRandomContext& FastRandomContext::operator=(FastRandomContext&& from) noexcept
+{
+    requires_seed = from.requires_seed;
+    rng = from.rng;
+    std::copy(std::begin(from.bytebuf), std::end(from.bytebuf), std::begin(bytebuf));
+    bytebuf_size = from.bytebuf_size;
+    bitbuf = from.bitbuf;
+    bitbuf_size = from.bitbuf_size;
+    from.requires_seed = true;
+    from.bytebuf_size = 0;
+    from.bitbuf_size = 0;
+    return *this;
+}
+
 void RandomInit()
 {
     RDRandInit();

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -394,6 +394,7 @@ uint256 FastRandomContext::rand256()
 
 std::vector<unsigned char> FastRandomContext::randbytes(size_t len)
 {
+    if (requires_seed) RandomSeed();
     std::vector<unsigned char> ret(len);
     if (len > 0) {
         rng.Output(&ret[0], len);

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -21,7 +21,17 @@
 #include <sys/time.h>
 #endif
 
-#include <openssl/crypto.h>
+#ifdef HAVE_SYS_GETRANDOM
+#include <sys/syscall.h>
+#include <linux/random.h>
+#endif
+#ifdef HAVE_GETENTROPY
+#include <unistd.h>
+#endif
+#ifdef HAVE_SYSCTL_ARND
+#include <sys/sysctl.h>
+#endif
+
 #include <openssl/err.h>
 #include <openssl/rand.h>
 
@@ -93,32 +103,65 @@ static void RandAddSeedPerfmon()
 }
 
 /** Get 32 bytes of system entropy. */
-static void GetOSRand(unsigned char *ent32)
+void GetOSRand(unsigned char *ent32)
 {
-#ifdef WIN32
+#if defined(WIN32)
     HCRYPTPROV hProvider;
     int ret = CryptAcquireContextW(&hProvider, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT);
     if (!ret) {
         RandFailure();
     }
-    ret = CryptGenRandom(hProvider, 32, ent32);
+    ret = CryptGenRandom(hProvider, NUM_OS_RANDOM_BYTES, ent32);
     if (!ret) {
         RandFailure();
     }
     CryptReleaseContext(hProvider, 0);
+#elif defined(HAVE_SYS_GETRANDOM)
+    /* Linux. From the getrandom(2) man page:
+     * "If the urandom source has been initialized, reads of up to 256 bytes
+     * will always return as many bytes as requested and will not be
+     * interrupted by signals."
+     */
+    if (syscall(SYS_getrandom, ent32, NUM_OS_RANDOM_BYTES, 0) != NUM_OS_RANDOM_BYTES) {
+        RandFailure();
+    }
+#elif defined(HAVE_GETENTROPY)
+    /* On OpenBSD this can return up to 256 bytes of entropy, will return an
+     * error if more are requested.
+     * The call cannot return less than the requested number of bytes.
+     */
+    if (getentropy(ent32, NUM_OS_RANDOM_BYTES) != 0) {
+        RandFailure();
+    }
+#elif defined(HAVE_SYSCTL_ARND)
+    /* FreeBSD and similar. It is possible for the call to return less
+     * bytes than requested, so need to read in a loop.
+     */
+    static const int name[2] = {CTL_KERN, KERN_ARND};
+    int have = 0;
+    do {
+        size_t len = NUM_OS_RANDOM_BYTES - have;
+        if (sysctl(name, ARRAYLEN(name), ent32 + have, &len, NULL, 0) != 0) {
+            RandFailure();
+        }
+        have += len;
+    } while (have < NUM_OS_RANDOM_BYTES);
 #else
+    /* Fall back to /dev/urandom if there is no specific method implemented to
+     * get system entropy for this OS.
+     */
     int f = open("/dev/urandom", O_RDONLY);
     if (f == -1) {
         RandFailure();
     }
     int have = 0;
     do {
-        ssize_t n = read(f, ent32 + have, 32 - have);
-        if (n <= 0 || n + have > 32) {
+        ssize_t n = read(f, ent32 + have, NUM_OS_RANDOM_BYTES - have);
+        if (n <= 0 || n + have > NUM_OS_RANDOM_BYTES) {
             RandFailure();
         }
         have += n;
-    } while (have < 32);
+    } while (have < NUM_OS_RANDOM_BYTES);
     close(f);
 #endif
 }

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -65,6 +65,63 @@ static inline int64_t GetPerformanceCounter()
 #endif
 }
 
+#if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
+static std::atomic<bool> hwrand_initialized{false};
+static bool rdrand_supported = false;
+static constexpr uint32_t CPUID_F1_ECX_RDRAND = 0x40000000;
+static void RDRandInit()
+{
+    //! When calling cpuid function #1, ecx register will have this set if RDRAND is available.
+    // Avoid clobbering ebx, as that is used for PIC on x86.
+    uint32_t eax, tmp, ecx, edx;
+    __asm__ ("mov %%ebx, %1; cpuid; mov %1, %%ebx": "=a"(eax), "=g"(tmp), "=c"(ecx), "=d"(edx) : "a"(1));
+    if (ecx & CPUID_F1_ECX_RDRAND) {
+        LogPrintf("Using RdRand as entropy source\n");
+        rdrand_supported = true;
+    }
+    hwrand_initialized.store(true);
+}
+#else
+static void RDRandInit() {}
+#endif
+
+static bool GetHWRand(unsigned char* ent32) {
+#if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
+    assert(hwrand_initialized.load(std::memory_order_relaxed));
+    if (rdrand_supported) {
+        uint8_t ok;
+        // Not all assemblers support the rdrand instruction, write it in hex.
+#ifdef __i386__
+        for (int iter = 0; iter < 4; ++iter) {
+            uint32_t r1, r2;
+            __asm__ volatile (".byte 0x0f, 0xc7, 0xf0;" // rdrand %eax
+                              ".byte 0x0f, 0xc7, 0xf2;" // rdrand %edx
+                              "setc %2" :
+                              "=a"(r1), "=d"(r2), "=q"(ok) :: "cc");
+            if (!ok) return false;
+            WriteLE32(ent32 + 8 * iter, r1);
+            WriteLE32(ent32 + 8 * iter + 4, r2);
+        }
+#else
+        uint64_t r1, r2, r3, r4;
+        __asm__ volatile (".byte 0x48, 0x0f, 0xc7, 0xf0, " // rdrand %rax
+                                "0x48, 0x0f, 0xc7, 0xf3, " // rdrand %rbx
+                                "0x48, 0x0f, 0xc7, 0xf1, " // rdrand %rcx
+                                "0x48, 0x0f, 0xc7, 0xf2; " // rdrand %rdx
+                          "setc %4" :
+                          "=a"(r1), "=b"(r2), "=c"(r3), "=d"(r4), "=q"(ok) :: "cc");
+        if (!ok) return false;
+        WriteLE64(ent32, r1);
+        WriteLE64(ent32 + 8, r2);
+        WriteLE64(ent32 + 16, r3);
+        WriteLE64(ent32 + 24, r4);
+#endif
+        return true;
+    }
+#endif
+    return false;
+}
+
 void RandAddSeed()
 {
     // Seed with CPU performance counter
@@ -256,6 +313,11 @@ void GetStrongRandBytes(unsigned char* out, int num)
     GetOSRand(buf);
     hasher.Write(buf, 32);
 
+    // Third source: HW RNG, if available.
+    if (GetHWRand(buf)) {
+        hasher.Write(buf, 32);
+    }
+
     // Combine with and update state
     {
         std::unique_lock<std::mutex> lock(cs_rng_state);
@@ -381,4 +443,9 @@ FastRandomContext::FastRandomContext(bool fDeterministic) : requires_seed(!fDete
     }
     uint256 seed;
     rng.SetKey(seed.begin(), 32);
+}
+
+void RandomInit()
+{
+    RDRandInit();
 }

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -185,6 +185,7 @@ void GetDevURandom(unsigned char *ent32)
     do {
         ssize_t n = read(f, ent32 + have, NUM_OS_RANDOM_BYTES - have);
         if (n <= 0 || n + have > NUM_OS_RANDOM_BYTES) {
+            close(f);
             RandFailure();
         }
         have += n;

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -27,8 +27,11 @@
 #include <sys/syscall.h>
 #include <linux/random.h>
 #endif
-#ifdef HAVE_GETENTROPY
+#if defined(HAVE_GETENTROPY) || (defined(HAVE_GETENTROPY_RAND) && defined(MAC_OSX))
 #include <unistd.h>
+#endif
+#if defined(HAVE_GETENTROPY_RAND) && defined(MAC_OSX)
+#include <sys/random.h>
 #endif
 #ifdef HAVE_SYSCTL_ARND
 #include <sys/sysctl.h>
@@ -235,6 +238,15 @@ void GetOSRand(unsigned char *ent32)
      */
     if (getentropy(ent32, NUM_OS_RANDOM_BYTES) != 0) {
         RandFailure();
+    }
+#elif defined(HAVE_GETENTROPY_RAND) && defined(MAC_OSX)
+    // We need a fallback for OSX < 10.12
+    if (&getentropy != NULL) {
+        if (getentropy(ent32, NUM_OS_RANDOM_BYTES) != 0) {
+            RandFailure();
+        }
+    } else {
+        GetDevURandom(ent32);
     }
 #elif defined(HAVE_SYSCTL_ARND)
     /* FreeBSD and similar. It is possible for the call to return less

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -32,6 +32,8 @@
 #include <sys/sysctl.h>
 #endif
 
+#include <mutex>
+
 #include <openssl/err.h>
 #include <openssl/rand.h>
 
@@ -192,6 +194,10 @@ void GetRandBytes(unsigned char* buf, int num)
     }
 }
 
+static std::mutex cs_rng_state;
+static unsigned char rng_state[32] = {0};
+static uint64_t rng_counter = 0;
+
 void GetStrongRandBytes(unsigned char* out, int num)
 {
     assert(num <= 32);
@@ -207,8 +213,17 @@ void GetStrongRandBytes(unsigned char* out, int num)
     GetOSRand(buf);
     hasher.Write(buf, 32);
 
+    // Combine with and update state
+    {
+        std::unique_lock<std::mutex> lock(cs_rng_state);
+        hasher.Write(rng_state, sizeof(rng_state));
+        hasher.Write((const unsigned char*)&rng_counter, sizeof(rng_counter));
+        ++rng_counter;
+        hasher.Finalize(buf);
+        memcpy(rng_state, buf + 32, 32);
+    }
+
     // Produce output
-    hasher.Finalize(buf);
     memcpy(out, buf, num);
     OPENSSL_cleanse(buf, 64);
 }

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -77,7 +77,7 @@ static void RDRandInit()
 {
     uint32_t eax, ebx, ecx, edx;
     if (__get_cpuid(1, &eax, &ebx, &ecx, &edx) && (ecx & CPUID_F1_ECX_RDRAND)) {
-        LogPrintf("Using RdRand as entropy source\n");
+        LogPrintf("Using RdRand as an additional entropy source\n");
         rdrand_supported = true;
     }
     hwrand_initialized.store(true);

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -209,6 +209,22 @@ static std::mutex cs_rng_state;
 static unsigned char rng_state[32] = {0};
 static uint64_t rng_counter = 0;
 
+static void AddDataToRng(void* data, size_t len) {
+    CSHA512 hasher;
+    hasher.Write((const unsigned char*)&len, sizeof(len));
+    hasher.Write((const unsigned char*)data, len);
+    unsigned char buf[64];
+    {
+        std::unique_lock<std::mutex> lock(cs_rng_state);
+        hasher.Write(rng_state, sizeof(rng_state));
+        hasher.Write((const unsigned char*)&rng_counter, sizeof(rng_counter));
+        ++rng_counter;
+        hasher.Finalize(buf);
+        memcpy(rng_state, buf + 32, 32);
+    }
+    OPENSSL_cleanse(buf, 64);
+}
+
 void GetStrongRandBytes(unsigned char* out, int num)
 {
     assert(num <= 32);

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -5,8 +5,10 @@
 
 #include "random.h"
 
+#include "crypto/sha512.h"
 #ifdef WIN32
 #include "compat.h" // for Windows API
+#include <wincrypt.h>
 #endif
 #include "serialize.h"        // for begin_ptr(vec)
 #include "util.h"             // for LogPrint()
@@ -43,7 +45,7 @@ void RandAddSeed()
     OPENSSL_cleanse((void*)&nCounter, sizeof(nCounter));
 }
 
-void RandAddSeedPerfmon()
+static void RandAddSeedPerfmon()
 {
     RandAddSeed();
 
@@ -83,12 +85,56 @@ void RandAddSeedPerfmon()
 #endif
 }
 
+/** Get 32 bytes of system entropy. */
+static void GetOSRand(unsigned char *ent32)
+{
+#ifdef WIN32
+    HCRYPTPROV hProvider;
+    int ret = CryptAcquireContextW(&hProvider, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT);
+    assert(ret);
+    ret = CryptGenRandom(hProvider, 32, ent32);
+    assert(ret);
+    CryptReleaseContext(hProvider, 0);
+#else
+    int f = open("/dev/urandom", O_RDONLY);
+    assert(f != -1);
+    int have = 0;
+    do {
+        ssize_t n = read(f, ent32 + have, 32 - have);
+        assert(n > 0 && n <= 32 - have);
+        have += n;
+    } while (have < 32);
+    close(f);
+#endif
+}
+
 void GetRandBytes(unsigned char* buf, int num)
 {
     if (RAND_bytes(buf, num) != 1) {
         LogPrintf("%s: OpenSSL RAND_bytes() failed with error: %s\n", __func__, ERR_error_string(ERR_get_error(), NULL));
         assert(false);
     }
+}
+
+void GetStrongRandBytes(unsigned char* out, int num)
+{
+    assert(num <= 32);
+    CSHA512 hasher;
+    unsigned char buf[64];
+
+    // First source: OpenSSL's RNG
+    RandAddSeedPerfmon();
+    GetRandBytes(buf, 32);
+    hasher.Write(buf, 32);
+
+    // Second source: OS RNG
+    GetOSRand(buf);
+    hasher.Write(buf, 32);
+
+    // Produce output
+    hasher.Finalize(buf);
+    memcpy(out, buf, num);
+    OPENSSL_cleanse(buf, 64);
 }
 
 uint64_t GetRand(uint64_t nMax)

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -205,6 +205,22 @@ void GetRandBytes(unsigned char* buf, int num)
     }
 }
 
+static void AddDataToRng(void* data, size_t len);
+
+void RandAddSeedSleep()
+{
+    int64_t nPerfCounter1 = GetPerformanceCounter();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    int64_t nPerfCounter2 = GetPerformanceCounter();
+
+    // Combine with and update state
+    AddDataToRng(&nPerfCounter1, sizeof(nPerfCounter1));
+    AddDataToRng(&nPerfCounter2, sizeof(nPerfCounter2));
+
+    OPENSSL_cleanse(&nPerfCounter1, sizeof(nPerfCounter1));
+    OPENSSL_cleanse(&nPerfCounter2, sizeof(nPerfCounter2));
+}
+
 static std::mutex cs_rng_state;
 static unsigned char rng_state[32] = {0};
 static uint64_t rng_counter = 0;

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -36,6 +36,10 @@
 
 #include <mutex>
 
+#if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
+#include <cpuid.h>
+#endif
+
 #include <openssl/err.h>
 #include <openssl/rand.h>
 
@@ -71,17 +75,8 @@ static bool rdrand_supported = false;
 static constexpr uint32_t CPUID_F1_ECX_RDRAND = 0x40000000;
 static void RDRandInit()
 {
-    uint32_t eax, ecx, edx;
-#if defined(__i386__) && ( defined(__PIC__) || defined(__PIE__))
-    // Avoid clobbering ebx, as that is used for PIC on x86.
-    uint32_t tmp;
-    __asm__ ("mov %%ebx, %1; cpuid; mov %1, %%ebx": "=a"(eax), "=g"(tmp), "=c"(ecx), "=d"(edx) : "a"(1));
-#else
-    uint32_t ebx;
-    __asm__ ("cpuid": "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx) : "a"(1));
-#endif
-    //! When calling cpuid function #1, ecx register will have this set if RDRAND is available.
-    if (ecx & CPUID_F1_ECX_RDRAND) {
+    uint32_t eax, ebx, ecx, edx;
+    if (__get_cpuid(1, &eax, &ebx, &ecx, &edx) && (ecx & CPUID_F1_ECX_RDRAND)) {
         LogPrintf("Using RdRand as entropy source\n");
         rdrand_supported = true;
     }

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -71,10 +71,16 @@ static bool rdrand_supported = false;
 static constexpr uint32_t CPUID_F1_ECX_RDRAND = 0x40000000;
 static void RDRandInit()
 {
-    //! When calling cpuid function #1, ecx register will have this set if RDRAND is available.
+    uint32_t eax, ecx, edx;
+#if defined(__i386__) && ( defined(__PIC__) || defined(__PIE__))
     // Avoid clobbering ebx, as that is used for PIC on x86.
-    uint32_t eax, tmp, ecx, edx;
+    uint32_t tmp;
     __asm__ ("mov %%ebx, %1; cpuid; mov %1, %%ebx": "=a"(eax), "=g"(tmp), "=c"(ecx), "=d"(edx) : "a"(1));
+#else
+    uint32_t ebx;
+    __asm__ ("cpuid": "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx) : "a"(1));
+#endif
+    //! When calling cpuid function #1, ecx register will have this set if RDRAND is available.
     if (ecx & CPUID_F1_ECX_RDRAND) {
         LogPrintf("Using RdRand as entropy source\n");
         rdrand_supported = true;

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -315,6 +315,10 @@ bool Random_SanityCheck()
         uint64_t stop = GetPerformanceCounter();
         if (stop == start) return false;
 
+        // We called GetPerformanceCounter. Use it as entropy.
+        RAND_add((const unsigned char*)&start, sizeof(start), 1);
+        RAND_add((const unsigned char*)&stop, sizeof(stop), 1);
+
         return true;
 }
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -17,6 +17,7 @@
 #include <stdlib.h>
 #include <limits>
 #include <chrono>
+#include <thread>
 
 #ifndef WIN32
 #include <sys/time.h>
@@ -279,6 +280,8 @@ FastRandomContext::FastRandomContext(const uint256& seed) : requires_seed(false)
 
 bool Random_SanityCheck()
 {
+    uint64_t start = GetPerformanceCounter();
+
     /* This does not measure the quality of randomness, but it does test that
      * OSRandom() overwrites all 32 bytes of the output given a maximum
      * number of tries.
@@ -305,7 +308,14 @@ bool Random_SanityCheck()
 
         tries += 1;
     } while (num_overwritten < NUM_OS_RANDOM_BYTES && tries < MAX_TRIES);
-    return (num_overwritten == NUM_OS_RANDOM_BYTES); /* If this failed, bailed out after too many tries */
+    if (num_overwritten != NUM_OS_RANDOM_BYTES) return false; /* If this failed, bailed out after too many tries */
+
+        // Check that GetPerformanceCounter increases at least during a GetOSRand() call + 1ms sleep.
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        uint64_t stop = GetPerformanceCounter();
+        if (stop == start) return false;
+
+        return true;
 }
 
 FastRandomContext::FastRandomContext(bool fDeterministic) : requires_seed(!fDeterministic), bytebuf_size(0), bitbuf_size(0)

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -158,10 +158,12 @@ void GetOSRand(unsigned char *ent32)
             RandFailure();
         }
     }
-#elif defined(HAVE_GETENTROPY)
+#elif defined(HAVE_GETENTROPY) && defined(__OpenBSD__)
     /* On OpenBSD this can return up to 256 bytes of entropy, will return an
      * error if more are requested.
      * The call cannot return less than the requested number of bytes.
+     * getentropy is explicitly limited to openbsd here, as a similar (but not
+     * the same) function may exist on other platforms via glibc.
      */
     if (getentropy(ent32, NUM_OS_RANDOM_BYTES) != 0) {
         RandFailure();

--- a/src/random.h
+++ b/src/random.h
@@ -10,11 +10,8 @@
 
 #include <stdint.h>
 
-/**
- * Seed OpenSSL PRNG with additional entropy data
- */
+/* Seed OpenSSL PRNG with additional entropy data */
 void RandAddSeed();
-void RandAddSeedPerfmon();
 
 /**
  * Functions to gather random data via the OpenSSL PRNG
@@ -23,6 +20,12 @@ void GetRandBytes(unsigned char* buf, int num);
 uint64_t GetRand(uint64_t nMax);
 int GetRandInt(int nMax);
 uint256 GetRandHash();
+
+/**
+ * Function to gather random data from multiple sources, failing whenever any
+ * of those source fail to provide a result.
+ */
+void GetStrongRandBytes(unsigned char* buf, int num);
 
 /**
  * Seed insecure_rand using the random pool.

--- a/src/random.h
+++ b/src/random.h
@@ -110,8 +110,14 @@ public:
         }
     }
 
+    /** Generate random bytes. */
+    std::vector<unsigned char> randbytes(size_t len);
+
     /** Generate a random 32-bit integer. */
     uint32_t rand32() { return randbits(32); }
+
+    /** generate a random uint256. */
+    uint256 rand256();
 
     /** Generate a random boolean. */
     bool randbool() { return randbits(1); }

--- a/src/random.h
+++ b/src/random.h
@@ -140,4 +140,7 @@ void GetOSRand(unsigned char *ent32);
  */
 bool Random_SanityCheck();
 
+/** Initialize the RNG. */
+void RandomInit();
+
 #endif // BITCOIN_RANDOM_H

--- a/src/random.h
+++ b/src/random.h
@@ -24,6 +24,13 @@ int GetRandInt(int nMax);
 uint256 GetRandHash();
 
 /**
+ * Add a little bit of randomness to the output of GetStrongRangBytes.
+ * This sleeps for a millisecond, so should only be called when there is
+ * no other work to be done.
+ */
+void RandAddSeedSleep();
+
+/**
  * Function to gather random data from multiple sources, failing whenever any
  * of those source fail to provide a result.
  */

--- a/src/random.h
+++ b/src/random.h
@@ -42,6 +42,10 @@ public:
         return (Rw << 16) + Rz;
     }
 
+    bool randbool() {
+        return rand32() & 1;
+    }
+
     uint32_t Rz;
     uint32_t Rw;
 };

--- a/src/random.h
+++ b/src/random.h
@@ -75,6 +75,14 @@ public:
     /** Initialize with explicit seed (only for testing) */
     explicit FastRandomContext(const uint256& seed);
 
+    // Do not permit copying a FastRandomContext (move it, or create a new one to get reseeded).
+    FastRandomContext(const FastRandomContext&) = delete;
+    FastRandomContext(FastRandomContext&&) = delete;
+    FastRandomContext& operator=(const FastRandomContext&) = delete;
+
+    /** Move a FastRandomContext. If the original one is used again, it will be reseeded. */
+    FastRandomContext& operator=(FastRandomContext&& from) noexcept;
+
     /** Generate a random 64-bit integer. */
     uint64_t rand64()
     {

--- a/src/random.h
+++ b/src/random.h
@@ -28,26 +28,23 @@ uint256 GetRandHash();
 void GetStrongRandBytes(unsigned char* buf, int num);
 
 /**
- * Seed insecure_rand using the random pool.
- * @param Deterministic Use a deterministic seed
+ * Fast randomness source. This is seeded once with secure random data, but
+ * is completely deterministic and insecure after that.
+ * This class is not thread-safe.
  */
-void seed_insecure_rand(bool fDeterministic = false);
+class FastRandomContext {
+public:
+    explicit FastRandomContext(bool fDeterministic=false);
 
-/**
- * MWC RNG of George Marsaglia
- * This is intended to be fast. It has a period of 2^59.3, though the
- * least significant 16 bits only have a period of about 2^30.1.
- *
- * @return random value
- */
-extern uint32_t insecure_rand_Rz;
-extern uint32_t insecure_rand_Rw;
-static inline uint32_t insecure_rand(void)
-{
-    insecure_rand_Rz = 36969 * (insecure_rand_Rz & 65535) + (insecure_rand_Rz >> 16);
-    insecure_rand_Rw = 18000 * (insecure_rand_Rw & 65535) + (insecure_rand_Rw >> 16);
-    return (insecure_rand_Rw << 16) + insecure_rand_Rz;
-}
+    uint32_t rand32() {
+        Rz = 36969 * (Rz & 65535) + (Rz >> 16);
+        Rw = 18000 * (Rw & 65535) + (Rw >> 16);
+        return (Rw << 16) + Rz;
+    }
+
+    uint32_t Rz;
+    uint32_t Rw;
+};
 
 /* Number of random bytes returned by GetOSRand.
  * When changing this constant make sure to change all call sites, and make

--- a/src/random.h
+++ b/src/random.h
@@ -61,4 +61,9 @@ static const ssize_t NUM_OS_RANDOM_BYTES = 32;
  */
 void GetOSRand(unsigned char *ent32);
 
+/** Check that OS randomness is available and returning the requested number
+ * of bytes.
+ */
+bool Random_SanityCheck();
+
 #endif // BITCOIN_RANDOM_H

--- a/src/random.h
+++ b/src/random.h
@@ -49,4 +49,16 @@ static inline uint32_t insecure_rand(void)
     return (insecure_rand_Rw << 16) + insecure_rand_Rz;
 }
 
+/* Number of random bytes returned by GetOSRand.
+ * When changing this constant make sure to change all call sites, and make
+ * sure that the underlying OS APIs for all platforms support the number.
+ * (many cap out at 256 bytes).
+ */
+static const ssize_t NUM_OS_RANDOM_BYTES = 32;
+
+/** Get 32 bytes of system entropy. Do not use this in application code: use
+ * GetStrongRandBytes instead.
+ */
+void GetOSRand(unsigned char *ent32);
+
 #endif // BITCOIN_RANDOM_H

--- a/src/random.h
+++ b/src/random.h
@@ -92,6 +92,17 @@ public:
         }
     }
 
+    /** Generate a random integer in the range [0..range). */
+    uint64_t randrange(uint64_t range)
+    {
+        --range;
+        int bits = CountBits(range);
+        while (true) {
+            uint64_t ret = randbits(bits);
+            if (ret <= range) return ret;
+        }
+    }
+
     /** Generate a random 32-bit integer. */
     uint32_t rand32() { return randbits(32); }
 

--- a/src/random.h
+++ b/src/random.h
@@ -6,6 +6,8 @@
 #ifndef BITCOIN_RANDOM_H
 #define BITCOIN_RANDOM_H
 
+#include "crypto/chacha20.h"
+#include "crypto/common.h"
 #include "uint256.h"
 
 #include <stdint.h>
@@ -33,21 +35,68 @@ void GetStrongRandBytes(unsigned char* buf, int num);
  * This class is not thread-safe.
  */
 class FastRandomContext {
+private:
+    bool requires_seed;
+    ChaCha20 rng;
+
+    unsigned char bytebuf[64];
+    int bytebuf_size;
+
+    uint64_t bitbuf;
+    int bitbuf_size;
+
+    void RandomSeed();
+
+    void FillByteBuffer()
+    {
+        if (requires_seed) {
+            RandomSeed();
+        }
+        rng.Output(bytebuf, sizeof(bytebuf));
+        bytebuf_size = sizeof(bytebuf);
+    }
+
+    void FillBitBuffer()
+    {
+        bitbuf = rand64();
+        bitbuf_size = 64;
+    }
+
 public:
-    explicit FastRandomContext(bool fDeterministic=false);
+    explicit FastRandomContext(bool fDeterministic = false);
 
-    uint32_t rand32() {
-        Rz = 36969 * (Rz & 65535) + (Rz >> 16);
-        Rw = 18000 * (Rw & 65535) + (Rw >> 16);
-        return (Rw << 16) + Rz;
+    /** Initialize with explicit seed (only for testing) */
+    explicit FastRandomContext(const uint256& seed);
+
+    /** Generate a random 64-bit integer. */
+    uint64_t rand64()
+    {
+        if (bytebuf_size < 8) FillByteBuffer();
+        uint64_t ret = ReadLE64(bytebuf + 64 - bytebuf_size);
+        bytebuf_size -= 8;
+        return ret;
     }
 
-    bool randbool() {
-        return rand32() & 1;
+    /** Generate a random (bits)-bit integer. */
+    uint64_t randbits(int bits) {
+        if (bits == 0) {
+            return 0;
+        } else if (bits > 32) {
+            return rand64() >> (64 - bits);
+        } else {
+            if (bitbuf_size < bits) FillBitBuffer();
+            uint64_t ret = bitbuf & (~(uint64_t)0 >> (64 - bits));
+            bitbuf >>= bits;
+            bitbuf_size -= bits;
+            return ret;
+        }
     }
 
-    uint32_t Rz;
-    uint32_t Rw;
+    /** Generate a random 32-bit integer. */
+    uint32_t rand32() { return randbits(32); }
+
+    /** Generate a random boolean. */
+    bool randbool() { return randbits(1); }
 };
 
 /* Number of random bytes returned by GetOSRand.

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -5,6 +5,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "scheduler.h"
+#include "random.h"
 #include "reverselock.h"
 #include <assert.h>
 #include <boost/bind.hpp>
@@ -33,6 +34,11 @@ void CScheduler::serviceQueue() {
     // is called.
     while (!shouldStop()) {
         try {
+            if (!shouldStop() && taskQueue.empty()) {
+                reverse_lock<boost::unique_lock<boost::mutex> > rlock(lock);
+                // Use this chance to get a tiny bit more entropy
+                RandAddSeedSleep();
+            }
             while (!shouldStop() && taskQueue.empty()) {
                 // Wait until there is something to do.
                 newTaskScheduled.wait(lock);

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
 CTransaction RandomOrphan()
 {
     std::map<uint256, COrphanTx>::iterator it;
-    it = mapOrphanTransactions.lower_bound(GetRandHash());
+    it = mapOrphanTransactions.lower_bound(insecure_rand256());
     if (it == mapOrphanTransactions.end())
         it = mapOrphanTransactions.begin();
     return it->second.tx;
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         CMutableTransaction tx;
         tx.vin.resize(1);
         tx.vin[0].prevout.n = 0;
-        tx.vin[0].prevout.hash = GetRandHash();
+        tx.vin[0].prevout.hash = insecure_rand256();
         tx.vin[0].scriptSig << OP_1;
         tx.vout.resize(1);
         tx.vout[0].nValue = 1*CENT;

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "coins.h"
-#include "random.h"
+#include "test_random.h"
 #include "uint256.h"
 
 #include <vector>

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -26,7 +26,7 @@ public:
             return false;
         }
         coins = it->second;
-        if (coins.IsPruned() && insecure_randrange(2) == 0) {
+        if (coins.IsPruned() && insecure_randbool() == 0) {
             // Randomly return false in case of an empty entry.
             return false;
         }
@@ -140,12 +140,12 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
 
         if (insecure_randrange(100) == 0) {
             // Every 100 iterations, change the cache stack.
-            if (stack.size() > 0 && insecure_randrange(2) == 0) {
+            if (stack.size() > 0 && insecure_randbool() == 0) {
                 stack.back()->Flush();
                 delete stack.back();
                 stack.pop_back();
             }
-            if (stack.size() == 0 || (stack.size() < 4 && insecure_randrange(2))) {
+            if (stack.size() == 0 || (stack.size() < 4 && insecure_randbool())) {
                 CCoinsView* tip = &base;
                 if (stack.size() > 0) {
                     tip = stack.back();

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -26,7 +26,7 @@ public:
             return false;
         }
         coins = it->second;
-        if (coins.IsPruned() && insecure_rand() % 2 == 0) {
+        if (coins.IsPruned() && insecure_randrange(2) == 0) {
             // Randomly return false in case of an empty entry.
             return false;
         }
@@ -45,7 +45,7 @@ public:
     {
         for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end(); ) {
             map_[it->first] = it->second.coins;
-            if (it->second.coins.IsPruned() && insecure_rand() % 3 == 0) {
+            if (it->second.coins.IsPruned() && insecure_randrange(3) == 0) {
                 // Randomly delete empty entries on write.
                 map_.erase(it->first);
             }
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
     std::vector<uint256> txids;
     txids.resize(NUM_SIMULATION_ITERATIONS / 8);
     for (unsigned int i = 0; i < txids.size(); i++) {
-        txids[i] = GetRandHash();
+        txids[i] = insecure_rand256();
     }
 
     for (unsigned int i = 0; i < NUM_SIMULATION_ITERATIONS; i++) {
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
             CCoins& coins = result[txid];
             CCoinsModifier entry = stack.back()->ModifyCoins(txid);
             BOOST_CHECK(coins == *entry);
-            if (insecure_rand() % 5 == 0 || coins.IsPruned()) {
+            if (insecure_randrange(5) == 0 || coins.IsPruned()) {
                 if (coins.IsPruned()) {
                     added_an_entry = true;
                 } else {
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
         }
 
         // Once every 1000 iterations and at the end, verify the full cache.
-        if (insecure_rand() % 1000 == 1 || i == NUM_SIMULATION_ITERATIONS - 1) {
+        if (insecure_randrange(1000) == 1 || i == NUM_SIMULATION_ITERATIONS - 1) {
             for (std::map<uint256, CCoins>::iterator it = result.begin(); it != result.end(); it++) {
                 const CCoins* coins = stack.back()->AccessCoins(it->first);
                 if (coins) {
@@ -138,14 +138,14 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
             }
         }
 
-        if (insecure_rand() % 100 == 0) {
+        if (insecure_randrange(100) == 0) {
             // Every 100 iterations, change the cache stack.
-            if (stack.size() > 0 && insecure_rand() % 2 == 0) {
+            if (stack.size() > 0 && insecure_randrange(2) == 0) {
                 stack.back()->Flush();
                 delete stack.back();
                 stack.pop_back();
             }
-            if (stack.size() == 0 || (stack.size() < 4 && insecure_rand() % 2)) {
+            if (stack.size() == 0 || (stack.size() < 4 && insecure_randrange(2))) {
                 CCoinsView* tip = &base;
                 if (stack.size() > 0) {
                     tip = stack.back();

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -37,7 +37,7 @@ void TestVector(const Hasher &h, const In &in, const Out &out) {
         Hasher hasher(h);
         size_t pos = 0;
         while (pos < in.size()) {
-            size_t len = insecure_rand() % ((in.size() - pos + 1) / 2 + 1);
+            size_t len = insecure_randrange((in.size() - pos + 1) / 2 + 1);
             hasher.Write((unsigned char*)&in[pos], len);
             pos += len;
             if (pos > 0 && pos + 2 * out.size() > in.size() && pos < in.size()) {

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -9,7 +9,7 @@
 #include "crypto/sha512.h"
 #include "crypto/hmac_sha256.h"
 #include "crypto/hmac_sha512.h"
-#include "random.h"
+#include "test_random.h"
 #include "utilstrencodings.h"
 
 #include <vector>

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "crypto/rfc6979_hmac_sha256.h"
+#include "crypto/chacha20.h"
 #include "crypto/ripemd160.h"
 #include "crypto/sha1.h"
 #include "crypto/sha256.h"
@@ -62,6 +63,19 @@ void TestHMACSHA256(const std::string &hexkey, const std::string &hexin, const s
 void TestHMACSHA512(const std::string &hexkey, const std::string &hexin, const std::string &hexout) {
     std::vector<unsigned char> key = ParseHex(hexkey);
     TestVector(CHMAC_SHA512(&key[0], key.size()), ParseHex(hexin), ParseHex(hexout));
+}
+
+void TestChaCha20(const std::string &hexkey, uint64_t nonce, uint64_t seek, const std::string& hexout)
+{
+    std::vector<unsigned char> key = ParseHex(hexkey);
+    ChaCha20 rng(key.data(), key.size());
+    rng.SetIV(nonce);
+    rng.Seek(seek);
+    std::vector<unsigned char> out = ParseHex(hexout);
+    std::vector<unsigned char> outres;
+    outres.resize(out.size());
+    rng.Output(outres.data(), outres.size());
+    BOOST_CHECK(out == outres);
 }
 
 std::string LongTestString(void) {
@@ -281,6 +295,36 @@ BOOST_AUTO_TEST_CASE(rfc6979_hmac_sha256)
             ("9c236c165b82ae0cd590659e100b6bab3036e7ba8b06749baf6981e16f1a2b95")
             ("df471061625bc0ea14b682feee2c9c02f235da04204c1d62a1536c6e17aed7a9")
             ("7597887cbd76321f32e30440679a22cf7f8d9d2eac390e581fea091ce202ba94"));
+}
+
+BOOST_AUTO_TEST_CASE(chacha20_testvector)
+{
+    // Test vector from RFC 7539
+    TestChaCha20("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", 0x4a000000UL, 1,
+                 "224f51f3401bd9e12fde276fb8631ded8c131f823d2c06e27e4fcaec9ef3cf788a3b0aa372600a92b57974cded2b9334794cb"
+                 "a40c63e34cdea212c4cf07d41b769a6749f3f630f4122cafe28ec4dc47e26d4346d70b98c73f3e9c53ac40c5945398b6eda1a"
+                 "832c89c167eacd901d7e2bf363");
+
+    // Test vectors from https://tools.ietf.org/html/draft-agl-tls-chacha20poly1305-04#section-7
+    TestChaCha20("0000000000000000000000000000000000000000000000000000000000000000", 0, 0,
+                 "76b8e0ada0f13d90405d6ae55386bd28bdd219b8a08ded1aa836efcc8b770dc7da41597c5157488d7724e03fb8d84a376a43b"
+                 "8f41518a11cc387b669b2ee6586");
+    TestChaCha20("0000000000000000000000000000000000000000000000000000000000000001", 0, 0,
+                 "4540f05a9f1fb296d7736e7b208e3c96eb4fe1834688d2604f450952ed432d41bbe2a0b6ea7566d2a5d1e7e20d42af2c53d79"
+                 "2b1c43fea817e9ad275ae546963");
+    TestChaCha20("0000000000000000000000000000000000000000000000000000000000000000", 0x0100000000000000ULL, 0,
+                 "de9cba7bf3d69ef5e786dc63973f653a0b49e015adbff7134fcb7df137821031e85a050278a7084527214f73efc7fa5b52770"
+                 "62eb7a0433e445f41e3");
+    TestChaCha20("0000000000000000000000000000000000000000000000000000000000000000", 1, 0,
+                 "ef3fdfd6c61578fbf5cf35bd3dd33b8009631634d21e42ac33960bd138e50d32111e4caf237ee53ca8ad6426194a88545ddc4"
+                 "97a0b466e7d6bbdb0041b2f586b");
+    TestChaCha20("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", 0x0706050403020100ULL, 0,
+                 "f798a189f195e66982105ffb640bb7757f579da31602fc93ec01ac56f85ac3c134a4547b733b46413042c9440049176905d3b"
+                 "e59ea1c53f15916155c2be8241a38008b9a26bc35941e2444177c8ade6689de95264986d95889fb60e84629c9bd9a5acb1cc1"
+                 "18be563eb9b3a4a472f82e09a7e778492b562ef7130e88dfe031c79db9d4f7c7a899151b9a475032b63fc385245fe054e3dd5"
+                 "a97a5f576fe064025d3ce042c566ab2c507b138db853e3d6959660996546cc9c4a6eafdc777c040d70eaf46f76dad3979e5c5"
+                 "360c3317166a1c894c94a371876a94df7628fe4eaaf2ccb27d5aaae0ad7ad0f9d4b6ad3b54098746d4524d38407a6deb3ab78"
+                 "fab78c9");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -11,6 +11,7 @@
 #include "crypto/hmac_sha256.h"
 #include "crypto/hmac_sha512.h"
 #include "test_random.h"
+#include "random.h"
 #include "utilstrencodings.h"
 
 #include <vector>
@@ -325,6 +326,28 @@ BOOST_AUTO_TEST_CASE(chacha20_testvector)
                  "a97a5f576fe064025d3ce042c566ab2c507b138db853e3d6959660996546cc9c4a6eafdc777c040d70eaf46f76dad3979e5c5"
                  "360c3317166a1c894c94a371876a94df7628fe4eaaf2ccb27d5aaae0ad7ad0f9d4b6ad3b54098746d4524d38407a6deb3ab78"
                  "fab78c9");
+}
+
+BOOST_AUTO_TEST_CASE(countbits_tests)
+{
+    FastRandomContext ctx;
+    for (int i = 0; i <= 64; ++i) {
+        if (i == 0) {
+            // Check handling of zero.
+            BOOST_CHECK_EQUAL(CountBits(0), 0);
+        } else if (i < 10) {
+            for (uint64_t j = 1 << (i - 1); (j >> i) == 0; ++j) {
+                // Exhaustively test up to 10 bits
+                BOOST_CHECK_EQUAL(CountBits(j), i);
+            }
+        } else {
+            for (int k = 0; k < 1000; k++) {
+                // Randomly test 1000 samples of each length above 10 bits.
+                uint64_t j = ((uint64_t)1) << (i - 1) | ctx.randbits(i - 1);
+                BOOST_CHECK_EQUAL(CountBits(j), i);
+            }
+        }
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -21,7 +21,7 @@ public:
     // flip one bit in one of the hashes - this should break the authentication
     void Damage() {
         unsigned int n = insecure_randrange(vHash.size());
-        int bit = insecure_randrange(256);
+        int bit = insecure_randbits(8);
         uint256 &hash = vHash[n];
         hash ^= ((uint256)1 << bit);
     }

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -20,8 +20,8 @@ class CPartialMerkleTreeTester : public CPartialMerkleTree
 public:
     // flip one bit in one of the hashes - this should break the authentication
     void Damage() {
-        unsigned int n = rand() % vHash.size();
-        int bit = rand() % 256;
+        unsigned int n = insecure_randrange(vHash.size());
+        int bit = insecure_randrange(256);
         uint256 &hash = vHash[n];
         hash ^= ((uint256)1 << bit);
     }

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -7,6 +7,7 @@
 #include "streams.h"
 #include "uint256.h"
 #include "version.h"
+#include "test_random.h"
 
 #include <vector>
 

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(pmt_test1)
             std::vector<bool> vMatch(nTx, false);
             std::vector<uint256> vMatchTxid1;
             for (unsigned int j=0; j<nTx; j++) {
-                bool fInclude = (secp256k1_rand32() & ((1 << (att/2)) - 1)) == 0;
+                bool fInclude = insecure_randbits(att / 2) == 0;
                 vMatch[j] = fInclude;
                 if (fInclude)
                     vMatchTxid1.push_back(vTxid[j]);

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -25,14 +25,21 @@ BOOST_AUTO_TEST_CASE(fastrandom_tests)
     BOOST_CHECK_EQUAL(ctx1.rand32(), ctx2.rand32());
     BOOST_CHECK_EQUAL(ctx1.rand64(), ctx2.rand64());
     BOOST_CHECK_EQUAL(ctx1.randbits(3), ctx2.randbits(3));
+    BOOST_CHECK(ctx1.randbytes(17) == ctx2.randbytes(17));
+    BOOST_CHECK(ctx1.rand256() == ctx2.rand256());
     BOOST_CHECK_EQUAL(ctx1.randbits(7), ctx2.randbits(7));
+    BOOST_CHECK(ctx1.randbytes(128) == ctx2.randbytes(128));
     BOOST_CHECK_EQUAL(ctx1.rand32(), ctx2.rand32());
     BOOST_CHECK_EQUAL(ctx1.randbits(3), ctx2.randbits(3));
+    BOOST_CHECK(ctx1.rand256() == ctx2.rand256());
+    BOOST_CHECK(ctx1.randbytes(50) == ctx2.randbytes(50));
 
     // Check that a nondeterministic ones are not
     FastRandomContext ctx3;
     FastRandomContext ctx4;
     BOOST_CHECK(ctx3.rand64() != ctx4.rand64()); // extremely unlikely to be equal
+    BOOST_CHECK(ctx3.rand256() != ctx4.rand256());
+    BOOST_CHECK(ctx3.randbytes(7) != ctx4.randbytes(7));
 }
 
 BOOST_AUTO_TEST_CASE(fastrandom_randbits)

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "random.h"
+
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(random_tests, BasicTestingSetup)
+
+static const ssize_t MAX_TRIES = 1024;
+
+BOOST_AUTO_TEST_CASE(osrandom_tests)
+{
+    /* This does not measure the quality of randomness, but it does test that
+     * OSRandom() overwrites all 32 bytes of the output given a maximum
+     * number of tries.
+     */
+    uint8_t data[NUM_OS_RANDOM_BYTES];
+    bool overwritten[NUM_OS_RANDOM_BYTES] = {}; /* Tracks which bytes have been overwritten at least once */
+    int num_overwritten;
+    int tries = 0;
+    /* Loop until all bytes have been overwritten at least once */
+    do {
+        memset(data, 0, NUM_OS_RANDOM_BYTES);
+        GetOSRand(data);
+        for (int x=0; x < NUM_OS_RANDOM_BYTES; ++x) {
+            overwritten[x] |= (data[x] != 0);
+        }
+
+        num_overwritten = 0;
+        for (int x=0; x < NUM_OS_RANDOM_BYTES; ++x) {
+            if (overwritten[x]) {
+                num_overwritten += 1;
+            }
+        }
+
+        tries += 1;
+    } while (num_overwritten < NUM_OS_RANDOM_BYTES && tries < MAX_TRIES);
+    BOOST_CHECK(num_overwritten == NUM_OS_RANDOM_BYTES); /* If this failed, bailed out after too many tries */
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -15,5 +15,24 @@ BOOST_AUTO_TEST_CASE(osrandom_tests)
     BOOST_CHECK(Random_SanityCheck());
 }
 
-BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_CASE(fastrandom_tests)
+{
+    // Check that deterministic FastRandomContexts are deterministic
+    FastRandomContext ctx1(true);
+    FastRandomContext ctx2(true);
 
+    BOOST_CHECK_EQUAL(ctx1.rand32(), ctx2.rand32());
+    BOOST_CHECK_EQUAL(ctx1.rand32(), ctx2.rand32());
+    BOOST_CHECK_EQUAL(ctx1.rand64(), ctx2.rand64());
+    BOOST_CHECK_EQUAL(ctx1.randbits(3), ctx2.randbits(3));
+    BOOST_CHECK_EQUAL(ctx1.randbits(7), ctx2.randbits(7));
+    BOOST_CHECK_EQUAL(ctx1.rand32(), ctx2.rand32());
+    BOOST_CHECK_EQUAL(ctx1.randbits(3), ctx2.randbits(3));
+
+    // Check that a nondeterministic ones are not
+    FastRandomContext ctx3;
+    FastRandomContext ctx4;
+    BOOST_CHECK(ctx3.rand64() != ctx4.rand64()); // extremely unlikely to be equal
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -10,36 +10,9 @@
 
 BOOST_FIXTURE_TEST_SUITE(random_tests, BasicTestingSetup)
 
-static const ssize_t MAX_TRIES = 1024;
-
 BOOST_AUTO_TEST_CASE(osrandom_tests)
 {
-    /* This does not measure the quality of randomness, but it does test that
-     * OSRandom() overwrites all 32 bytes of the output given a maximum
-     * number of tries.
-     */
-    uint8_t data[NUM_OS_RANDOM_BYTES];
-    bool overwritten[NUM_OS_RANDOM_BYTES] = {}; /* Tracks which bytes have been overwritten at least once */
-    int num_overwritten;
-    int tries = 0;
-    /* Loop until all bytes have been overwritten at least once */
-    do {
-        memset(data, 0, NUM_OS_RANDOM_BYTES);
-        GetOSRand(data);
-        for (int x=0; x < NUM_OS_RANDOM_BYTES; ++x) {
-            overwritten[x] |= (data[x] != 0);
-        }
-
-        num_overwritten = 0;
-        for (int x=0; x < NUM_OS_RANDOM_BYTES; ++x) {
-            if (overwritten[x]) {
-                num_overwritten += 1;
-            }
-        }
-
-        tries += 1;
-    } while (num_overwritten < NUM_OS_RANDOM_BYTES && tries < MAX_TRIES);
-    BOOST_CHECK(num_overwritten == NUM_OS_RANDOM_BYTES); /* If this failed, bailed out after too many tries */
+    BOOST_CHECK(Random_SanityCheck());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -35,11 +35,18 @@ BOOST_AUTO_TEST_CASE(fastrandom_tests)
     BOOST_CHECK(ctx1.randbytes(50) == ctx2.randbytes(50));
 
     // Check that a nondeterministic ones are not
-    FastRandomContext ctx3;
-    FastRandomContext ctx4;
-    BOOST_CHECK(ctx3.rand64() != ctx4.rand64()); // extremely unlikely to be equal
-    BOOST_CHECK(ctx3.rand256() != ctx4.rand256());
-    BOOST_CHECK(ctx3.randbytes(7) != ctx4.randbytes(7));
+    {
+        FastRandomContext ctx3, ctx4;
+        BOOST_CHECK(ctx3.rand64() != ctx4.rand64()); // extremely unlikely to be equal
+    }
+    {
+        FastRandomContext ctx3, ctx4;
+        BOOST_CHECK(ctx3.rand256() != ctx4.rand256());
+    }
+    {
+        FastRandomContext ctx3, ctx4;
+        BOOST_CHECK(ctx3.randbytes(7) != ctx4.randbytes(7));
+    }
 }
 
 BOOST_AUTO_TEST_CASE(fastrandom_randbits)

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -4,7 +4,7 @@
 
 #include "random.h"
 
-#include "test/test_bitcoin.h"
+#include "test/test_dapscoin.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -33,6 +33,21 @@ BOOST_AUTO_TEST_CASE(fastrandom_tests)
     FastRandomContext ctx3;
     FastRandomContext ctx4;
     BOOST_CHECK(ctx3.rand64() != ctx4.rand64()); // extremely unlikely to be equal
+}
+
+BOOST_AUTO_TEST_CASE(fastrandom_randbits)
+{
+    FastRandomContext ctx1;
+    FastRandomContext ctx2;
+    for (int bits = 0; bits < 63; ++bits) {
+        for (int j = 0; j < 1000; ++j) {
+            uint64_t rangebits = ctx1.randbits(bits);
+            BOOST_CHECK_EQUAL(rangebits >> bits, 0);
+            uint64_t range = ((uint64_t)1) << bits | rangebits;
+            uint64_t rand = ctx2.randrange(range);
+            BOOST_CHECK(rand < range);
+        }
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -49,8 +49,6 @@ static void MicroSleep(uint64_t n) {
 
 BOOST_AUTO_TEST_CASE(manythreads)
         {
-                seed_insecure_rand(false);
-
                 // Stress test: hundreds of microsecond-scheduled tasks,
                 // serviced by 10 threads.
                 //
@@ -65,7 +63,7 @@ BOOST_AUTO_TEST_CASE(manythreads)
 
                 boost::mutex counterMutex[10];
                 int counter[10] = { 0 };
-                boost::random::mt19937 rng(insecure_rand());
+                boost::random::mt19937 rng(42)
                 boost::random::uniform_int_distribution<> zeroToNine(0, 9);
                 boost::random::uniform_int_distribution<> randomMsec(-11, 1000);
                 boost::random::uniform_int_distribution<> randomDelta(-1000, 1000);

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -94,16 +94,16 @@ void static RandomTransaction(CMutableTransaction &tx, bool fSingle) {
     tx.nVersion = insecure_rand();
     tx.vin.clear();
     tx.vout.clear();
-    tx.nLockTime = (insecure_randrange(2)) ? insecure_rand() : 0;
-    int ins = (insecure_randrange(4)) + 1;
-    int outs = fSingle ? ins : (insecure_randrange(4)) + 1;
+    tx.nLockTime = (insecure_randbool()) ? insecure_rand() : 0;
+    int ins = (insecure_randbits(2)) + 1;
+    int outs = fSingle ? ins : (insecure_randbits(2)) + 1;
     for (int in = 0; in < ins; in++) {
         tx.vin.push_back(CTxIn());
         CTxIn &txin = tx.vin.back();
         txin.prevout.hash = insecure_rand256();
-        txin.prevout.n = insecure_randrange(4);
+        txin.prevout.n = insecure_randbits(2);
         RandomScript(txin.scriptSig);
-        txin.nSequence = (insecure_randrange(2)) ? insecure_rand() : (unsigned int)-1;
+        txin.nSequence = (insecure_randbool()) ? insecure_rand() : (unsigned int)-1;
     }
     for (int out = 0; out < outs; out++) {
         tx.vout.push_back(CTxOut());

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -85,7 +85,7 @@ uint256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, un
 void static RandomScript(CScript &script) {
     static const opcodetype oplist[] = {OP_FALSE, OP_1, OP_2, OP_3, OP_CHECKSIG, OP_IF, OP_VERIF, OP_RETURN, OP_CODESEPARATOR};
     script = CScript();
-    int ops = (insecure_rand() % 10);
+    int ops = (insecure_randrange(10));
     for (int i=0; i<ops; i++)
         script << oplist[insecure_rand() % (sizeof(oplist)/sizeof(oplist[0]))];
 }
@@ -94,21 +94,21 @@ void static RandomTransaction(CMutableTransaction &tx, bool fSingle) {
     tx.nVersion = insecure_rand();
     tx.vin.clear();
     tx.vout.clear();
-    tx.nLockTime = (insecure_rand() % 2) ? insecure_rand() : 0;
-    int ins = (insecure_rand() % 4) + 1;
-    int outs = fSingle ? ins : (insecure_rand() % 4) + 1;
+    tx.nLockTime = (insecure_randrange(2)) ? insecure_rand() : 0;
+    int ins = (insecure_randrange(4)) + 1;
+    int outs = fSingle ? ins : (insecure_randrange(4)) + 1;
     for (int in = 0; in < ins; in++) {
         tx.vin.push_back(CTxIn());
         CTxIn &txin = tx.vin.back();
-        txin.prevout.hash = GetRandHash();
-        txin.prevout.n = insecure_rand() % 4;
+        txin.prevout.hash = insecure_rand256();
+        txin.prevout.n = insecure_randrange(4);
         RandomScript(txin.scriptSig);
-        txin.nSequence = (insecure_rand() % 2) ? insecure_rand() : (unsigned int)-1;
+        txin.nSequence = (insecure_randrange(2)) ? insecure_rand() : (unsigned int)-1;
     }
     for (int out = 0; out < outs; out++) {
         tx.vout.push_back(CTxOut());
         CTxOut &txout = tx.vout.back();
-        txout.nValue = insecure_rand() % 100000000;
+        txout.nValue = insecure_randrange(100000000);
         RandomScript(txout.scriptPubKey);
     }
 }

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -87,7 +87,7 @@ void static RandomScript(CScript &script) {
     script = CScript();
     int ops = (insecure_randrange(10));
     for (int i=0; i<ops; i++)
-        script << oplist[insecure_rand() % (sizeof(oplist)/sizeof(oplist[0]))];
+        script << oplist[insecure_randrange(sizeof(oplist)/sizeof(oplist[0]))];
 }
 
 void static RandomTransaction(CMutableTransaction &tx, bool fSingle) {
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(sighash_test)
         RandomTransaction(txTo, (nHashType & 0x1f) == SIGHASH_SINGLE);
         CScript scriptCode;
         RandomScript(scriptCode);
-        int nIn = insecure_rand() % txTo.vin.size();
+        int nIn = insecure_randrange(txTo.vin.size());
 
         uint256 sh, sho;
         sho = SignatureHashOld(scriptCode, txTo, nIn, nHashType);

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -4,7 +4,7 @@
 
 #include "data/sighash.json.h"
 #include "main.h"
-#include "random.h"
+#include "test_random.h"
 #include "serialize.h"
 #include "script/script.h"
 #include "script/interpreter.h"

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(getlocator_test)
 
     // Test 100 random starting points for locators.
     for (int n=0; n<100; n++) {
-        int r = insecure_rand() % 150000;
+        int r = insecure_randrange(150000);
         CBlockIndex* tip = (r < 100000) ? &vBlocksMain[r] : &vBlocksSide[r - 100000];
         CBlockLocator locator = chain.GetLocator(tip);
 

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -35,8 +35,8 @@ BOOST_AUTO_TEST_CASE(skiplist_test)
     }
 
     for (int i=0; i < 1000; i++) {
-        int from = insecure_rand() % (SKIPLIST_LENGTH - 1);
-        int to = insecure_rand() % (from + 1);
+        int from = insecure_randrange(SKIPLIST_LENGTH - 1);
+        int to = insecure_randrange(from + 1);
 
         BOOST_CHECK(vIndex[SKIPLIST_LENGTH - 1].GetAncestor(from) == &vIndex[from]);
         BOOST_CHECK(vIndex[from].GetAncestor(to) == &vIndex[to]);

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "main.h"
-#include "random.h"
+#include "test_random.h"
 #include "util.h"
 
 #include <vector>

--- a/src/test/test_dapscoin.cpp
+++ b/src/test/test_dapscoin.cpp
@@ -130,14 +130,14 @@ struct TestingSetup {
 
 BOOST_GLOBAL_FIXTURE(TestingSetup);
 
-// void Shutdown(void* parg)
+// [[noreturn]] void Shutdown(void* parg)
 // {
-//   exit(0);
+//   std::exit(0);
 // }
 
-// void StartShutdown()
+// [[noreturn]] void StartShutdown()
 // {
-//   exit(0);
+//   std::exit(0);
 // }
 
 // bool ShutdownRequested()

--- a/src/test/test_dapscoin.cpp
+++ b/src/test/test_dapscoin.cpp
@@ -21,7 +21,8 @@
 extern CClientUIInterface uiInterface;
 extern CWallet* pwalletMain;
 
-FastRandomContext insecure_rand_ctx(true);
+uint256 insecure_rand_seed = GetRandHash();
+FastRandomContext insecure_rand_ctx(insecure_rand_seed);
 
 extern bool fPrintToConsole;
 extern void noui_connect();

--- a/src/test/test_dapscoin.cpp
+++ b/src/test/test_dapscoin.cpp
@@ -33,6 +33,7 @@ struct TestingSetup {
     boost::thread_group threadGroup;
 
     TestingSetup() {
+        RandomInit();
         SetupEnvironment();
         fPrintToDebugLog = true; // don't want to write to debug.log file
         fCheckBlockIndex = false;

--- a/src/test/test_dapscoin.cpp
+++ b/src/test/test_dapscoin.cpp
@@ -21,6 +21,8 @@
 extern CClientUIInterface uiInterface;
 extern CWallet* pwalletMain;
 
+FastRandomContext insecure_rand_ctx(true);
+
 extern bool fPrintToConsole;
 extern void noui_connect();
 

--- a/src/test/test_dapscoin.cpp
+++ b/src/test/test_dapscoin.cpp
@@ -41,7 +41,7 @@ struct TestingSetup {
 #ifdef ENABLE_WALLET
         bitdb.MakeMock();
 #endif
-        // pathTemp = GetTempPath() / strprintf("test_dapscoin_%lu_%i", (unsigned long)GetTime(), (int)(GetRand(100000)));
+        // pathTemp = GetTempPath() / strprintf("test_dapscoin_%lu_%i", (unsigned long)GetTime(), (int)(insecure_randrange(100000)));
         pathTemp = GetTempPath() / "test_dapscoin";
         boost::filesystem::create_directories(pathTemp);
         mapArgs["-datadir"] = pathTemp.string();

--- a/src/test/test_random.h
+++ b/src/test/test_random.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_RANDOM_H
+#define BITCOIN_TEST_RANDOM_H
+
+#include "random.h"
+
+extern FastRandomContext insecure_rand_ctx;
+
+static inline void seed_insecure_rand(bool fDeterministic = false)
+{
+    insecure_rand_ctx = FastRandomContext(fDeterministic);
+}
+
+static inline uint32_t insecure_rand(void)
+{
+    return insecure_rand_ctx.rand32();
+}
+
+#endif

--- a/src/test/test_random.h
+++ b/src/test/test_random.h
@@ -8,11 +8,17 @@
 
 #include "random.h"
 
+extern uint256 insecure_rand_seed;
 extern FastRandomContext insecure_rand_ctx;
 
 static inline void seed_insecure_rand(bool fDeterministic = false)
 {
-    insecure_rand_ctx = FastRandomContext(fDeterministic);
+    if (fDeterministic) {
+        insecure_rand_seed = uint256();
+    } else {
+        insecure_rand_seed = GetRandHash();
+    }
+    insecure_rand_ctx = FastRandomContext(insecure_rand_seed);
 }
 
 static inline uint32_t insecure_rand(void)

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -6,7 +6,7 @@
 
 #include "clientversion.h"
 #include "primitives/transaction.h"
-#include "random.h"
+#include "test_random.h"
 #include "sync.h"
 #include "utilstrencodings.h"
 #include "utilmoneystr.h"

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -14,6 +14,7 @@
 #include "coins.h"
 #include "primitives/transaction.h"
 #include "sync.h"
+#include "random.h"
 
 class CAutoFile;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -878,16 +878,14 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
         return false;
 
     CKeyingMaterial vMasterKey;
-    RandAddSeedPerfmon();
 
     vMasterKey.resize(WALLET_CRYPTO_KEY_SIZE);
-    GetRandBytes(&vMasterKey[0], WALLET_CRYPTO_KEY_SIZE);
+    GetStrongRandBytes(&vMasterKey[0], WALLET_CRYPTO_KEY_SIZE);
 
     CMasterKey kMasterKey;
-    RandAddSeedPerfmon();
 
     kMasterKey.vchSalt.resize(WALLET_CRYPTO_SALT_SIZE);
-    GetRandBytes(&kMasterKey.vchSalt[0], WALLET_CRYPTO_SALT_SIZE);
+    GetStrongRandBytes(&kMasterKey.vchSalt[0], WALLET_CRYPTO_SALT_SIZE);
 
     CCrypter crypter;
     int64_t nStartTime = GetTimeMillis();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2035,7 +2035,7 @@ static CAmount ApproximateBestSubset(int numOut, int ringSize, vector<pair<CAmou
     nBest = nTotalLower;
     int estimateTxSize = 0;
     CAmount nFeeNeeded = 0;
-    seed_insecure_rand();
+    FastRandomContext insecure_rand;
 
     for (int nRep = 0; nRep < iterations && nBest != nTargetValue + nFeeNeeded; nRep++) {
         vfIncluded.assign(vValue.size(), false);
@@ -2050,7 +2050,7 @@ static CAmount ApproximateBestSubset(int numOut, int ringSize, vector<pair<CAmou
                 //that the rng is fast. We do not use a constant random sequence,
                 //because there may be some privacy improvement by making
                 //the selection random.
-                if (nPass == 0 ? insecure_rand() & 1 : !vfIncluded[i]) {
+                if (nPass == 0 ? insecure_rand.rand32() & 1 : !vfIncluded[i]) {
                     nTotal += vValue[i].first;
                     vfIncluded[i] = true;
                     numSelected++;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2050,7 +2050,7 @@ static CAmount ApproximateBestSubset(int numOut, int ringSize, vector<pair<CAmou
                 //that the rng is fast. We do not use a constant random sequence,
                 //because there may be some privacy improvement by making
                 //the selection random.
-                if (nPass == 0 ? insecure_rand.rand32() & 1 : !vfIncluded[i]) {
+                if (nPass == 0 ? insecure_rand.randbool() : !vfIncluded[i]) {
                     nTotal += vValue[i].first;
                     vfIncluded[i] = true;
                     numSelected++;


### PR DESCRIPTION
> Since #576 hasn't changed in over a month, here is a reworked version of it.
> So in this PR:
> -We add the memory_cleanse function from upstream, to remove a number of OpenSSL calls.
> -We use OS randomness in addition to OpenSSL randomness (see #576 for why it's needed).

backport of https://github.com/PIVX-Project/PIVX/pull/643 for rpcserver