### PR TITLE
[Upstream] [GUI][Backport] Explicitly disable "Dark Mode" appearance on macOS

### DIFF
--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -100,6 +100,9 @@
   <key>LSAppNapIsDisabled</key>
     <string>True</string>
 
+  <key>NSRequiresAquaSystemAppearance</key>
+    <string>True</string>
+
   <key>LSApplicationCategoryType</key>
     <string>public.app-category.finance</string>
 </dict>


### PR DESCRIPTION
> Straightforward change, preventing any macOS dark mode theme forced change.
> Coming from btc [cf2f430](https://github.com/PIVX-Project/PIVX/commit/cf2f4306fe26305b24bba8833af845ada3a42ec8)

from https://github.com/PIVX-Project/PIVX/pull/1122