### PR TITLE
[Upstream] [Node] Replace IsSuperMajority with height checks

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -123,6 +123,7 @@ public:
         nMinNumPoSBlocks = 59;
         nMaxNumPoSBlocks = 120;
         nSoftForkBlock = 120000; // Soft fork block for difficulty change
+        nBIP65ActivationHeight = 125000; // Last v3 block was 124712, leave a bit of padding
 
         /**
          * Build the genesis block. Note that the output of the genesis coinbase cannot
@@ -262,6 +263,7 @@ public:
         MAX_MONEY = 5000000000.0;
         nMaxMoneyOut = MAX_MONEY * COIN;
         nSoftForkBlock = 0; // Soft fork block for difficulty change - testnet started with it
+        nBIP65ActivationHeight = 0;
 
         //! Modify the testnet genesis block so the timestamp is valid for a later start.
         genesis.nTime = 1608422400;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -108,6 +108,7 @@ public:
     int LAST_POW_BLOCK() const { return nLastPOWBlock; }
     int START_POA_BLOCK() const { return nStartPOABlock; }
     int SoftFork() const { return nSoftForkBlock;}
+    int BIP65ActivationHeight() const { return nBIP65ActivationHeight; }
 
     //For PoA block time
     int POA_BLOCK_TIME() const { return nPoABlockTime; }
@@ -159,6 +160,7 @@ protected:
     std::string strObfuscationPoolDummyAddress;
     int64_t nStartMasternodePayments;
     int64_t nBudget_Fee_Confirmations;
+    int nBIP65ActivationHeight;
 
     //For PoA blocks
     int nPoABlockTime;


### PR DESCRIPTION
BIP65 was enabled with block version 5. It makes sense to save a bit of
performance by simply checking for height activation instead of looking
for a super majority.

from https://github.com/PIVX-Project/PIVX/pull/1067