### PR TITLE
[Upstream] [Build] Remove unnecessary BOOST dependency

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5673,11 +5673,10 @@ bool CMerkleTx::IsTransactionLockTimedOut() const
 
 std::string CWallet::GetUniqueWalletBackupName() const
 {
-    boost::posix_time::ptime timeLocal = boost::posix_time::second_clock::local_time();
     std::stringstream ssDateTime;
+    std::string strWalletBackupName = strprintf("%s", DateTimeStrFormat(".%Y-%m-%d-%H-%M", GetTime()));
+    ssDateTime << strWalletBackupName;
 
-
-    ssDateTime << boost::gregorian::to_iso_extended_string(timeLocal.date()) << "-" << timeLocal.time_of_day();
     return strprintf("wallet%s.dat%s", "", DateTimeStrFormat(".%Y-%m-%d-%H-%M", GetTime()));
 }
 


### PR DESCRIPTION
> When build with `--enable-debug` the linker complains about a missing `boost::gregorian` dependency which is not really needed.
> 
> This PR removes this dependency, because, as we all know, with each BOOST-dependency somewhere a Unicorn dies...
> 
> It also addresses #601
> Thanks and kudos to @FornaxA for finding the problem!

from https://github.com/PIVX-Project/PIVX/pull/605