### PR TITLE
Remove Timed Ban/PoA Fix

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -126,11 +126,7 @@ unsigned short GetListenPort() {
 }
 
 bool IsUnsupportedVersion(std::string strSubVer) {
-    std::time_t banningTime = std::time(0);
-    if (banningTime >= Params().PoAFixTime()) {
-        return (strSubVer == "/PRCY:1.0.0.2/" || strSubVer == "/PRCY:1.0.0.3/" || strSubVer == "/PRCY:1.0.0.4/" || strSubVer == "/PRCY:1.0.0.5/");
-    }
-    return (strSubVer == "/PRCY:1.0.0.2/" || strSubVer == "/PRCY:1.0.0.3/" || strSubVer == "/PRCY:1.0.0.4/");
+    return (strSubVer == "/PRCY:1.0.0.2/" || strSubVer == "/PRCY:1.0.0.3/" || strSubVer == "/PRCY:1.0.0.4/" || strSubVer == "/PRCY:1.0.0.5/");
 }
 
 // find 'best' local address for a particular peer

--- a/src/poa.cpp
+++ b/src/poa.cpp
@@ -484,18 +484,9 @@ bool CheckPoABlockRewardAmount(const CBlock& block, const CBlockIndex* pindex)
 }
 
 bool IsFixedAudit(std::string txid) {
-    std::time_t fixedTime = std::time(0);
-    if (fixedTime >= Params().PoAFixTime()) {
-        return (txid == "9965850037f14dcb4abf1168016e9f96f53692322714e7fac92a2b8838544135" || txid == "dd3d1dccf8f39a220e3a83cfabaf1b567b6696af877073ec580d09af6198f098");
-    }
-    return (txid == "9965850037f14dcb4abf1168016e9f96f53692322714e7fac92a2b8838544135");
+    return (txid == "9965850037f14dcb4abf1168016e9f96f53692322714e7fac92a2b8838544135" || txid == "dd3d1dccf8f39a220e3a83cfabaf1b567b6696af877073ec580d09af6198f098");
 }
 
 bool IsWrongAudit(std::string txid) {
-    std::time_t fixedTime = std::time(0);
-    if (fixedTime >= Params().PoAFixTime()) {
-        //Currently only one
-        return (txid == "ef99f7882a681a075ebd51fa83be01685257ca66ccb736950fefc037f00e1538");
-    }
-    return (txid == "");
+    return (txid == "ef99f7882a681a075ebd51fa83be01685257ca66ccb736950fefc037f00e1538");
 }


### PR DESCRIPTION
These become permanent after Friday, March 26, 2021 12:00:00 AM (GMT) and no longer require a time check