### PR TITLE
[Upstream] [BugFix] Shutdown, stop threadGroup before dump data to disk.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -201,15 +201,16 @@ void PrepareShutdown()
     GeneratePrcycoins(false, NULL, 0);
 #endif
     StopNode();
-    DumpMasternodes();
-    DumpBudgets();
-    DumpMasternodePayments();
-    UnregisterNodeSignals(GetNodeSignals());
 
     // After everything has been shut down, but before things get flushed, stop the
     // CScheduler/checkqueue threadGroup
     threadGroup.interrupt_all();
     threadGroup.join_all();
+
+    DumpMasternodes();
+    DumpBudgets();
+    DumpMasternodePayments();
+    UnregisterNodeSignals(GetNodeSignals());
 
     if (fFeeEstimatesInitialized) {
         boost::filesystem::path est_path = GetDataDir() / FEE_ESTIMATES_FILENAME;


### PR DESCRIPTION
> In the shutdown process, stop every thread before dump data to disk, otherwise threads will continue modifying data structures while and after the dump process is being / was executed, ending up not storing all of the data and/or corrupting the node state.

from https://github.com/PIVX-Project/PIVX/pull/2191