### PR TITLE
[Hard Fork] Change Hard Fork block to 370000

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -137,7 +137,7 @@ public:
         nPoAFixTime = 1616716800; // Fork time for PoA fix - Friday, March 26, 2021 12:00:00 AM (GMT)
         nPoAPaddingBlock = 169869; // Last block with 120 PoS blocks in a PoA Audit
         nPoAPadding = 10; // Current PoA Padding
-        nHardForkBlock = 365000; // Add hard fork block for Consensus/PoA Padding
+        nHardForkBlock = 370000; // Add hard fork block for Consensus/PoA Padding
 
         /**
          * Build the genesis block. Note that the output of the genesis coinbase cannot


### PR DESCRIPTION
To allow more time for exchanges/hosts to update, we will move the Hard Fork block to 370,000