### PR TITLE
[Upstream] [Core] Add -debugexclude option

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -491,6 +491,7 @@ std::string HelpMessage(HelpMessageMode mode)
     }
     strUsage += HelpMessageOpt("-debug=<category>", strprintf(_("Output debugging information (default: %u, supplying <category> is optional)"), 0) + ". " +
         _("If <category> is not supplied, output all debugging information.") + _("<category> can be:") + " " + ListLogCategories() + ".");
+    strUsage += HelpMessageOpt("-debugexclude=<category>", _("Exclude debugging information for a category. Can be used in conjunction with -debug=1 to output debug logs for all categories except one or more specified categories."));
     if (GetBoolArg("-help-debug", false))
         strUsage += HelpMessageOpt("-nodebug", "Turn off debugging messages, same as -debug=0");
 #ifdef ENABLE_WALLET
@@ -938,10 +939,22 @@ bool AppInit2(bool isDaemon)
             find(categories.begin(), categories.end(), std::string("0")) != categories.end())) {
         for (const auto& cat : categories) {
             uint32_t flag;
-            if (!GetLogCategory(&flag, &cat)) {
-                InitWarning(strprintf(_("Unsupported logging category %s.\n"), cat));
-            }
-            logCategories |= flag;
+            if (!GetLogCategory(&flag, &cat))
+                InitWarning(strprintf(_("Unsupported logging category %s=%s."), "-debug", cat));
+            else
+                logCategories |= flag;
+        }
+    }
+
+    // Now remove the logging categories which were explicitly excluded
+    if (mapMultiArgs.count("-debugexclude") > 0) {
+        const std::vector<std::string>& excludedCategories = mapMultiArgs.at("-debugexclude");
+        for (const auto& cat : excludedCategories) {
+            uint32_t flag;
+            if (!GetLogCategory(&flag, &cat))
+                InitWarning(strprintf(_("Unsupported logging category %s=%s."), "-debugexclude", cat));
+            else
+                logCategories &= ~flag;
         }
     }
 


### PR DESCRIPTION
> Implemented on top of:
> 
> * [x]  [[Util] tinyformat / LogPrint backports #1449](https://github.com/PIVX-Project/PIVX/pull/1449)
> * [x]  [[Util] LogAcceptCategory: use uint32_t rather than sets of strings #1437](https://github.com/PIVX-Project/PIVX/pull/1437)
> 
> Backports [bitcoin#10123](https://github.com/bitcoin/bitcoin/pull/10123)
> 
> > setting `-debug` can lead to very noisy debug.logs with subcomponents filling up the log file. See for example https://travis-ci.org/bitcoin/bitcoin/jobs/216767286 where there are hundreds of libevent debug logs.
> 
> This commit adds an option to exclude certain components from debug logging. The usage is:
> 
> ```
> pivxd -debug -debugexclude=<component1> -debugexclude=<component2> ...
> ```
> 
> This finally reduces spammy logs in the functional tests debug, due to libevent and leveldb ([bitcoin#10124](https://github.com/bitcoin/bitcoin/pull/10124) was already included backporting the test suite).

from https://github.com/PIVX-Project/PIVX/pull/1439