### PR TITLE
[Fix] Use Spendable balance when checking Masternode controller Staking Status

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2160,6 +2160,9 @@ StakingStatusError CWallet::StakingCoinStatus(CAmount& minFee, CAmount& maxFee)
     minFee = 0;
     maxFee = 0;
     CAmount nBalance = GetBalance();
+    if (pwalletMain->IsMasternodeController()) {
+        nBalance = GetSpendableBalance();
+    }
     if (nBalance < MINIMUM_STAKE_AMOUNT) {
         return StakingStatusError::UNSTAKABLE_BALANCE_TOO_LOW;
     }


### PR DESCRIPTION
- Use Spendable balance when checking Masternode controller Staking Status
![image](https://user-images.githubusercontent.com/75491804/107155656-95b20b00-6947-11eb-9bff-20d2a1845861.png)
