### PR TITLE
[Upstream] [GUI] MacOS fix open files with no default app.

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -364,25 +364,27 @@ void bringToFront(QWidget* w)
     }
 }
 
-void openDebugLogfile()
+bool openDebugLogfile()
 {
     fs::path pathDebug = GetDataDir() / "debug.log";
 
     /* Open debug.log with the associated application */
     if (fs::exists(pathDebug))
-        QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(pathDebug)));
+        return QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(pathDebug)));
+    return false;
 }
 
-void openConfigfile()
+bool openConfigfile()
 {
     fs::path pathConfig = GetConfigFile();
 
     /* Open prcycoin.conf with the associated application */
     if (fs::exists(pathConfig))
-        QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(pathConfig)));
+        return QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(pathConfig)));
+    return false;
 }
 
-void openMNConfigfile()
+bool openMNConfigfile()
 {
     fs::path pathConfig = GetMasternodeConfigFile();
 
@@ -391,13 +393,14 @@ void openMNConfigfile()
         QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(pathConfig)));
 }
 
-void showDataDir()
+bool showDataDir()
 {
-    fs::path pathBackups = GetDataDir();
+    fs::path pathDataDir = GetDataDir();
 
     /* Open folder with default browser */
-    if (fs::exists(pathBackups))
-        QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(pathBackups)));
+    if (fs::exists(pathDataDir))
+        return QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(pathDataDir)));
+    return false;
 }
 
 void showQtDir()
@@ -406,13 +409,14 @@ void showQtDir()
     QDesktopServices::openUrl(QUrl(pathQt, QUrl::TolerantMode));
 }
 
-void showBackups()
+bool showBackups()
 {
     fs::path pathBackups = GetDataDir() / "backups";
 
     /* Open folder with default browser */
     if (fs::exists(pathBackups))
-        QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(pathBackups)));
+        return QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(pathBackups)));
+    return false;
 }
 
 void SubstituteFonts(const QString& language)

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -116,22 +116,22 @@ void bringToFront(QWidget* w);
 bool isObscured(QWidget* w);
 
 // Open debug.log
-void openDebugLogfile();
+bool openDebugLogfile();
 
 // Open prcycoin.conf
-void openConfigfile();
+bool openConfigfile();
 
 // Open masternode.conf
-void openMNConfigfile();
+bool openMNConfigfile();
 
 // Browse DataDir folder
-void showDataDir();
+bool showDataDir();
 
 // Browse Qt Dir folder
 void showQtDir();
 
 // Browse backup folder
-void showBackups();
+bool showBackups();
 
 // Replace invalid default fonts with known good ones
 void SubstituteFonts(const QString& language);


### PR DESCRIPTION
> Built on top of #1515, only last commit counts for this.
> 
> When MacOS has no default app to open *.conf and *.log throws an error instead of try to open them with a text editor. This PR solves the issue.
> 
> Coming from btc@[16044](https://github.com/bitcoin/bitcoin/pull/16044)

First commit is a cherry pick of https://github.com/PIVX-Project/PIVX/commit/680d2ddda15e0251d2b54e12c169595fce29d1c2 to match the conversion from void to bool

from https://github.com/PIVX-Project/PIVX/pull/1516