### PR TITLE
[Upstream] Fixing few shutdown problems

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1727,8 +1727,11 @@ bool AppInit2(bool isDaemon)
 
     // scan for better chains in the block chain database, that are not yet connected in the active best chain
     CValidationState state;
-    if (!ActivateBestChain(state))
+    if (!ActivateBestChain(state)) {
         strErrors << "Failed to connect best block";
+        StartShutdown();
+        return false;
+    }
     // update g_best_block if needed
     {
         LOCK(g_best_block_mutex);

--- a/src/qt/prcycoin.cpp
+++ b/src/qt/prcycoin.cpp
@@ -383,7 +383,6 @@ void BitcoinApplication::createWindow(const NetworkStyle* networkStyle)
 
     pollShutdownTimer = new QTimer(window);
     connect(pollShutdownTimer, SIGNAL(timeout()), window, SLOT(detectShutdown()));
-    pollShutdownTimer->start(200);
 }
 
 void BitcoinApplication::createSplashScreen(const NetworkStyle* networkStyle)
@@ -533,6 +532,7 @@ void BitcoinApplication::initializeResult(int retval)
             }
         }
 #endif
+        pollShutdownTimer->start(200);
     } else {
         quit(); // Exit main loop
     }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -14,7 +14,7 @@
 #include "recentrequeststablemodel.h"
 #include "transactionrecord.h"
 #include "transactiontablemodel.h"
-
+#include "init.h" // for ShutdownRequested(). Future: move to an interface wrapper
 
 #include "base58.h"
 #include "wallet/db.h"
@@ -61,6 +61,11 @@ WalletModel::WalletModel(CWallet* wallet, OptionsModel* optionsModel, QObject* p
     pollTimer->start(MODEL_UPDATE_DELAY);
 
     subscribeToCoreSignals();
+}
+
+bool WalletModel::isShutdownRequested()
+{
+    return ShutdownRequested();
 }
 
 WalletModel::~WalletModel()

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -136,6 +136,8 @@ public:
     QAbstractTableModel* getTxTableModel();
     RecentRequestsTableModel* getRecentRequestsTableModel();
 
+    bool isShutdownRequested();
+
     CAmount getBalance(const CCoinControl* coinControl = NULL) const;
     CAmount getUnconfirmedBalance() const;
     CAmount getImmatureBalance() const;


### PR DESCRIPTION
> First commit was decoupled from #2131, the topbar staking status polling should not try to refresh data if shutdown was requested.
> Second commit is coming from [bitcoin#12377](https://github.com/bitcoin/bitcoin/pull/12377).
> Third commit is starting the shutdown process and returning early (without starting the import thread) if the best chain cannot be activated during the node's initialization.

from https://github.com/PIVX-Project/PIVX/pull/2228

https://github.com/PRCYCoin/PRCYCoin/commit/fe398cc24040ee7544d621f694c76d19c07979d5 was slightly modified to only add the function, it is not currently in use, but can be useful for future
