### PR TITLE
[Build] Fix typo in Qt test makefile

### DIFF
--- a/src/Makefile.qttest.include
+++ b/src/Makefile.qttest.include
@@ -41,7 +41,7 @@ qt_test_test_prcycoin_qt_LDADD += $(LIBBITCOIN_CLI) $(LIBBITCOIN_COMMON) $(LIBBI
   $(QR_LIBS) $(PROTOBUF_LIBS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(LIBSECP256K1) \
   $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS)
 qt_test_test_prcycoin_qt_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(QT_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
-qt_test_test_bitcoin_qt_CXXFLAGS = $(AM_CXXFLAGS) $(QT_PIE_FLAGS)
+qt_test_test_prcycoin_qt_CXXFLAGS = $(AM_CXXFLAGS) $(QT_PIE_FLAGS)
 
 CLEAN_BITCOIN_QT_TEST = $(TEST_QT_MOC_CPP) qt/test/*.gcda qt/test/*.gcno
 


### PR DESCRIPTION
Typo in target flags name causes the position independent flag (-fPIC or
-fPIE) to not be properly passed on when linking the Qt test binary.

On systems that have Qt built with reduced exports, this causes a linker
error.

Gitian and depends based builds aren't affected.

from https://github.com/PIVX-Project/PIVX/pull/541