### PR TITLE
[Upstream] [RPC] Don't allow backupwallet to overwrite the wallet-in-use

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1145,6 +1145,10 @@ bool AttemptBackupWallet(const CWallet& wallet, const fs::path& pathSrc, const f
 {
     bool retStatus;
     try {
+        if (fs::equivalent(pathSrc, pathDest)) {
+            LogPrintf("cannot backup to wallet source file %s\n", pathDest.string());
+            return false;
+        }
 #if BOOST_VERSION >= 105800 /* BOOST_LIB_VERSION 1_58 */
         fs::copy_file(pathSrc, pathDest, fs::copy_option::overwrite_if_exists);
 #else


### PR DESCRIPTION
> Prevent file access collisions and possible file corruption by refusing
> to overwrite the current wallet in use.
> 
> On the off chance that a user attempts to use `backupwallet` in a way that the destination is the same as the source, an error will be returned instead of an attempted backup.

from https://github.com/PIVX-Project/PIVX/pull/711