### PR TITLE
[Upstream] [Init] Add -debuglogfile option

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -390,14 +390,13 @@ bool InitHTTPServer()
 
     // Redirect libevent's logging to our own log
     event_set_log_callback(&libevent_log_cb);
-#if LIBEVENT_VERSION_NUMBER >= 0x02010100
-    // If -debug=libevent, set full libevent debugging.
-    // Otherwise, disable all libevent debugging.
-    if (LogAcceptCategory(BCLog::LIBEVENT))
-        event_enable_debug_logging(EVENT_DBG_ALL);
-    else
-        event_enable_debug_logging(EVENT_DBG_NONE);
-#endif
+    // Update libevent's log handling. Returns false if our version of
+    // libevent doesn't support debug logging, in which case we should
+    // clear the BCLog::LIBEVENT flag.
+    if (!UpdateHTTPServerLogging(logCategories & BCLog::LIBEVENT)) {
+        logCategories &= ~BCLog::LIBEVENT;
+    }
+
 #ifdef WIN32
     evthread_use_windows_threads();
 #else
@@ -438,6 +437,20 @@ bool InitHTTPServer()
     eventBase = base;
     eventHTTP = http;
     return true;
+}
+
+bool UpdateHTTPServerLogging(bool enable) {
+#if LIBEVENT_VERSION_NUMBER >= 0x02010100
+    if (enable) {
+        event_enable_debug_logging(EVENT_DBG_ALL);
+    } else {
+        event_enable_debug_logging(EVENT_DBG_NONE);
+    }
+    return true;
+#else
+    // Can't update libevent logging if version < 02010100
+    return false;
+#endif
 }
 
 std::thread threadHTTP;

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -32,6 +32,10 @@ void InterruptHTTPServer();
 /** Stop HTTP server */
 void StopHTTPServer();
 
+/** Change logging level for libevent. Removes BCLog::LIBEVENT from logCategories if
+ * libevent doesn't support debug logging.*/
+bool UpdateHTTPServerLogging(bool enable);
+
 /** Handler for requests to a certain HTTP path */
 typedef std::function<void(HTTPRequest* req, const std::string &)> HTTPRequestHandler;
 /** Register handler for prefix.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -381,6 +381,7 @@ std::string HelpMessage(HelpMessageMode mode)
 #endif
     }
     strUsage += HelpMessageOpt("-datadir=<dir>", _("Specify data directory"));
+    strUsage += HelpMessageOpt("-debuglogfile=<file>", strprintf(_("Specify location of debug log file: this can be an absolute path or a path relative to the data directory (default: %s)"), DEFAULT_DEBUGLOGFILE));
     strUsage += HelpMessageOpt("-backuppath=<(dir/file)>", _("Specify custom backup path to add a copy of any wallet backup. If set as dir, every backup generates a timestamped file. If set as file, will rewrite to that file every backup."));
     strUsage += HelpMessageOpt("-dbcache=<n>", strprintf(_("Set database cache size in megabytes (%d to %d, default: %d)"), nMinDbCache, nMaxDbCache, nDefaultDbCache));
     strUsage += HelpMessageOpt("-loadblock=<file>", _("Imports blocks from external blk000??.dat file") + " " + _("on startup"));
@@ -1092,7 +1093,9 @@ bool AppInit2(bool isDaemon)
 #endif
     if (GetBoolArg("-shrinkdebugfile", logCategories != BCLog::NONE))
         ShrinkDebugFile();
-
+    if (fPrintToDebugLog && !OpenDebugLog()) {
+        return InitError(strprintf("Could not open debug log file %s", GetDebugLogPath().string()));
+    }
     LogPrintf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));
 #ifdef ENABLE_WALLET
     LogPrintf("Using BerkeleyDB version %s\n", DbEnv::version(0, 0, 0));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -897,8 +897,8 @@ void InitLogging()
     fLogTimestamps = GetBoolArg("-logtimestamps", true);
     fLogIPs = GetBoolArg("-logips", false);
 
-    LogPrintf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
-    LogPrintf("PRCY version %s (%s)\n", FormatFullVersion(), CLIENT_DATE);
+    if (fPrintToDebugLog)
+        OpenDebugLog();
 }
 
 /** Initialize prcy.

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -92,6 +92,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
         {"listunspent", 0},
         {"listunspent", 1},
         {"listunspent", 2},
+        {"logging", 0},
+        {"logging", 1},
         {"getblock", 1},
         {"getblockheader", 1},
         {"gettransaction", 1},

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -486,6 +486,58 @@ UniValue setmocktime(const UniValue& params, bool fHelp) {
     return NullUniValue;
 }
 
+uint32_t getCategoryMask(UniValue cats) {
+    cats = cats.get_array();
+    uint32_t mask = 0;
+    for (unsigned int i = 0; i < cats.size(); ++i) {
+        uint32_t flag = 0;
+        std::string cat = cats[i].get_str();
+        if (!GetLogCategory(&flag, &cat)) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "unknown logging category " + cat);
+        }
+        mask |= flag;
+    }
+    return mask;
+}
+
+UniValue logging(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() > 2) {
+        throw std::runtime_error(
+            "logging [include,...] <exclude>\n"
+            "Gets and sets the logging configuration.\n"
+            "When called without an argument, returns the list of categories that are currently being debug logged.\n"
+            "When called with arguments, adds or removes categories from debug logging.\n"
+            "The valid logging categories are: " + ListLogCategories() + "\n"
+            "libevent logging is configured on startup and cannot be modified by this RPC during runtime."
+            "Arguments:\n"
+            "1. \"include\" (array of strings) add debug logging for these categories.\n"
+            "2. \"exclude\" (array of strings) remove debug logging for these categories.\n"
+            "\nResult: <categories>  (string): a list of the logging categories that are active.\n"
+            "\nExamples:\n"
+            + HelpExampleCli("logging", "\"[\\\"all\\\"]\" \"[\\\"http\\\"]\"")
+            + HelpExampleRpc("logging", "[\"all\"], \"[libevent]\"")
+        );
+    }
+
+    if (params.size() > 0 && params[0].isArray()) {
+        logCategories |= getCategoryMask(params[0]);
+    }
+
+    if (params.size() > 1 && params[1].isArray()) {
+        logCategories &= ~getCategoryMask(params[1]);
+    }
+
+
+    UniValue result(UniValue::VOBJ);
+    std::vector<CLogCategoryActive> vLogCatActive = ListActiveLogCategories();
+    for (const auto& logCatActive : vLogCatActive) {
+        result.pushKV(logCatActive.category, logCatActive.active);
+    }
+
+    return result;
+}
+
 #ifdef ENABLE_WALLET
 UniValue getstakingstatus(const UniValue& params, bool fHelp)
 {

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -8,6 +8,7 @@
 
 #include "base58.h"
 #include "clientversion.h"
+#include "httpserver.h"
 #include "init.h"
 #include "main.h"
 #include "masternode-sync.h"
@@ -520,6 +521,7 @@ UniValue logging(const UniValue& params, bool fHelp)
         );
     }
 
+    uint32_t originalLogCategories = logCategories;
     if (params.size() > 0 && params[0].isArray()) {
         logCategories |= getCategoryMask(params[0]);
     }
@@ -528,6 +530,20 @@ UniValue logging(const UniValue& params, bool fHelp)
         logCategories &= ~getCategoryMask(params[1]);
     }
 
+    // Update libevent logging if BCLog::LIBEVENT has changed.
+    // If the library version doesn't allow it, UpdateHTTPServerLogging() returns false,
+    // in which case we should clear the BCLog::LIBEVENT flag.
+    // Throw an error if the user has explicitly asked to change only the libevent
+    // flag and it failed.
+    uint32_t changedLogCategories = originalLogCategories ^ logCategories;
+    if (changedLogCategories & BCLog::LIBEVENT) {
+        if (!UpdateHTTPServerLogging(logCategories & BCLog::LIBEVENT)) {
+            logCategories &= ~BCLog::LIBEVENT;
+            if (changedLogCategories == BCLog::LIBEVENT) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "libevent logging cannot be updated when using libevent before v2.1.1.");
+            }
+        }
+    }
 
     UniValue result(UniValue::VOBJ);
     std::vector<CLogCategoryActive> vLogCatActive = ListActiveLogCategories();

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -338,6 +338,7 @@ static const CRPCCommand vRPCCommands[] =
         {"rawtransactions", "getrawtransactionbyblockheight", &getrawtransactionbyblockheight, true, false, false},
         /* Utility functions */
         //{"util", "createmultisig", &createmultisig, true, true, false},
+        {"util", "logging", &logging, true, false, false},
         // {"util", "validateaddress", &validateaddress, true, false, false}, /* uses wallet if enabled */
         // {"util", "verifymessage", &verifymessage, true, false, false},
         //{"util", "estimatefee", &estimatefee, true, true, false},

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -344,6 +344,7 @@ extern UniValue mnfinalbudget(const UniValue& params, bool fHelp);
 extern UniValue checkbudgets(const UniValue& params, bool fHelp);
 
 extern UniValue getinfo(const UniValue& params, bool fHelp); // in rpcmisc.cpp
+extern UniValue logging(const UniValue& params, bool fHelp);
 extern UniValue getversion(const UniValue& params, bool fHelp); // in rpcmisc.cpp
 extern UniValue mnsync(const UniValue& params, bool fHelp);
 extern UniValue validateaddress(const UniValue& params, bool fHelp);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -129,7 +129,7 @@ bool fLogTimestamps = false;
 bool fLogIPs = false;
 volatile bool fReopenDebugLog = false;
 
-/** Log categories bitfield. Leveldb/libevent need special handling if their flags are changed at runtime. */
+/** Log categories bitfield. libevent needs special handling if their flags are changed at runtime. */
 std::atomic<uint32_t> logCategories(0);
 
 /** Init OpenSSL library multithreading support */
@@ -334,6 +334,21 @@ static std::string LogTimestampStr(const std::string &str, bool *fStartedNewLine
         *fStartedNewLine = false;
 
     return strStamped;
+}
+
+std::vector<CLogCategoryActive> ListActiveLogCategories()
+{
+    std::vector<CLogCategoryActive> ret;
+    for (unsigned int i = 0; i < ARRAYLEN(LogCategories); i++) {
+        // Omit the special cases.
+        if (LogCategories[i].flag != BCLog::NONE && LogCategories[i].flag != BCLog::ALL) {
+            CLogCategoryActive catActive;
+            catActive.category = LogCategories[i].category;
+            catActive.active = LogAcceptCategory(LogCategories[i].flag);
+            ret.push_back(catActive);
+        }
+    }
+    return ret;
 }
 
 std::string FilterInjection(const std::string& str) 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -129,7 +129,7 @@ bool fLogTimestamps = false;
 bool fLogIPs = false;
 volatile bool fReopenDebugLog = false;
 
-/** Log categories bitfield. libevent needs special handling if their flags are changed at runtime. */
+/** Log categories bitfield. */
 std::atomic<uint32_t> logCategories(0);
 
 /** Init OpenSSL library multithreading support */

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -195,22 +195,50 @@ public:
 
 static boost::once_flag debugPrintInitFlag = BOOST_ONCE_INIT;
 /**
- * We use boost::call_once() to make sure these are initialized
- * in a thread-safe manner the first time called:
+ * We use boost::call_once() to make sure mutexDebugLog and
+ * vMsgsBeforeOpenLog are initialized in a thread-safe manner.
+ *
+ * NOTE: fileout, mutexDebugLog and sometimes vMsgsBeforeOpenLog
+ * are leaked on exit. This is ugly, but will be cleaned up by
+ * the OS/libc. When the shutdown sequence is fully audited and
+ * tested, explicit destruction of these objects can be implemented.
  */
-static FILE* fileout = NULL;
-static boost::mutex* mutexDebugLog = NULL;
+static FILE* fileout = nullptr;
+static boost::mutex* mutexDebugLog = nullptr;
+
+static std::list<std::string> *vMsgsBeforeOpenLog;
+
+static int FileWriteStr(const std::string &str, FILE *fp)
+{
+    return fwrite(str.data(), 1, str.size(), fp);
+}
 
 static void DebugPrintInit()
 {
-    assert(fileout == NULL);
-    assert(mutexDebugLog == NULL);
+    assert(mutexDebugLog == nullptr);
+    mutexDebugLog = new boost::mutex();
+    vMsgsBeforeOpenLog = new std::list<std::string>;
+}
+
+void OpenDebugLog()
+{
+    boost::call_once(&DebugPrintInit, debugPrintInitFlag);
+    boost::mutex::scoped_lock scoped_lock(*mutexDebugLog);
+    assert(fileout == nullptr);
+    assert(vMsgsBeforeOpenLog);
 
     fs::path pathDebug = GetDataDir() / "debug.log";
     fileout = fsbridge::fopen(pathDebug, "a");
-    if (fileout) setbuf(fileout, NULL); // unbuffered
+    if (fileout) setbuf(fileout, nullptr); // unbuffered
 
-    mutexDebugLog = new boost::mutex();
+    // dump buffered messages from before we opened the log
+    while (!vMsgsBeforeOpenLog->empty()) {
+        FileWriteStr(vMsgsBeforeOpenLog->front(), fileout);
+        vMsgsBeforeOpenLog->pop_front();
+    }
+
+    delete vMsgsBeforeOpenLog;
+    vMsgsBeforeOpenLog = nullptr;
 }
 
 struct CLogCategoryDesc
@@ -283,6 +311,31 @@ std::string ListLogCategories()
     return ret;
 }
 
+/**
+ * fStartedNewLine is a state variable held by the calling context that will
+ * suppress printing of the timestamp when multiple calls are made that don't
+ * end in a newline. Initialize it to true, and hold it, in the calling context.
+ */
+static std::string LogTimestampStr(const std::string &str, bool *fStartedNewLine)
+{
+    std::string strStamped;
+
+    if (!fLogTimestamps)
+        return str;
+
+    if (*fStartedNewLine)
+        strStamped =  DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()) + ' ' + str;
+    else
+        strStamped = str;
+
+    if (!str.empty() && str[str.size()-1] == '\n')
+        *fStartedNewLine = true;
+    else
+        *fStartedNewLine = false;
+
+    return strStamped;
+}
+
 std::string FilterInjection(const std::string& str) 
 {
     //std::cout << "filtering" << std::endl;
@@ -311,36 +364,34 @@ int LogPrintStr(const std::string& str)
 {
     std::string filteredStr = FilterInjection(str);
     int ret = 0; // Returns total number of characters written
+    static bool fStartedNewLine = true;
     if (fPrintToConsole) {
         // print to console
         ret = fwrite(filteredStr.data(), 1, filteredStr.size(), stdout);
         fflush(stdout);
-    } else if (fPrintToDebugLog && AreBaseParamsConfigured()) {
-        static bool fStartedNewLine = true;
+    } else if (fPrintToDebugLog) {
         boost::call_once(&DebugPrintInit, debugPrintInitFlag);
-
-        if (fileout == NULL)
-            return ret;
-
         boost::mutex::scoped_lock scoped_lock(*mutexDebugLog);
 
-        // reopen the log file, if requested
-        if (fReopenDebugLog) {
-            fReopenDebugLog = false;
-            fs::path pathDebug = GetDataDir() / "debug.log";
-            if (freopen(pathDebug.string().c_str(), "a", fileout) != NULL)
-                setbuf(fileout, NULL); // unbuffered
+        std::string strTimestamped = LogTimestampStr(str, &fStartedNewLine);
+
+        // buffer if we haven't opened the log yet
+        if (fileout == NULL) {
+            assert(vMsgsBeforeOpenLog);
+            ret = strTimestamped.length();
+            vMsgsBeforeOpenLog->push_back(strTimestamped);
+
+        } else {
+            // reopen the log file, if requested
+            if (fReopenDebugLog) {
+                fReopenDebugLog = false;
+                boost::filesystem::path pathDebug = GetDataDir() / "debug.log";
+                if (freopen(pathDebug.string().c_str(),"a",fileout) != NULL)
+                    setbuf(fileout, NULL); // unbuffered
+            }
+
+            ret = FileWriteStr(strTimestamped, fileout);
         }
-
-        // Debug print useful for profiling
-        if (fLogTimestamps && fStartedNewLine)
-            ret += fprintf(fileout, "%s ", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
-        if (!filteredStr.empty() && filteredStr[filteredStr.size() - 1] == '\n')
-            fStartedNewLine = true;
-        else
-            fStartedNewLine = false;
-
-        ret = fwrite(filteredStr.data(), 1, filteredStr.size(), fileout);
     }
 
     return ret;

--- a/src/util.h
+++ b/src/util.h
@@ -58,6 +58,12 @@ extern volatile bool fReopenDebugLog;
 void SetupEnvironment();
 bool SetupNetworking();
 
+struct CLogCategoryActive
+{
+    std::string category;
+    bool active;
+};
+
 namespace BCLog {
     enum LogFlags : uint32_t {
         NONE        = 0,
@@ -97,8 +103,10 @@ static inline bool LogAcceptCategory(uint32_t category)
     return (logCategories.load(std::memory_order_relaxed) & category) != 0;
 }
 
-/** Returns a string with the supported log categories */
+/** Returns a string with the log categories. */
 std::string ListLogCategories();
+/** Returns a vector of the active log categories. */
+std::vector<CLogCategoryActive> ListActiveLogCategories();
 /** Return true if str parses as a log category and set the flags in f */
 bool GetLogCategory(uint32_t *f, const std::string *str);
 /** Send a string to the log output */

--- a/src/util.h
+++ b/src/util.h
@@ -33,6 +33,8 @@
 #include <boost/thread/exceptions.hpp>
 #include "pubkey.h"
 
+extern const char * const DEFAULT_DEBUGLOGFILE;
+
 //PRCY only features
 
 extern bool fMasterNode;
@@ -160,7 +162,8 @@ void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet, std::map
 fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
 fs::path GetTempPath();
-void OpenDebugLog();
+fs::path GetDebugLogPath();
+bool OpenDebugLog();
 void ShrinkDebugFile();
 void runCommand(std::string strCommand);
 

--- a/src/util.h
+++ b/src/util.h
@@ -152,6 +152,7 @@ void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet, std::map
 fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
 fs::path GetTempPath();
+void OpenDebugLog();
 void ShrinkDebugFile();
 void runCommand(std::string strCommand);
 

--- a/test/functional/feature_logging.py
+++ b/test/functional/feature_logging.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Copyright (c) 20200 The PIVX Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test debug logging."""
+
+import os
+
+from test_framework.test_framework import PivxTestFramework
+
+class LoggingTest(PivxTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        # test default log file name
+        assert os.path.isfile(os.path.join(self.nodes[0].datadir, "regtest", "debug.log"))
+        self.log.info("Default filename ok")
+
+        # test alternative log file name in datadir
+        self.restart_node(0, ["-debuglogfile=foo.log"])
+        assert os.path.isfile(os.path.join(self.nodes[0].datadir, "regtest", "foo.log"))
+        self.log.info("Alternative filename ok")
+
+        # test alternative log file name outside datadir
+        tempname = os.path.join(self.options.tmpdir, "foo.log")
+        self.restart_node(0, ["-debuglogfile=%s" % tempname])
+        assert os.path.isfile(tempname)
+        self.log.info("Alternative filename outside datadir ok")
+
+        # check that invalid log (relative) will cause error
+        self.stop_node(0)
+        self.assert_start_raises_init_error(0, ["-debuglogfile=ssdksjdf/sdasdfa/sdfsdfsfd"],
+                                                "Error: Could not open debug log file")
+        self.log.info("Invalid relative filename throws")
+
+        # check that invalid log (absolute) will cause error
+        self.stop_node(0)
+        invalidname = os.path.join(self.options.tmpdir, "foo/foo.log")
+        self.assert_start_raises_init_error(0, ["-debuglogfile=%s" % invalidname],
+                                               "Error: Could not open debug log file")
+        self.log.info("Invalid absolute filename throws")
+
+
+if __name__ == '__main__':
+    LoggingTest().main()

--- a/test/functional/feature_logging.py
+++ b/test/functional/feature_logging.py
@@ -31,17 +31,34 @@ class LoggingTest(PivxTestFramework):
         self.log.info("Alternative filename outside datadir ok")
 
         # check that invalid log (relative) will cause error
+        invdir = os.path.join(self.nodes[0].datadir, "regtest", "foo")
+        invalidname = os.path.join("foo", "foo.log")
         self.stop_node(0)
-        self.assert_start_raises_init_error(0, ["-debuglogfile=ssdksjdf/sdasdfa/sdfsdfsfd"],
+        self.assert_start_raises_init_error(0, ["-debuglogfile=%s" % (invalidname)],
                                                 "Error: Could not open debug log file")
+        assert not os.path.isfile(os.path.join(invdir, "foo.log"))
         self.log.info("Invalid relative filename throws")
+
+        # check that a previously invalid log (relative) works after path exists
+        os.mkdir(invdir)
+        self.start_node(0, ["-debuglogfile=%s" % (invalidname)])
+        assert os.path.isfile(os.path.join(invdir, "foo.log"))
+        self.log.info("Relative filename ok when path exists")
 
         # check that invalid log (absolute) will cause error
         self.stop_node(0)
-        invalidname = os.path.join(self.options.tmpdir, "foo/foo.log")
+        invdir = os.path.join(self.options.tmpdir, "foo")
+        invalidname = os.path.join(invdir, "foo.log")
         self.assert_start_raises_init_error(0, ["-debuglogfile=%s" % invalidname],
                                                "Error: Could not open debug log file")
+        assert not os.path.isfile(os.path.join(invdir, "foo.log"))
         self.log.info("Invalid absolute filename throws")
+
+        # check that a previously invalid log (relative) works after path exists
+        os.mkdir(invdir)
+        self.start_node(0, ["-debuglogfile=%s" % (invalidname)])
+        assert os.path.isfile(os.path.join(invdir, "foo.log"))
+        self.log.info("Absolute filename ok when path exists")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
> Implemented on top of
> 
> * [x]  [[Util] tinyformat / LogPrint backports #1449](https://github.com/PIVX-Project/PIVX/pull/1449)
> * [x]  [[Util] LogAcceptCategory: use uint32_t rather than sets of strings #1437](https://github.com/PIVX-Project/PIVX/pull/1437)
> * [x]  [[Core] Add -debugexclude option #1439](https://github.com/PIVX-Project/PIVX/pull/1439)
> * [x]  [[Util] Buffer log messages and explicitly open logs #1450](https://github.com/PIVX-Project/PIVX/pull/1450)
> * [x]  [[RPC] Add logging RPC #1451](https://github.com/PIVX-Project/PIVX/pull/1451)
> 
> Only last 4 commits are relevant to this PR. Backports [bitcoin#11781](https://github.com/bitcoin/bitcoin/pull/11781)
> 
> > This patch adds an option to configure the name and/or directory of the debug log file.
> > The user can specify either a relative path, in which case the path is relative to the (network specific) data directory. They can also specify an absolute path to put the log anywhere else in the file system.
> 
> Functional test included.

from https://github.com/PIVX-Project/PIVX/pull/1455

Excludes:
- Doc updates commit, which will be in a separate commit.
- Tests added, but we currently do not have ` test/functional/test_runner.py` implemented yet.
