### PR TITLE
[Consensus] Make masternode collateral amount a consensus param (chainparams)

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -454,7 +454,7 @@ bool CActiveMasternode::GetVinFromOutput(COutput out, CTxIn& vin, CPubKey& pubke
         return false;
     }
 
-    if (amount != 5000 * COIN) {
+    if (amount != Params().MNCollateralAmt()) {
         LogPrintf("dsee - masternode collateralization not equal to 5K %s\n", vin.prevout.hash.ToString());
         return false;
     }
@@ -500,7 +500,7 @@ vector<COutput> CActiveMasternode::SelectCoinsMasternode()
 
         // Filter
         for (const COutput& out : vCoins) {
-            if (pwalletMain->getCTxOutValue(*out.tx, out.tx->vout[out.i]) == 5000 * COIN) { //exactly
+            if (pwalletMain->getCTxOutValue(*out.tx, out.tx->vout[out.i]) == Params().MNCollateralAmt()) { //exactly
                 filteredCoins.push_back(out);
             }
         }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -121,6 +121,7 @@ public:
         nMasternodeCountDrift = 20;
         MAX_MONEY = 70000000.0;
         nMaxMoneyOut = MAX_MONEY * COIN;
+        nMNCollateralAmt = 5000 * COIN;
 
         /** Height or Time Based Activations **/
         nLastPOWBlock = 500;
@@ -282,6 +283,7 @@ public:
         nModifierUpdateBlock = 51197; //approx Mon, 17 Apr 2017 04:00:00 GMT
         MAX_MONEY = 70000000.0;
         nMaxMoneyOut = MAX_MONEY * COIN;
+        nMNCollateralAmt = 5000 * COIN;
         nSoftForkBlock = 600; // Soft fork block for difficulty change - testnet started with it
         nPoANewDiff = 650;
         nBIP65ActivationHeight = 0;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -85,6 +85,7 @@ public:
     int64_t Interval() const { return nTargetTimespan / nTargetSpacing; }
     int COINBASE_MATURITY() const { return nMaturity; }
     CAmount MaxMoneyOut() const { return nMaxMoneyOut; }
+    CAmount MNCollateralAmt() const { return nMNCollateralAmt; }
     /** The masternode count that we will allow the see-saw reward payments to be off by */
     int MasternodeCountDrift() const { return nMasternodeCountDrift; }
     /** Make miner stop after a block is found. In RPC, don't return until nGenProcLimit blocks are generated */
@@ -149,6 +150,7 @@ protected:
     int nMaturity;
     int nModifierUpdateBlock;
     CAmount nMaxMoneyOut;
+    CAmount nMNCollateralAmt;
     int nMinerThreads;
     std::vector<CDNSSeedData> vSeeds;
     std::vector<unsigned char> base58Prefixes[MAX_BASE58_TYPES];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2145,7 +2145,7 @@ CAmount GetSeeSaw(const CAmount& blockValue, int nMasternodeCount, int nHeight)
     }
 
     int64_t nMoneySupply = chainActive.Tip()->nMoneySupply;
-    int64_t mNodeCoins = nMasternodeCount * 5000 * COIN;
+    int64_t mNodeCoins = nMasternodeCount * Params().MNCollateralAmt();
 
     // Use this log to compare the masternode count for different clients
     LogPrintf("Adjusting seesaw at height %d with %d masternodes (without drift: %d) at %ld\n", nHeight,nMasternodeCount, nMasternodeCount - Params().MasternodeCountDrift(), GetTime());

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -891,7 +891,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
             return;
         }
 
-        if (amount != 5000 * COIN) {
+        if (amount != Params().MNCollateralAmt()) {
             LogPrint("masternode","dsee - masternode collateralization not equal to 5K %s\n", vin.prevout.hash.ToString());
             return;
         }

--- a/src/obfuscation.cpp
+++ b/src/obfuscation.cpp
@@ -544,7 +544,7 @@ bool CObfuScationSigner::IsVinAssociatedWithPubkey(CTxIn& vin, CPubKey& pubkey)
             return false;
         }
 
-        if (amount == 5000 * COIN) {
+        if (amount == Params().MNCollateralAmt()) {
             if (out.scriptPubKey == payee2) return true;
         }
     }


### PR DESCRIPTION
Make masternode collateral amount a consensus param

A bit of a cherry pick from https://github.com/PIVX-Project/PIVX/pull/2296
https://github.com/PIVX-Project/PIVX/pull/2296/commits/86dcf69e392ac081d97c1cb68c6b733113c5421a

This makes it easier for modifying the MN Collateral in the future, which we have briefly discussed