### PR TITLE
[Wallet] Hide Incorrect Values When Locked

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -322,6 +322,9 @@ UniValue getrawtransaction(const UniValue& params, bool fHelp)
     if (params.size() > 1)
         fVerbose = (params[1].get_int() != 0);
 
+    if (params[1].get_int() == 2)
+        EnsureWalletIsUnlocked();
+
     CTransaction tx;
     uint256 hashBlock = 0;
     if (!GetTransaction(hash, tx, hashBlock, true))

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -110,7 +110,12 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
                                         CAmount decodedAmount;
                                         CKey blind;
                                         pwalletMain->RevealTxOutAmount(prev, prev.vout[allDecoys[i].n], decodedAmount, blind);
-                                        decoy.push_back(Pair("decoded_amount", ValueFromAmount(decodedAmount)));
+                                        if (pwalletMain->IsLocked()) {
+                                            decoy.push_back(Pair("decoded_amount", "Wallet is Locked"));
+                                        } else {
+                                            decoy.push_back(Pair("decoded_amount", ValueFromAmount(decodedAmount)));
+                                        }
+                                        
                                         decoy.push_back(Pair("isMine", true));
                                     }
                                 }
@@ -163,7 +168,12 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
             } else {
                 pBlind = blind.begin();
             }
-            out.push_back(Pair("decoded_amount", ValueFromAmount(decodedAmount)));
+            if (pwalletMain->IsLocked()) {
+                out.push_back(Pair("decoded_amount", "Wallet is Locked"));
+            } else {
+                out.push_back(Pair("decoded_amount", ValueFromAmount(decodedAmount)));
+            }
+
             out.push_back(Pair("isMine", true));
         } else {
             out.push_back(Pair("isMine", false));


### PR DESCRIPTION
- Show "Wallet is Locked" instead of incorrect decoded_amount
- Add `getrawtransaction TXID 2` RPC - which will EnsureWalletIsUnlocked() first