### PR TITLE
[Hard Fork] Change Hard Fork block to 375000

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -137,7 +137,7 @@ public:
         nPoAFixTime = 1616716800; // Fork time for PoA fix - Friday, March 26, 2021 12:00:00 AM (GMT)
         nPoAPaddingBlock = 169869; // Last block with 120 PoS blocks in a PoA Audit
         nPoAPadding = 10; // Current PoA Padding
-        nHardForkBlock = 370000; // Add hard fork block for Consensus/PoA Padding
+        nHardForkBlock = 375000; // Add hard fork block for Consensus/PoA Padding
 
         /**
          * Build the genesis block. Note that the output of the genesis coinbase cannot


### PR DESCRIPTION
With the addition of a few Consensus changes, we have had to move the Hard Fork block from 370k to 375k to give Exchanges, partners, and users at least 10k blocks to update from release.