### PR TITLE
[Minor Cleanup] Chainparams

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -280,11 +280,6 @@ public:
         nModifierUpdateBlock = 51197; //approx Mon, 17 Apr 2017 04:00:00 GMT
         MAX_MONEY = 5000000000.0;
         nMaxMoneyOut = MAX_MONEY * COIN;
-        nBlockEnforceSerialRange = 1; //Enforce serial range starting this block
-        nBlockRecalculateAccumulators = 9908000; //Trigger a recalculation of accumulators
-        nBlockFirstFraudulent = 9891737; //First block that bad serials emerged
-        nBlockLastGoodCheckpoint = 9891730; //Last valid accumulator checkpoint
-        nBlockEnforceInvalidUTXO = 9902850; //Start enforcing the invalid UTXO's
         nSoftForkBlock = 0; // Soft fork block for difficulty change - testnet started with it
 
         //! Modify the testnet genesis block so the timestamp is valid for a later start.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -137,7 +137,6 @@ public:
         /** Height or Time Based Activations **/
         nLastPOWBlock = 500;
         nStartPOABlock = 560;
-//        nRemoveRewardBlock = 6000;
         nModifierUpdateBlock = 615800;
         nPoABlockTime = 60 * 60; //a PoA block every 60 minutes
         nMinNumPoSBlocks = 59;
@@ -274,7 +273,6 @@ public:
         nTargetSpacing = 1 * 60;  // PRCYcoin: 1 minute
         nLastPOWBlock = 500;
         nStartPOABlock = 560;
-//        nRemoveRewardBlock = 6000;
         nPoABlockTime = 30 * 60;  //1 PoA block every 30 minutes
         nMinNumPoSBlocks = 20;
         nMaturity = 15;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -102,7 +102,6 @@ public:
     int ModifierUpgradeBlock() const { return nModifierUpdateBlock; }
     int LAST_POW_BLOCK() const { return nLastPOWBlock; }
     int START_POA_BLOCK() const { return nStartPOABlock; }
-//    int REMOVE_REWARD_BLOCK() const { return nRemoveRewardBlock; }
     int Block_Enforce_Invalid() const { return nBlockEnforceInvalidUTXO; }
     int SoftFork() const { return nSoftForkBlock;}
 
@@ -111,8 +110,6 @@ public:
     int MIN_NUM_POS_BLOCKS_AUDITED() const {return nMinNumPoSBlocks;}
     int MAX_NUM_POS_BLOCKS_AUDITED() const {return nMaxNumPoSBlocks;}
     int nLastPOWBlock;
-//    int nRemoveRewardBlock;
-//    int TEAM_REWARD_FREQUENCY = 3; //every  TEAM_REWARD_FREQUENCY PoA blocks, reward the prcy team
     double MAX_MONEY;
     CAmount TOTAL_SUPPLY = 70000000 * COIN; //70M PRCY
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -102,7 +102,6 @@ public:
     int ModifierUpgradeBlock() const { return nModifierUpdateBlock; }
     int LAST_POW_BLOCK() const { return nLastPOWBlock; }
     int START_POA_BLOCK() const { return nStartPOABlock; }
-    int Block_Enforce_Invalid() const { return nBlockEnforceInvalidUTXO; }
     int SoftFork() const { return nSoftForkBlock;}
 
     //For PoA block time
@@ -155,11 +154,6 @@ protected:
     std::string strObfuscationPoolDummyAddress;
     int64_t nStartMasternodePayments;
     int64_t nBudget_Fee_Confirmations;
-    int nBlockEnforceSerialRange;
-    int nBlockRecalculateAccumulators;
-    int nBlockFirstFraudulent;
-    int nBlockLastGoodCheckpoint;
-    int nBlockEnforceInvalidUTXO;
 
     //For PoA blocks
     int nPoABlockTime;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1463,9 +1463,6 @@ bool AppInit2(bool isDaemon)
                     break;
                 }
 
-                // Populate list of invalid/fraudulent outpoints that are banned from the chain
-                PopulateInvalidOutPointMap();
-
                 // Recalculate money supply for blocks
                 if (GetBoolArg("-reindexmoneysupply", false)) {
                     RecalculatePRCYSupply(1);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2739,19 +2739,9 @@ CBitcoinAddress addressExp2("DTQYdnNqKuEHXyNeeYhPQGGGdqHbXYwjpj");
 map<COutPoint, COutPoint> mapInvalidOutPoints;
 map<CBigNum, CAmount> mapInvalidSerials;
 
-void AddInvalidSpendsToMap(const CBlock& block)
-{
-    //empty function
-}
-
 // Populate global map (mapInvalidOutPoints) of invalid/fraudulent OutPoints that are banned from being used on the chain.
 CAmount nFilteredThroughBittrex = 0;
 bool fListPopulatedAfterLock = false;
-
-void PopulateInvalidOutPointMap()
-{
-    //empty function
-}
 
 CAmount GetInvalidUTXOValue()
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1888,14 +1888,6 @@ bool AcceptableInputs(CTxMemPool& pool, CValidationState& state, const CTransact
                         *pfMissingInputs = true;
                     return false;
                 }
-
-                // check for invalid/fraudulent inputs
-                if (!ValidOutPoint(txin.prevout, chainHeight)) {
-                    return state.Invalid(
-                        error("%s : tried to spend invalid input %s in tx %s", __func__, txin.prevout.ToString(),
-                            tx.GetHash().GetHex()),
-                        REJECT_INVALID, "bad-txns-invalid-inputs");
-                }
             }
 
             // are the actual inputs available?
@@ -2761,12 +2753,6 @@ void PopulateInvalidOutPointMap()
     //empty function
 }
 
-bool ValidOutPoint(const COutPoint out, int nHeight)
-{
-    bool isInvalid = nHeight >= Params().Block_Enforce_Invalid() && mapInvalidOutPoints.count(out);
-    return !isInvalid;
-}
-
 CAmount GetInvalidUTXOValue()
 {
     CAmount nValue = 0;
@@ -3225,9 +3211,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                         pwalletMain->keyImagesSpends[keyImage.GetHex()] = true;
                     }
                     pwalletMain->pendingKeyImages.remove(keyImage.GetHex());
-                }
-                if (!ValidOutPoint(in.prevout, pindex->nHeight)) {
-                    return state.DoS(100, error("%s : tried to spend invalid input %s in tx %s", __func__, in.prevout.ToString(), tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-inputs");
                 }
             }
 

--- a/src/main.h
+++ b/src/main.h
@@ -373,7 +373,6 @@ bool IsSerialInBlockchain(const CBigNum& bnSerial, int& nHeightTx);
 bool RemoveSerialFromDB(const CBigNum& bnSerial);
 bool IsTransactionInChain(uint256 txId, int& nHeightTx);
 bool IsBlockHashInChain(const uint256& hashBlock);
-void PopulateInvalidOutPointMap();
 bool RecalculatePRCYSupply(int nHeightStart);
 bool ReindexAccumulators(list<uint256>& listMissingCheckpoints, string& strError);
 

--- a/src/main.h
+++ b/src/main.h
@@ -374,7 +374,6 @@ bool RemoveSerialFromDB(const CBigNum& bnSerial);
 bool IsTransactionInChain(uint256 txId, int& nHeightTx);
 bool IsBlockHashInChain(const uint256& hashBlock);
 void PopulateInvalidOutPointMap();
-bool ValidOutPoint(const COutPoint out, int nHeight);
 bool RecalculatePRCYSupply(int nHeightStart);
 bool ReindexAccumulators(list<uint256>& listMissingCheckpoints, string& strError);
 


### PR DESCRIPTION
- Cleanup commented out chainparam items
- Remove some unused chainparam items
- Remove unused function based on Block_Enforce_Invalid()
  - Params().Block_Enforce_Invalid() / nBlockEnforceInvalidUTXO = 9902850; //Start enforcing the invalid UTXO's - PRCY is nowhere near this block.
- Remove empty functions