### PR TITLE
[Upstream] Guarding wallet access from init and better MN collateral output lock logging.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1850,13 +1850,14 @@ bool AppInit2(bool isDaemon)
 #ifdef ENABLE_WALLET
     if (GetBoolArg("-mnconflock", true) && pwalletMain) {
         LOCK(pwalletMain->cs_wallet);
-        LogPrintf("Locking Masternodes:\n");
+        LogPrintf("Locking Masternodes collateral utxo:\n");
         uint256 mnTxHash;
-        for (CMasternodeConfig::CMasternodeEntry mne : masternodeConfig.getEntries()) {
-            LogPrintf("  %s %s\n", mne.getTxHash(), mne.getOutputIndex());
+        for (const auto& mne : masternodeConfig.getEntries()) {
             mnTxHash.SetHex(mne.getTxHash());
             COutPoint outpoint = COutPoint(mnTxHash, (unsigned int) std::stoul(mne.getOutputIndex().c_str()));
             pwalletMain->LockCoin(outpoint);
+            LogPrintf("Locked collateral, MN: %s, tx hash: %s, output index: %s\n",
+                      mne.getAlias(), mne.getTxHash(), mne.getOutputIndex());
         }
     }
 #endif
@@ -1865,7 +1866,7 @@ bool AppInit2(bool isDaemon)
     nSwiftTXDepth = GetArg("-swifttxdepth", nSwiftTXDepth);
     nSwiftTXDepth = std::min(std::max(nSwiftTXDepth, 0), 60);
 
-    //lite mode disables all Masternode and Obfuscation related functionality
+    // lite mode disables all Masternode and Obfuscation related functionality
     fLiteMode = GetBoolArg("-litemode", false);
     if (fMasterNode && fLiteMode) {
         return InitError("You can not start a masternode in litemode");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1847,6 +1847,7 @@ bool AppInit2(bool isDaemon)
     //get the mode of budget voting for this masternode
     strBudgetMode = GetArg("-budgetvotemode", "auto");
 
+#ifdef ENABLE_WALLET
     if (GetBoolArg("-mnconflock", true) && pwalletMain) {
         LOCK(pwalletMain->cs_wallet);
         LogPrintf("Locking Masternodes:\n");
@@ -1858,6 +1859,7 @@ bool AppInit2(bool isDaemon)
             pwalletMain->LockCoin(outpoint);
         }
     }
+#endif
 
     fEnableSwiftTX = GetBoolArg("-enableswifttx", fEnableSwiftTX);
     nSwiftTXDepth = GetArg("-swifttxdepth", nSwiftTXDepth);


### PR DESCRIPTION
> Two changes:
> 
> 1. Guarding `pwalletMain` access from init.cpp, so in the future we could enable pivxd to run without the wallet.
> 2. BugFix: `Wallet::LockCoin` verifying that the MN collateral utxo is in the wallet's map before add it to the locked set. Printing the correct error if the transaction is unknown for the wallet.

from https://github.com/PIVX-Project/PIVX/pull/2218
Item 2 was removed from the PR upstream and replaced with https://github.com/PRCYCoin/PRCYCoin/commit/64db9725d6f5db86a6f2648c76730709346a4367