### PR TITLE
[Net] Relay actual peers instead of localhost on getaddr

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -452,11 +452,11 @@ public:
         // Known checking here is only to save space from duplicates.
         // SendMessages will filter it again for knowns that were added
         // after addresses were pushed.
-        if (addr.IsValid() && !setAddrKnown.count(addr)) {
+        if (_addr.IsValid() && !setAddrKnown.count(_addr)) {
             if (vAddrToSend.size() >= MAX_ADDR_TO_SEND) {
                 vAddrToSend[insecure_rand.randrange(vAddrToSend.size())] = _addr;
             } else {
-                vAddrToSend.push_back(addr);
+                vAddrToSend.push_back(_addr);
             }
         }
     }


### PR DESCRIPTION
> This fixes the getaddr response which is crucial for dns-seeders and wallet to find peers. On current code it only checks localhost addr being valid and if its known, while in reality we need to relay the node passed in args.
> 
> Credit to @Aviator-Coding for pointing the bug out and the fix.

backports https://github.com/PIVX-Project/PIVX/pull/1492