### PR TITLE
Hard Fork Hot Fix

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -136,7 +136,7 @@ public:
         nPoAFixTime = 1616716800; // Fork time for PoA fix - Friday, March 26, 2021 12:00:00 AM (GMT)
         nPoAPaddingBlock = 169869; // Last block with 120 PoS blocks in a PoA Audit
         nPoAPadding = 10; // Current PoA Padding
-        nHardForkBlock = 350000; // Add hard fork block for Consensus/PoA Padding
+        nHardForkBlock = 365000; // Add hard fork block for Consensus/PoA Padding
 
         /**
          * Build the genesis block. Note that the output of the genesis coinbase cannot

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -127,9 +127,9 @@ unsigned short GetListenPort() {
 
 bool IsUnsupportedVersion(std::string strSubVer, int nHeight) {
     if (nHeight >= Params().HardFork()) {
-        return (strSubVer == "/PRCY:1.0.0.2/" || strSubVer == "/PRCY:1.0.0.3/" || strSubVer == "/PRCY:1.0.0.4/" || strSubVer == "/PRCY:1.0.0.5/" || strSubVer == "/PRCY:1.0.0.6/");
+        return (strSubVer == "/PRCY:1.0.0.2/" || strSubVer == "/PRCY:1.0.0.3/" || strSubVer == "/PRCY:1.0.0.4/" || strSubVer == "/PRCY:1.0.0.5/" || strSubVer == "/PRCY:1.0.0.7/");
     }
-    return (strSubVer == "/PRCY:1.0.0.2/" || strSubVer == "/PRCY:1.0.0.3/" || strSubVer == "/PRCY:1.0.0.4/" || strSubVer == "/PRCY:1.0.0.5/");
+    return (strSubVer == "/PRCY:1.0.0.2/" || strSubVer == "/PRCY:1.0.0.3/" || strSubVer == "/PRCY:1.0.0.4/" || strSubVer == "/PRCY:1.0.0.5/" || strSubVer == "/PRCY:1.0.0.6/");
 }
 
 // find 'best' local address for a particular peer

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -126,7 +126,10 @@ unsigned short GetListenPort() {
 }
 
 bool IsUnsupportedVersion(std::string strSubVer, int nHeight) {
-    return (strSubVer == "/PRCY:1.0.0.2/" || strSubVer == "/PRCY:1.0.0.3/" || strSubVer == "/PRCY:1.0.0.4/" || strSubVer == "/PRCY:1.0.0.5/" || strSubVer == "/PRCY:1.0.0.6/");
+    if (nHeight >= Params().HardFork()) {
+        return (strSubVer == "/PRCY:1.0.0.2/" || strSubVer == "/PRCY:1.0.0.3/" || strSubVer == "/PRCY:1.0.0.4/" || strSubVer == "/PRCY:1.0.0.5/" || strSubVer == "/PRCY:1.0.0.6/");
+    }
+    return (strSubVer == "/PRCY:1.0.0.2/" || strSubVer == "/PRCY:1.0.0.3/" || strSubVer == "/PRCY:1.0.0.4/" || strSubVer == "/PRCY:1.0.0.5/");
 }
 
 // find 'best' local address for a particular peer

--- a/src/poa.cpp
+++ b/src/poa.cpp
@@ -525,11 +525,17 @@ bool CheckPoABlockPaddingAmount(const CBlock& block, const CBlockIndex* pindex)
 // To determine them, check the last 1-5 audited blocks of the raw data of
 // the PoA block where the issue occurred. Compare to the real blocks/txids.
 bool IsFixedAudit(std::string txid, int nHeight) {
-    // Correct TXIDs for Block 17152, Block 135946, Block 311330 and Block 311331
-    return (txid == "9965850037f14dcb4abf1168016e9f96f53692322714e7fac92a2b8838544135" || txid == "dd3d1dccf8f39a220e3a83cfabaf1b567b6696af877073ec580d09af6198f098" || txid =="e8aafd0513a8b2da536d55d9efd788956d03c6a0baa8acc4251f8dc0f3f03e87" || txid == "2666169b99521f12b6c69454f66e23af465c63e4a4807a5a8ed45467846ebe93");
+    if (nHeight >= Params().HardFork()) {
+        // Correct TXIDs for Block 17152, Block 135946, Block 311330 and Block 311331
+        return (txid == "9965850037f14dcb4abf1168016e9f96f53692322714e7fac92a2b8838544135" || txid == "dd3d1dccf8f39a220e3a83cfabaf1b567b6696af877073ec580d09af6198f098" || txid =="e8aafd0513a8b2da536d55d9efd788956d03c6a0baa8acc4251f8dc0f3f03e87" || txid == "2666169b99521f12b6c69454f66e23af465c63e4a4807a5a8ed45467846ebe93");
+    }
+    return (txid == "9965850037f14dcb4abf1168016e9f96f53692322714e7fac92a2b8838544135" || txid == "dd3d1dccf8f39a220e3a83cfabaf1b567b6696af877073ec580d09af6198f098");
 }
 
 bool IsWrongAudit(std::string txid, int nHeight) {
-    // Orphan TXIDs for Block 135946, Block 311330 and Block 311331
-    return (txid == "ef99f7882a681a075ebd51fa83be01685257ca66ccb736950fefc037f00e1538" || txid == "6514be1fad4d956a059924d5185a6f9db20a62f2f99e3e9b79257d6d3ca36065" || txid == "fd5a19a7a7df25774a6a030295f01bae6395be4229ebe2caf4974d536432e0dd");
+    if (nHeight >= Params().HardFork()) {
+        // Orphan TXIDs for Block 135946, Block 311330 and Block 311331
+        return (txid == "ef99f7882a681a075ebd51fa83be01685257ca66ccb736950fefc037f00e1538" || txid == "6514be1fad4d956a059924d5185a6f9db20a62f2f99e3e9b79257d6d3ca36065" || txid == "fd5a19a7a7df25774a6a030295f01bae6395be4229ebe2caf4974d536432e0dd");
+    }
+    return (txid == "ef99f7882a681a075ebd51fa83be01685257ca66ccb736950fefc037f00e1538");
 }

--- a/src/poa.cpp
+++ b/src/poa.cpp
@@ -525,17 +525,13 @@ bool CheckPoABlockPaddingAmount(const CBlock& block, const CBlockIndex* pindex)
 // To determine them, check the last 1-5 audited blocks of the raw data of
 // the PoA block where the issue occurred. Compare to the real blocks/txids.
 bool IsFixedAudit(std::string txid, int nHeight) {
-    if (nHeight >= Params().HardFork()) {
-        // Correct TXIDs for Block 17152, Block 135946, Block 311330 and Block 311331
-        return (txid == "9965850037f14dcb4abf1168016e9f96f53692322714e7fac92a2b8838544135" || txid == "dd3d1dccf8f39a220e3a83cfabaf1b567b6696af877073ec580d09af6198f098" || txid =="e8aafd0513a8b2da536d55d9efd788956d03c6a0baa8acc4251f8dc0f3f03e87" || txid == "2666169b99521f12b6c69454f66e23af465c63e4a4807a5a8ed45467846ebe93");
-    }
-    return (txid == "9965850037f14dcb4abf1168016e9f96f53692322714e7fac92a2b8838544135" || txid == "dd3d1dccf8f39a220e3a83cfabaf1b567b6696af877073ec580d09af6198f098");
+    LogPrint("poa", "%s: block %d passed in as nHeight\n", __func__, nHeight);
+    // Correct TXIDs for Block 17152, Block 135946, Block 311330 and Block 311331
+    return (txid == "9965850037f14dcb4abf1168016e9f96f53692322714e7fac92a2b8838544135" || txid == "dd3d1dccf8f39a220e3a83cfabaf1b567b6696af877073ec580d09af6198f098" || txid =="e8aafd0513a8b2da536d55d9efd788956d03c6a0baa8acc4251f8dc0f3f03e87" || txid == "2666169b99521f12b6c69454f66e23af465c63e4a4807a5a8ed45467846ebe93");
 }
 
 bool IsWrongAudit(std::string txid, int nHeight) {
-    if (nHeight >= Params().HardFork()) {
-        // Orphan TXIDs for Block 135946, Block 311330 and Block 311331
-        return (txid == "ef99f7882a681a075ebd51fa83be01685257ca66ccb736950fefc037f00e1538" || txid == "6514be1fad4d956a059924d5185a6f9db20a62f2f99e3e9b79257d6d3ca36065" || txid == "fd5a19a7a7df25774a6a030295f01bae6395be4229ebe2caf4974d536432e0dd");
-    }
-    return (txid == "ef99f7882a681a075ebd51fa83be01685257ca66ccb736950fefc037f00e1538");
+    LogPrint("poa", "%s: block %d passed in as nHeight\n", __func__, nHeight);
+    // Orphan TXIDs for Block 135946, Block 311330 and Block 311331
+    return (txid == "ef99f7882a681a075ebd51fa83be01685257ca66ccb736950fefc037f00e1538" || txid == "6514be1fad4d956a059924d5185a6f9db20a62f2f99e3e9b79257d6d3ca36065" || txid == "fd5a19a7a7df25774a6a030295f01bae6395be4229ebe2caf4974d536432e0dd");
 }

--- a/src/poa.cpp
+++ b/src/poa.cpp
@@ -192,8 +192,8 @@ bool CheckPoAContainRecentHash(const CBlock& block)
     }
     //Find the previous PoA block
     CBlockIndex* pindex = currentTip;
+    nHeight = pindex->nHeight;
     while (pindex->nHeight >= Params().START_POA_BLOCK()) {
-        nHeight = pindex->nHeight;
         if (pindex->GetBlockHeader().IsPoABlockByVersion()) {
             break;
         }


### PR DESCRIPTION
- Fix height in CheckPoAContainRecentHash
- Change Hard Fork block to 365000
- Restore checks for Hard Fork
- Ban v1.0.0.7 after Hard Fork
- Add "poa" logs for IsFixedAudit/IsWrongAudit `LogPrint("poa", "%s: block %d passed in as nHeight\n", __func__, nHeight);`