### PR TITLE
[Upstream] [Util] Refactor logging code into a global object

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -128,6 +128,7 @@ BITCOIN_CORE_H = \
   keystore.h \
   dbwrapper.h \
   limitedmap.h \
+  logging.h \
   main.h \
   masternode.h \
   masternode-payments.h \
@@ -375,6 +376,7 @@ libbitcoin_util_a_SOURCES = \
   compat/glibcxx_sanity.cpp \
   compat/strnlen.cpp \
   fs.cpp \
+  logging.cpp \
   random.cpp \
   rpc/protocol.cpp \
   support/cleanse.cpp \

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -20,7 +20,7 @@ void CActiveMasternode::ManageStatus()
 
     if (!fMasterNode) return;
 
-    if (logCategories != BCLog::NONE) LogPrint(BCLog::MASTERNODE, "CActiveMasternode::ManageStatus() - Begin\n");
+    LogPrint(BCLog::MASTERNODE, "CActiveMasternode::ManageStatus() - Begin\n");
 
     //need correct blocks to send ping
     if (Params().NetworkID() != CBaseChainParams::REGTEST && !masternodeSync.IsBlockchainSynced()) {

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -393,8 +393,8 @@ bool InitHTTPServer()
     // Update libevent's log handling. Returns false if our version of
     // libevent doesn't support debug logging, in which case we should
     // clear the BCLog::LIBEVENT flag.
-    if (!UpdateHTTPServerLogging(logCategories & BCLog::LIBEVENT)) {
-        logCategories &= ~BCLog::LIBEVENT;
+    if (!UpdateHTTPServerLogging(g_logger->WillLogCategory(BCLog::LIBEVENT))) {
+        g_logger->DisableCategory(BCLog::LIBEVENT);
     }
 
 #ifdef WIN32

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -32,7 +32,7 @@ void InterruptHTTPServer();
 /** Stop HTTP server */
 void StopHTTPServer();
 
-/** Change logging level for libevent. Removes BCLog::LIBEVENT from logCategories if
+/** Change logging level for libevent. Removes BCLog::LIBEVENT from log categories if
  * libevent doesn't support debug logging.*/
 bool UpdateHTTPServerLogging(bool enable);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1044,13 +1044,12 @@ bool AppInit2(bool isDaemon)
 #ifndef WIN32
     CreatePidFile(GetPidFile(), getpid());
 #endif
-    if (GetBoolArg("-shrinkdebugfile", logCategories != BCLog::NONE))
-        ShrinkDebugFile();
-    if (g_logger->fPrintToDebugLog && !OpenDebugLog()) {
-        return UIError(strprintf("Could not open debug log file %s", GetDebugLogPath().string()));
+    if (g_logger->fPrintToDebugLog) {
+        if (GetBoolArg("-shrinkdebugfile", logCategories != BCLog::NONE))
+            g_logger->ShrinkDebugFile();
+        if (!g_logger->OpenDebugLog())
+            return UIError(strprintf("Could not open debug log file %s", g_logger->GetDebugLogPath().string()));
     }
-    if (g_logger->fPrintToDebugLog)
-        OpenDebugLog();
     LogPrintf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));
 #ifdef ENABLE_WALLET
     LogPrintf("Using BerkeleyDB version %s\n", DbEnv::version(0, 0, 0));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -298,7 +298,7 @@ void HandleSIGTERM(int)
 
 void HandleSIGHUP(int)
 {
-    fReopenDebugLog = true;
+    g_logger->fReopenDebugLog = true;
 }
 
 #ifndef WIN32
@@ -877,12 +877,16 @@ static std::string ResolveErrMsg(const char * const optname, const std::string& 
 
 void InitLogging()
 {
-    fPrintToConsole = GetBoolArg("-printtoconsole", false);
-    fLogTimestamps = GetBoolArg("-logtimestamps", true);
-    fLogIPs = GetBoolArg("-logips", false);
+    g_logger->fPrintToConsole = GetBoolArg("-printtoconsole", !GetBoolArg("-daemon", false));
+    //g_logger->fPrintToDebugLog = !IsArgNegated("-debuglogfile");
+    g_logger->fPrintToDebugLog = true;
+    g_logger->fLogTimestamps = GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
+    g_logger->fLogTimeMicros = GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
 
-    if (fPrintToDebugLog)
-        OpenDebugLog();
+    fLogIPs = GetBoolArg("-logips", DEFAULT_LOGIPS);
+
+    LogPrintf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
+    LogPrintf("PRCY version %s (%s)\n", FormatFullVersion(), CLIENT_DATE);
 }
 
 /** Initialize prcy.
@@ -1042,14 +1046,16 @@ bool AppInit2(bool isDaemon)
 #endif
     if (GetBoolArg("-shrinkdebugfile", logCategories != BCLog::NONE))
         ShrinkDebugFile();
-    if (fPrintToDebugLog && !OpenDebugLog()) {
+    if (g_logger->fPrintToDebugLog && !OpenDebugLog()) {
         return UIError(strprintf("Could not open debug log file %s", GetDebugLogPath().string()));
     }
+    if (g_logger->fPrintToDebugLog)
+        OpenDebugLog();
     LogPrintf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));
 #ifdef ENABLE_WALLET
     LogPrintf("Using BerkeleyDB version %s\n", DbEnv::version(0, 0, 0));
 #endif
-    if (!fLogTimestamps)
+    if (!g_logger->fLogTimestamps)
         LogPrintf("Startup time: %s\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()));
     LogPrintf("Default data directory %s\n", GetDefaultDataDir().string());
     LogPrintf("Using data directory %s\n", strDataDir);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -926,11 +926,9 @@ bool AppInit2(bool isDaemon)
     if (!(GetBoolArg("-nodebug", false) ||
             find(categories.begin(), categories.end(), std::string("0")) != categories.end())) {
         for (const auto& cat : categories) {
-            uint32_t flag;
-            if (!GetLogCategory(&flag, &cat)) {
+            if (!g_logger->EnableCategory(cat)) {
                 UIWarning(strprintf(_("Unsupported logging category %s=%s."), "-debug", cat));
             }
-            g_logger->EnableCategory(static_cast<BCLog::LogFlags>(flag));
         }
     }
 
@@ -938,11 +936,9 @@ bool AppInit2(bool isDaemon)
     if (mapMultiArgs.count("-debugexclude") > 0) {
         const std::vector<std::string>& excludedCategories = mapMultiArgs.at("-debugexclude");
         for (const auto& cat : excludedCategories) {
-            uint32_t flag;
-            if (!GetLogCategory(&flag, &cat)) {
+            if (!g_logger->DisableCategory(cat)) {
                 UIWarning(strprintf(_("Unsupported logging category %s=%s."), "-debugexclude", cat));
             }
-            g_logger->DisableCategory(static_cast<BCLog::LogFlags>(flag));
         }
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -298,7 +298,7 @@ void HandleSIGTERM(int)
 
 void HandleSIGHUP(int)
 {
-    g_logger->fReopenDebugLog = true;
+    g_logger->m_reopen_file = true;
 }
 
 #ifndef WIN32
@@ -877,11 +877,11 @@ static std::string ResolveErrMsg(const char * const optname, const std::string& 
 
 void InitLogging()
 {
-    g_logger->fPrintToConsole = GetBoolArg("-printtoconsole", !GetBoolArg("-daemon", false));
-    //g_logger->fPrintToDebugLog = !IsArgNegated("-debuglogfile");
-    g_logger->fPrintToDebugLog = true;
-    g_logger->fLogTimestamps = GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
-    g_logger->fLogTimeMicros = GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
+    g_logger->m_print_to_console = GetBoolArg("-printtoconsole", !GetBoolArg("-daemon", false));
+    //g_logger->m_print_to_file = !IsArgNegated("-debuglogfile");
+    g_logger->m_print_to_file = true;
+    g_logger->m_log_timestamps = GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
+    g_logger->m_log_time_micros = GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
 
     fLogIPs = GetBoolArg("-logips", DEFAULT_LOGIPS);
 
@@ -1040,7 +1040,7 @@ bool AppInit2(bool isDaemon)
 #ifndef WIN32
     CreatePidFile(GetPidFile(), getpid());
 #endif
-    if (g_logger->fPrintToDebugLog) {
+    if (g_logger->m_print_to_file) {
         if (GetBoolArg("-shrinkdebugfile", g_logger->DefaultShrinkDebugFile()))
             g_logger->ShrinkDebugFile();
         if (!g_logger->OpenDebugLog())
@@ -1050,7 +1050,7 @@ bool AppInit2(bool isDaemon)
 #ifdef ENABLE_WALLET
     LogPrintf("Using BerkeleyDB version %s\n", DbEnv::version(0, 0, 0));
 #endif
-    if (!g_logger->fLogTimestamps)
+    if (!g_logger->m_log_timestamps)
         LogPrintf("Startup time: %s\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()));
     LogPrintf("Default data directory %s\n", GetDefaultDataDir().string());
     LogPrintf("Using data directory %s\n", strDataDir);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -877,16 +877,28 @@ static std::string ResolveErrMsg(const char * const optname, const std::string& 
 
 void InitLogging()
 {
-    g_logger->m_print_to_console = GetBoolArg("-printtoconsole", !GetBoolArg("-daemon", false));
     //g_logger->m_print_to_file = !IsArgNegated("-debuglogfile");
     g_logger->m_print_to_file = true;
+    g_logger->m_file_path = AbsPathForConfigVal(GetArg("-debuglogfile", DEFAULT_DEBUGLOGFILE));
+
+    // Add newlines to the logfile to distinguish this execution from the last
+    // one; called before console logging is set up, so this is only sent to
+    // debug.log.
+    LogPrintf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
+
+    g_logger->m_print_to_console = GetBoolArg("-printtoconsole", !GetBoolArg("-daemon", false));
     g_logger->m_log_timestamps = GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
     g_logger->m_log_time_micros = GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
 
     fLogIPs = GetBoolArg("-logips", DEFAULT_LOGIPS);
 
-    LogPrintf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
-    LogPrintf("PRCY version %s (%s)\n", FormatFullVersion(), CLIENT_DATE);
+    std::string version_string = FormatFullVersion();
+#ifdef DEBUG
+    version_string += " (debug build)";
+#else
+    version_string += " (release build)";
+#endif
+    LogPrintf("PRCY version %s (%s)\n", version_string, CLIENT_DATE);
 }
 
 /** Initialize prcy.
@@ -1044,7 +1056,7 @@ bool AppInit2(bool isDaemon)
         if (GetBoolArg("-shrinkdebugfile", g_logger->DefaultShrinkDebugFile()))
             g_logger->ShrinkDebugFile();
         if (!g_logger->OpenDebugLog())
-            return UIError(strprintf("Could not open debug log file %s", g_logger->GetDebugLogPath().string()));
+            return UIError(strprintf("Could not open debug log file %s", g_logger->m_file_path.string()));
     }
     LogPrintf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));
 #ifdef ENABLE_WALLET

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -927,10 +927,10 @@ bool AppInit2(bool isDaemon)
             find(categories.begin(), categories.end(), std::string("0")) != categories.end())) {
         for (const auto& cat : categories) {
             uint32_t flag;
-            if (!GetLogCategory(&flag, &cat))
+            if (!GetLogCategory(&flag, &cat)) {
                 UIWarning(strprintf(_("Unsupported logging category %s=%s."), "-debug", cat));
-            else
-                logCategories |= flag;
+            }
+            g_logger->EnableCategory(static_cast<BCLog::LogFlags>(flag));
         }
     }
 
@@ -939,10 +939,10 @@ bool AppInit2(bool isDaemon)
         const std::vector<std::string>& excludedCategories = mapMultiArgs.at("-debugexclude");
         for (const auto& cat : excludedCategories) {
             uint32_t flag;
-            if (!GetLogCategory(&flag, &cat))
+            if (!GetLogCategory(&flag, &cat)) {
                 UIWarning(strprintf(_("Unsupported logging category %s=%s."), "-debugexclude", cat));
-            else
-                logCategories &= ~flag;
+            }
+            g_logger->DisableCategory(static_cast<BCLog::LogFlags>(flag));
         }
     }
 
@@ -1045,7 +1045,7 @@ bool AppInit2(bool isDaemon)
     CreatePidFile(GetPidFile(), getpid());
 #endif
     if (g_logger->fPrintToDebugLog) {
-        if (GetBoolArg("-shrinkdebugfile", logCategories != BCLog::NONE))
+        if (GetBoolArg("-shrinkdebugfile", g_logger->DefaultShrinkDebugFile()))
             g_logger->ShrinkDebugFile();
         if (!g_logger->OpenDebugLog())
             return UIError(strprintf("Could not open debug log file %s", g_logger->GetDebugLogPath().string()));

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -401,7 +401,7 @@ bool CheckProofOfStake(const CBlock block, uint256& hashProofOfStake)
 
     unsigned int nInterval = 0;
     unsigned int nTime = block.nTime;
-    if (!CheckStakeKernelHash(block.nBits, blockprev, txPrev, txin.prevout, &txin.encryptionKey[0], nTime, nInterval, true, hashProofOfStake, logCategories != BCLog::NONE))
+    if (!CheckStakeKernelHash(block.nBits, blockprev, txPrev, txin.prevout, &txin.encryptionKey[0], nTime, nInterval, true, hashProofOfStake))
         return error("CheckProofOfStake() : INFO: check kernel failed on coinstake %s, hashProof=%s \n", tx.GetHash().ToString().c_str(), hashProofOfStake.ToString().c_str()); // may occur during initial download or if behind on block chain sync
 
     return true;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -9,9 +9,6 @@
 #include "util.h"
 #include "utilstrencodings.h"
 
-#include <list>
-#include <mutex>
-
 const char * const DEFAULT_DEBUGLOGFILE = "debug.log";
 
 /**
@@ -35,40 +32,12 @@ bool fLogIPs = DEFAULT_LOGIPS;
 /** Log categories bitfield. Leveldb/libevent need special handling if their flags are changed at runtime. */
 std::atomic<uint32_t> logCategories(0);
 
-/**
- * LogPrintf() has been broken a couple of times now
- * by well-meaning people adding mutexes in the most straightforward way.
- * It breaks because it may be called by global destructors during shutdown.
- * Since the order of destruction of static/global objects is undefined,
- * defining a mutex as a global object doesn't work (the mutex gets
- * destroyed, and then some later destructor calls OutputDebugStringF,
- * maybe indirectly, and you get a core dump at shutdown trying to lock
- * the mutex).
- */
-
-static boost::once_flag debugPrintInitFlag = BOOST_ONCE_INIT;
-
-/**
- * We use boost::call_once() to make sure these are initialized
- * in a thread-safe manner the first time called:
- */
-static FILE* fileout = nullptr;
-static boost::mutex* mutexDebugLog = nullptr;
-static std::list<std::string> *vMsgsBeforeOpenLog;
-
 static int FileWriteStr(const std::string &str, FILE *fp)
 {
     return fwrite(str.data(), 1, str.size(), fp);
 }
 
-static void DebugPrintInit()
-{
-    assert(mutexDebugLog == nullptr);
-    mutexDebugLog = new boost::mutex();
-    vMsgsBeforeOpenLog = new std::list<std::string>;
-}
-
-fs::path GetDebugLogPath()
+fs::path BCLog::Logger::GetDebugLogPath() const
 {
     fs::path logfile(GetArg("-debuglogfile", DEFAULT_DEBUGLOGFILE));
     if (logfile.is_absolute()) {
@@ -78,12 +47,10 @@ fs::path GetDebugLogPath()
     }
 }
 
-bool OpenDebugLog()
+bool BCLog::Logger::OpenDebugLog()
 {
-    boost::call_once(&DebugPrintInit, debugPrintInitFlag);
-    boost::mutex::scoped_lock scoped_lock(*mutexDebugLog);
+    std::lock_guard<std::mutex> scoped_lock(mutexDebugLog);
     assert(fileout == nullptr);
-    assert(vMsgsBeforeOpenLog);
 
     fs::path pathDebug = GetDebugLogPath();
 
@@ -92,13 +59,11 @@ bool OpenDebugLog()
 
     setbuf(fileout, nullptr); // unbuffered
     // dump buffered messages from before we opened the log
-    while (!vMsgsBeforeOpenLog->empty()) {
-        FileWriteStr(vMsgsBeforeOpenLog->front(), fileout);
-        vMsgsBeforeOpenLog->pop_front();
+    while (!vMsgsBeforeOpenLog.empty()) {
+        FileWriteStr(vMsgsBeforeOpenLog.front(), fileout);
+        vMsgsBeforeOpenLog.pop_front();
     }
 
-    delete vMsgsBeforeOpenLog;
-    vMsgsBeforeOpenLog = nullptr;
     return true;
 }
 
@@ -215,16 +180,14 @@ int BCLog::Logger::LogPrintStr(const std::string &str)
         ret = fwrite(str.data(), 1, str.size(), stdout);
         fflush(stdout);
     } else if (fPrintToDebugLog) {
-        boost::call_once(&DebugPrintInit, debugPrintInitFlag);
-        boost::mutex::scoped_lock scoped_lock(*mutexDebugLog);
+        std::lock_guard<std::mutex> scoped_lock(mutexDebugLog);
 
         std::string strTimestamped = LogTimestampStr(str);
 
         // buffer if we haven't opened the log yet
         if (fileout == NULL) {
-            assert(vMsgsBeforeOpenLog);
             ret = strTimestamped.length();
-            vMsgsBeforeOpenLog->push_back(strTimestamped);
+            vMsgsBeforeOpenLog.push_back(strTimestamped);
 
         } else {
             // reopen the log file, if requested
@@ -242,7 +205,7 @@ int BCLog::Logger::LogPrintStr(const std::string &str)
     return ret;
 }
 
-void ShrinkDebugFile()
+void BCLog::Logger::ShrinkDebugFile()
 {
     // Scroll debug.log if it's getting too big
     fs::path pathLog = GetDebugLogPath();

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -14,11 +14,23 @@
 
 const char * const DEFAULT_DEBUGLOGFILE = "debug.log";
 
-bool fPrintToConsole = false;
-bool fPrintToDebugLog = true;
-bool fLogTimestamps = false;
-bool fLogIPs = false;
-std::atomic<bool> fReopenDebugLog(false);
+/**
+ * NOTE: the logger instances is leaked on exit. This is ugly, but will be
+ * cleaned up by the OS/libc. Defining a logger as a global object doesn't work
+ * since the order of destruction of static/global objects is undefined.
+ * Consider if the logger gets destroyed, and then some later destructor calls
+ * LogPrintf, maybe indirectly, and you get a core dump at shutdown trying to
+ * access the logger. When the shutdown sequence is fully audited and tested,
+ * explicit destruction of these objects can be implemented by changing this
+ * from a raw pointer to a std::unique_ptr.
+ *
+ * This method of initialization was originally introduced in
+ * bitcoin@ee3374234c60aba2cc4c5cd5cac1c0aefc2d817c.
+ */
+BCLog::Logger* const g_logger = new BCLog::Logger();
+
+bool fLogIPs = DEFAULT_LOGIPS;
+
 
 /** Log categories bitfield. Leveldb/libevent need special handling if their flags are changed at runtime. */
 std::atomic<uint32_t> logCategories(0);
@@ -175,35 +187,29 @@ std::vector<CLogCategoryActive> ListActiveLogCategories()
     return ret;
 }
 
-/**
- * fStartedNewLine is a state variable held by the calling context that will
- * suppress printing of the timestamp when multiple calls are made that don't
- * end in a newline. Initialize it to true, and hold it, in the calling context.
- */
-static std::string LogTimestampStr(const std::string &str, bool *fStartedNewLine)
+std::string BCLog::Logger::LogTimestampStr(const std::string &str)
 {
     std::string strStamped;
 
     if (!fLogTimestamps)
         return str;
 
-    if (*fStartedNewLine)
+    if (fStartedNewLine)
         strStamped =  DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()) + ' ' + str;
     else
         strStamped = str;
 
     if (!str.empty() && str[str.size()-1] == '\n')
-        *fStartedNewLine = true;
+        fStartedNewLine = true;
     else
-        *fStartedNewLine = false;
+        fStartedNewLine = false;
 
     return strStamped;
 }
 
-int LogPrintStr(const std::string& str)
+int BCLog::Logger::LogPrintStr(const std::string &str)
 {
     int ret = 0; // Returns total number of characters written
-    static bool fStartedNewLine = true;
     if (fPrintToConsole) {
         // print to console
         ret = fwrite(str.data(), 1, str.size(), stdout);
@@ -212,7 +218,7 @@ int LogPrintStr(const std::string& str)
         boost::call_once(&DebugPrintInit, debugPrintInitFlag);
         boost::mutex::scoped_lock scoped_lock(*mutexDebugLog);
 
-        std::string strTimestamped = LogTimestampStr(str, &fStartedNewLine);
+        std::string strTimestamped = LogTimestampStr(str);
 
         // buffer if we haven't opened the log yet
         if (fileout == NULL) {

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -7,7 +7,6 @@
 #include "chainparamsbase.h"
 #include "logging.h"
 #include "util.h"
-#include "utilstrencodings.h"
 
 const char * const DEFAULT_DEBUGLOGFILE = "debug.log";
 
@@ -68,9 +67,25 @@ void BCLog::Logger::EnableCategory(BCLog::LogFlags flag)
     logCategories |= flag;
 }
 
+bool BCLog::Logger::EnableCategory(const std::string& str)
+{
+    BCLog::LogFlags flag;
+    if (!GetLogCategory(flag, str)) return false;
+    EnableCategory(flag);
+    return true;
+}
+
 void BCLog::Logger::DisableCategory(BCLog::LogFlags flag)
 {
     logCategories &= ~flag;
+}
+
+bool BCLog::Logger::DisableCategory(const std::string& str)
+{
+    BCLog::LogFlags flag;
+    if (!GetLogCategory(flag, str)) return false;
+    DisableCategory(flag);
+    return true;
 }
 
 bool BCLog::Logger::WillLogCategory(BCLog::LogFlags category) const
@@ -85,7 +100,7 @@ bool BCLog::Logger::DefaultShrinkDebugFile() const
 
 struct CLogCategoryDesc
 {
-    uint32_t flag;
+    BCLog::LogFlags flag;
     std::string category;
 };
 
@@ -121,18 +136,16 @@ const CLogCategoryDesc LogCategories[] = {
         {BCLog::ALL,            "all"},
 };
 
-bool GetLogCategory(uint32_t *f, const std::string *str)
+bool GetLogCategory(BCLog::LogFlags& flag, const std::string& str)
 {
-    if (f && str) {
-        if (*str == "") {
-            *f = BCLog::ALL;
+    if (str == "") {
+        flag = BCLog::ALL;
+        return true;
+    }
+    for (const CLogCategoryDesc& category_desc : LogCategories) {
+        if (category_desc.category == str) {
+            flag = category_desc.flag;
             return true;
-        }
-        for (unsigned int i = 0; i < ARRAYLEN(LogCategories); i++) {
-            if (LogCategories[i].category == *str) {
-                *f = LogCategories[i].flag;
-                return true;
-            }
         }
     }
     return false;
@@ -142,11 +155,11 @@ std::string ListLogCategories()
 {
     std::string ret;
     int outcount = 0;
-    for (unsigned int i = 0; i < ARRAYLEN(LogCategories); i++) {
+    for (const CLogCategoryDesc& category_desc : LogCategories) {
         // Omit the special cases.
-        if (LogCategories[i].flag != BCLog::NONE && LogCategories[i].flag != BCLog::ALL) {
+        if (category_desc.flag != BCLog::NONE && category_desc.flag != BCLog::ALL) {
             if (outcount != 0) ret += ", ";
-            ret += LogCategories[i].category;
+            ret += category_desc.category;
             outcount++;
         }
     }
@@ -156,12 +169,12 @@ std::string ListLogCategories()
 std::vector<CLogCategoryActive> ListActiveLogCategories()
 {
     std::vector<CLogCategoryActive> ret;
-    for (unsigned int i = 0; i < ARRAYLEN(LogCategories); i++) {
+    for (const CLogCategoryDesc& category_desc : LogCategories) {
         // Omit the special cases.
-        if (LogCategories[i].flag != BCLog::NONE && LogCategories[i].flag != BCLog::ALL) {
+        if (category_desc.flag != BCLog::NONE && category_desc.flag != BCLog::ALL) {
             CLogCategoryActive catActive;
-            catActive.category = LogCategories[i].category;
-            catActive.active = LogAcceptCategory(static_cast<BCLog::LogFlags>(LogCategories[i].flag));
+            catActive.category = category_desc.category;
+            catActive.active = LogAcceptCategory(category_desc.flag);
             ret.push_back(catActive);
         }
     }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -44,19 +44,19 @@ fs::path BCLog::Logger::GetDebugLogPath() const
 
 bool BCLog::Logger::OpenDebugLog()
 {
-    std::lock_guard<std::mutex> scoped_lock(mutexDebugLog);
-    assert(fileout == nullptr);
+    std::lock_guard<std::mutex> scoped_lock(m_file_mutex);
+    assert(m_fileout == nullptr);
 
     fs::path pathDebug = GetDebugLogPath();
 
-    fileout = fopen(pathDebug.string().c_str(), "a");
-    if (!fileout) return false;
+    m_fileout = fopen(pathDebug.string().c_str(), "a");
+    if (!m_fileout) return false;
 
-    setbuf(fileout, nullptr); // unbuffered
+    setbuf(m_fileout, nullptr); // unbuffered
     // dump buffered messages from before we opened the log
-    while (!vMsgsBeforeOpenLog.empty()) {
-        FileWriteStr(vMsgsBeforeOpenLog.front(), fileout);
-        vMsgsBeforeOpenLog.pop_front();
+    while (!m_msgs_before_open.empty()) {
+        FileWriteStr(m_msgs_before_open.front(), m_fileout);
+        m_msgs_before_open.pop_front();
     }
 
     return true;
@@ -64,7 +64,7 @@ bool BCLog::Logger::OpenDebugLog()
 
 void BCLog::Logger::EnableCategory(BCLog::LogFlags flag)
 {
-    logCategories |= flag;
+    m_categories |= flag;
 }
 
 bool BCLog::Logger::EnableCategory(const std::string& str)
@@ -77,7 +77,7 @@ bool BCLog::Logger::EnableCategory(const std::string& str)
 
 void BCLog::Logger::DisableCategory(BCLog::LogFlags flag)
 {
-    logCategories &= ~flag;
+    m_categories &= ~flag;
 }
 
 bool BCLog::Logger::DisableCategory(const std::string& str)
@@ -90,12 +90,12 @@ bool BCLog::Logger::DisableCategory(const std::string& str)
 
 bool BCLog::Logger::WillLogCategory(BCLog::LogFlags category) const
 {
-    return (logCategories.load(std::memory_order_relaxed) & category) != 0;
+    return (m_categories.load(std::memory_order_relaxed) & category) != 0;
 }
 
 bool BCLog::Logger::DefaultShrinkDebugFile() const
 {
-    return logCategories == BCLog::NONE;
+    return m_categories == BCLog::NONE;
 }
 
 struct CLogCategoryDesc
@@ -185,18 +185,18 @@ std::string BCLog::Logger::LogTimestampStr(const std::string &str)
 {
     std::string strStamped;
 
-    if (!fLogTimestamps)
+    if (!m_log_timestamps)
         return str;
 
-    if (fStartedNewLine)
+    if (m_started_new_line)
         strStamped =  DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()) + ' ' + str;
     else
         strStamped = str;
 
     if (!str.empty() && str[str.size()-1] == '\n')
-        fStartedNewLine = true;
+        m_started_new_line = true;
     else
-        fStartedNewLine = false;
+        m_started_new_line = false;
 
     return strStamped;
 }
@@ -204,30 +204,30 @@ std::string BCLog::Logger::LogTimestampStr(const std::string &str)
 int BCLog::Logger::LogPrintStr(const std::string &str)
 {
     int ret = 0; // Returns total number of characters written
-    if (fPrintToConsole) {
+    if (m_print_to_console) {
         // print to console
         ret = fwrite(str.data(), 1, str.size(), stdout);
         fflush(stdout);
-    } else if (fPrintToDebugLog) {
-        std::lock_guard<std::mutex> scoped_lock(mutexDebugLog);
+    } else if (m_print_to_file) {
+        std::lock_guard<std::mutex> scoped_lock(m_file_mutex);
 
         std::string strTimestamped = LogTimestampStr(str);
 
         // buffer if we haven't opened the log yet
-        if (fileout == NULL) {
+        if (m_fileout == NULL) {
             ret = strTimestamped.length();
-            vMsgsBeforeOpenLog.push_back(strTimestamped);
+            m_msgs_before_open.push_back(strTimestamped);
 
         } else {
             // reopen the log file, if requested
-            if (fReopenDebugLog) {
-                fReopenDebugLog = false;
+            if (m_reopen_file) {
+                m_reopen_file = false;
                 fs::path pathDebug = GetDebugLogPath();
-                if (freopen(pathDebug.string().c_str(),"a",fileout) != NULL)
-                    setbuf(fileout, NULL); // unbuffered
+                if (freopen(pathDebug.string().c_str(),"a",m_fileout) != NULL)
+                    setbuf(m_fileout, NULL); // unbuffered
             }
 
-            ret = FileWriteStr(strTimestamped, fileout);
+            ret = FileWriteStr(strTimestamped, m_fileout);
         }
     }
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -28,10 +28,6 @@ BCLog::Logger* const g_logger = new BCLog::Logger();
 
 bool fLogIPs = DEFAULT_LOGIPS;
 
-
-/** Log categories bitfield. Leveldb/libevent need special handling if their flags are changed at runtime. */
-std::atomic<uint32_t> logCategories(0);
-
 static int FileWriteStr(const std::string &str, FILE *fp)
 {
     return fwrite(str.data(), 1, str.size(), fp);
@@ -65,6 +61,26 @@ bool BCLog::Logger::OpenDebugLog()
     }
 
     return true;
+}
+
+void BCLog::Logger::EnableCategory(BCLog::LogFlags flag)
+{
+    logCategories |= flag;
+}
+
+void BCLog::Logger::DisableCategory(BCLog::LogFlags flag)
+{
+    logCategories &= ~flag;
+}
+
+bool BCLog::Logger::WillLogCategory(BCLog::LogFlags category) const
+{
+    return (logCategories.load(std::memory_order_relaxed) & category) != 0;
+}
+
+bool BCLog::Logger::DefaultShrinkDebugFile() const
+{
+    return logCategories == BCLog::NONE;
 }
 
 struct CLogCategoryDesc
@@ -145,7 +161,7 @@ std::vector<CLogCategoryActive> ListActiveLogCategories()
         if (LogCategories[i].flag != BCLog::NONE && LogCategories[i].flag != BCLog::ALL) {
             CLogCategoryActive catActive;
             catActive.category = LogCategories[i].category;
-            catActive.active = LogAcceptCategory(LogCategories[i].flag);
+            catActive.active = LogAcceptCategory(static_cast<BCLog::LogFlags>(LogCategories[i].flag));
             ret.push_back(catActive);
         }
     }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -6,7 +6,7 @@
 
 #include "chainparamsbase.h"
 #include "logging.h"
-#include "util.h"
+#include "utiltime.h"
 
 const char * const DEFAULT_DEBUGLOGFILE = "debug.log";
 
@@ -32,24 +32,14 @@ static int FileWriteStr(const std::string &str, FILE *fp)
     return fwrite(str.data(), 1, str.size(), fp);
 }
 
-fs::path BCLog::Logger::GetDebugLogPath() const
-{
-    fs::path logfile(GetArg("-debuglogfile", DEFAULT_DEBUGLOGFILE));
-    if (logfile.is_absolute()) {
-        return logfile;
-    } else {
-        return GetDataDir() / logfile;
-    }
-}
-
 bool BCLog::Logger::OpenDebugLog()
 {
     std::lock_guard<std::mutex> scoped_lock(m_file_mutex);
+
     assert(m_fileout == nullptr);
+    assert(!m_file_path.empty());
 
-    fs::path pathDebug = GetDebugLogPath();
-
-    m_fileout = fopen(pathDebug.string().c_str(), "a");
+    m_fileout = fopen(m_file_path.string().c_str(), "a");
     if (!m_fileout) return false;
 
     setbuf(m_fileout, nullptr); // unbuffered
@@ -222,8 +212,7 @@ int BCLog::Logger::LogPrintStr(const std::string &str)
             // reopen the log file, if requested
             if (m_reopen_file) {
                 m_reopen_file = false;
-                fs::path pathDebug = GetDebugLogPath();
-                if (freopen(pathDebug.string().c_str(),"a",m_fileout) != NULL)
+                if (freopen(m_file_path.string().c_str(),"a",m_fileout) != NULL)
                     setbuf(m_fileout, NULL); // unbuffered
             }
 
@@ -236,17 +225,21 @@ int BCLog::Logger::LogPrintStr(const std::string &str)
 
 void BCLog::Logger::ShrinkDebugFile()
 {
+    // Amount of debug.log to save at end when shrinking (must fit in memory)
+    constexpr size_t RECENT_DEBUG_HISTORY_SIZE = 10 * 1000000;
+
+    assert(!m_file_path.empty());
+
     // Scroll debug.log if it's getting too big
-    fs::path pathLog = GetDebugLogPath();
-    FILE* file = fopen(pathLog.string().c_str(), "r");
-    if (file && fs::file_size(pathLog) > 10 * 1000000) {
+    FILE* file = fopen(m_file_path.string().c_str(), "r");
+    if (file && fs::file_size(m_file_path) > RECENT_DEBUG_HISTORY_SIZE) {
         // Restart the file with some of the end
         std::vector<char> vch(200000, 0);
         fseek(file, -((long)vch.size()), SEEK_END);
         int nBytes = fread(vch.data(), 1, vch.size(), file);
         fclose(file);
 
-        file = fopen(pathLog.string().c_str(), "w");
+        file = fopen(m_file_path.string().c_str(), "w");
         if (file) {
             fwrite(vch.data(), 1, nBytes, file);
             fclose(file);

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -1,0 +1,258 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2018 The Bitcoin developers
+// Copyright (c) 2015-2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "chainparamsbase.h"
+#include "logging.h"
+#include "util.h"
+#include "utilstrencodings.h"
+
+#include <list>
+#include <mutex>
+
+const char * const DEFAULT_DEBUGLOGFILE = "debug.log";
+
+bool fPrintToConsole = false;
+bool fPrintToDebugLog = true;
+bool fLogTimestamps = false;
+bool fLogIPs = false;
+std::atomic<bool> fReopenDebugLog(false);
+
+/** Log categories bitfield. Leveldb/libevent need special handling if their flags are changed at runtime. */
+std::atomic<uint32_t> logCategories(0);
+
+/**
+ * LogPrintf() has been broken a couple of times now
+ * by well-meaning people adding mutexes in the most straightforward way.
+ * It breaks because it may be called by global destructors during shutdown.
+ * Since the order of destruction of static/global objects is undefined,
+ * defining a mutex as a global object doesn't work (the mutex gets
+ * destroyed, and then some later destructor calls OutputDebugStringF,
+ * maybe indirectly, and you get a core dump at shutdown trying to lock
+ * the mutex).
+ */
+
+static boost::once_flag debugPrintInitFlag = BOOST_ONCE_INIT;
+
+/**
+ * We use boost::call_once() to make sure these are initialized
+ * in a thread-safe manner the first time called:
+ */
+static FILE* fileout = nullptr;
+static boost::mutex* mutexDebugLog = nullptr;
+static std::list<std::string> *vMsgsBeforeOpenLog;
+
+static int FileWriteStr(const std::string &str, FILE *fp)
+{
+    return fwrite(str.data(), 1, str.size(), fp);
+}
+
+static void DebugPrintInit()
+{
+    assert(mutexDebugLog == nullptr);
+    mutexDebugLog = new boost::mutex();
+    vMsgsBeforeOpenLog = new std::list<std::string>;
+}
+
+fs::path GetDebugLogPath()
+{
+    fs::path logfile(GetArg("-debuglogfile", DEFAULT_DEBUGLOGFILE));
+    if (logfile.is_absolute()) {
+        return logfile;
+    } else {
+        return GetDataDir() / logfile;
+    }
+}
+
+bool OpenDebugLog()
+{
+    boost::call_once(&DebugPrintInit, debugPrintInitFlag);
+    boost::mutex::scoped_lock scoped_lock(*mutexDebugLog);
+    assert(fileout == nullptr);
+    assert(vMsgsBeforeOpenLog);
+
+    fs::path pathDebug = GetDebugLogPath();
+
+    fileout = fopen(pathDebug.string().c_str(), "a");
+    if (!fileout) return false;
+
+    setbuf(fileout, nullptr); // unbuffered
+    // dump buffered messages from before we opened the log
+    while (!vMsgsBeforeOpenLog->empty()) {
+        FileWriteStr(vMsgsBeforeOpenLog->front(), fileout);
+        vMsgsBeforeOpenLog->pop_front();
+    }
+
+    delete vMsgsBeforeOpenLog;
+    vMsgsBeforeOpenLog = nullptr;
+    return true;
+}
+
+struct CLogCategoryDesc
+{
+    uint32_t flag;
+    std::string category;
+};
+
+const CLogCategoryDesc LogCategories[] = {
+        {BCLog::NONE,           "0"},
+        {BCLog::NET,            "net"},
+        {BCLog::TOR,            "tor"},
+        {BCLog::MEMPOOL,        "mempool"},
+        {BCLog::HTTP,           "http"},
+        {BCLog::BENCH,          "bench"},
+        {BCLog::ZMQ,            "zmq"},
+        {BCLog::DB,             "db"},
+        {BCLog::RPC,            "rpc"},
+        {BCLog::ESTIMATEFEE,    "estimatefee"},
+        {BCLog::ADDRMAN,        "addrman"},
+        {BCLog::SELECTCOINS,    "selectcoins"},
+        {BCLog::REINDEX,        "reindex"},
+        {BCLog::CMPCTBLOCK,     "cmpctblock"},
+        {BCLog::RAND,           "rand"},
+        {BCLog::PRUNE,          "prune"},
+        {BCLog::PROXY,          "proxy"},
+        {BCLog::MEMPOOLREJ,     "mempoolrej"},
+        {BCLog::LIBEVENT,       "libevent"},
+        {BCLog::COINDB,         "coindb"},
+        {BCLog::QT,             "qt"},
+        {BCLog::LEVELDB,        "leveldb"},
+        {BCLog::STAKING,        "staking"},
+        {BCLog::MASTERNODE,     "masternode"},
+        {BCLog::MNBUDGET,       "mnbudget"},
+        {BCLog::POA,            "poa"},
+        {BCLog::SUPPLY,         "supply"},
+        {BCLog::ALL,            "1"},
+        {BCLog::ALL,            "all"},
+};
+
+bool GetLogCategory(uint32_t *f, const std::string *str)
+{
+    if (f && str) {
+        if (*str == "") {
+            *f = BCLog::ALL;
+            return true;
+        }
+        for (unsigned int i = 0; i < ARRAYLEN(LogCategories); i++) {
+            if (LogCategories[i].category == *str) {
+                *f = LogCategories[i].flag;
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+std::string ListLogCategories()
+{
+    std::string ret;
+    int outcount = 0;
+    for (unsigned int i = 0; i < ARRAYLEN(LogCategories); i++) {
+        // Omit the special cases.
+        if (LogCategories[i].flag != BCLog::NONE && LogCategories[i].flag != BCLog::ALL) {
+            if (outcount != 0) ret += ", ";
+            ret += LogCategories[i].category;
+            outcount++;
+        }
+    }
+    return ret;
+}
+
+std::vector<CLogCategoryActive> ListActiveLogCategories()
+{
+    std::vector<CLogCategoryActive> ret;
+    for (unsigned int i = 0; i < ARRAYLEN(LogCategories); i++) {
+        // Omit the special cases.
+        if (LogCategories[i].flag != BCLog::NONE && LogCategories[i].flag != BCLog::ALL) {
+            CLogCategoryActive catActive;
+            catActive.category = LogCategories[i].category;
+            catActive.active = LogAcceptCategory(LogCategories[i].flag);
+            ret.push_back(catActive);
+        }
+    }
+    return ret;
+}
+
+/**
+ * fStartedNewLine is a state variable held by the calling context that will
+ * suppress printing of the timestamp when multiple calls are made that don't
+ * end in a newline. Initialize it to true, and hold it, in the calling context.
+ */
+static std::string LogTimestampStr(const std::string &str, bool *fStartedNewLine)
+{
+    std::string strStamped;
+
+    if (!fLogTimestamps)
+        return str;
+
+    if (*fStartedNewLine)
+        strStamped =  DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()) + ' ' + str;
+    else
+        strStamped = str;
+
+    if (!str.empty() && str[str.size()-1] == '\n')
+        *fStartedNewLine = true;
+    else
+        *fStartedNewLine = false;
+
+    return strStamped;
+}
+
+int LogPrintStr(const std::string& str)
+{
+    int ret = 0; // Returns total number of characters written
+    static bool fStartedNewLine = true;
+    if (fPrintToConsole) {
+        // print to console
+        ret = fwrite(str.data(), 1, str.size(), stdout);
+        fflush(stdout);
+    } else if (fPrintToDebugLog) {
+        boost::call_once(&DebugPrintInit, debugPrintInitFlag);
+        boost::mutex::scoped_lock scoped_lock(*mutexDebugLog);
+
+        std::string strTimestamped = LogTimestampStr(str, &fStartedNewLine);
+
+        // buffer if we haven't opened the log yet
+        if (fileout == NULL) {
+            assert(vMsgsBeforeOpenLog);
+            ret = strTimestamped.length();
+            vMsgsBeforeOpenLog->push_back(strTimestamped);
+
+        } else {
+            // reopen the log file, if requested
+            if (fReopenDebugLog) {
+                fReopenDebugLog = false;
+                fs::path pathDebug = GetDebugLogPath();
+                if (freopen(pathDebug.string().c_str(),"a",fileout) != NULL)
+                    setbuf(fileout, NULL); // unbuffered
+            }
+
+            ret = FileWriteStr(strTimestamped, fileout);
+        }
+    }
+
+    return ret;
+}
+
+void ShrinkDebugFile()
+{
+    // Scroll debug.log if it's getting too big
+    fs::path pathLog = GetDebugLogPath();
+    FILE* file = fopen(pathLog.string().c_str(), "r");
+    if (file && fs::file_size(pathLog) > 10 * 1000000) {
+        // Restart the file with some of the end
+        std::vector<char> vch(200000, 0);
+        fseek(file, -((long)vch.size()), SEEK_END);
+        int nBytes = fread(vch.data(), 1, vch.size(), file);
+        fclose(file);
+
+        file = fopen(pathLog.string().c_str(), "w");
+        if (file) {
+            fwrite(vch.data(), 1, nBytes, file);
+            fclose(file);
+        }
+    } else if (file != NULL)
+        fclose(file);
+}

--- a/src/logging.h
+++ b/src/logging.h
@@ -87,11 +87,12 @@ namespace BCLog {
 
     public:
         bool m_print_to_console = false;
-        bool m_print_to_file = true;
+        bool m_print_to_file = false;
 
         bool m_log_timestamps = DEFAULT_LOGTIMESTAMPS;
         bool m_log_time_micros = DEFAULT_LOGTIMEMICROS;
 
+        fs::path m_file_path;
         std::atomic<bool> m_reopen_file{false};
 
         /** Send a string to the log output */
@@ -100,7 +101,6 @@ namespace BCLog {
         /** Returns whether logs will be written to any output */
         bool Enabled() const { return m_print_to_console || m_print_to_file; }
 
-        fs::path GetDebugLogPath() const;
         bool OpenDebugLog();
         void ShrinkDebugFile();
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -105,8 +105,12 @@ namespace BCLog {
         void ShrinkDebugFile();
 
         uint32_t GetCategoryMask() const { return logCategories.load(); }
+
         void EnableCategory(LogFlags flag);
+        bool EnableCategory(const std::string& str);
         void DisableCategory(LogFlags flag);
+        bool DisableCategory(const std::string& str);
+
         bool WillLogCategory(LogFlags category) const;
 
         bool DefaultShrinkDebugFile() const;
@@ -128,8 +132,8 @@ std::string ListLogCategories();
 /** Returns a vector of the active log categories. */
 std::vector<CLogCategoryActive> ListActiveLogCategories();
 
-/** Return true if str parses as a log category and set the flags in f */
-bool GetLogCategory(uint32_t *f, const std::string *str);
+/** Return true if str parses as a log category and set the flag */
+bool GetLogCategory(BCLog::LogFlags& flag, const std::string& str);
 
 /** Get format string from VA_ARGS for error reporting */
 template<typename... Args> std::string FormatStringFromLogArgs(const char *fmt, const Args&... args) { return fmt; }

--- a/src/logging.h
+++ b/src/logging.h
@@ -69,42 +69,42 @@ namespace BCLog {
     class Logger
     {
     private:
-        FILE* fileout = nullptr;
-        std::mutex mutexDebugLog;
-        std::list<std::string> vMsgsBeforeOpenLog;
+        FILE* m_fileout = nullptr;
+        std::mutex m_file_mutex;
+        std::list<std::string> m_msgs_before_open;
 
         /**
-         * fStartedNewLine is a state variable that will suppress printing of
+         * m_started_new_line is a state variable that will suppress printing of
          * the timestamp when multiple calls are made that don't end in a
          * newline.
          */
-        std::atomic_bool fStartedNewLine{true};
+        std::atomic_bool m_started_new_line{true};
 
         /** Log categories bitfield. */
-        std::atomic<uint32_t> logCategories{0};
+        std::atomic<uint32_t> m_categories{0};
 
         std::string LogTimestampStr(const std::string& str);
 
     public:
-        bool fPrintToConsole = false;
-        bool fPrintToDebugLog = true;
+        bool m_print_to_console = false;
+        bool m_print_to_file = true;
 
-        bool fLogTimestamps = DEFAULT_LOGTIMESTAMPS;
-        bool fLogTimeMicros = DEFAULT_LOGTIMEMICROS;
+        bool m_log_timestamps = DEFAULT_LOGTIMESTAMPS;
+        bool m_log_time_micros = DEFAULT_LOGTIMEMICROS;
 
-        std::atomic<bool> fReopenDebugLog{false};
+        std::atomic<bool> m_reopen_file{false};
 
         /** Send a string to the log output */
         int LogPrintStr(const std::string &str);
 
         /** Returns whether logs will be written to any output */
-        bool Enabled() const { return fPrintToConsole || fPrintToDebugLog; }
+        bool Enabled() const { return m_print_to_console || m_print_to_file; }
 
         fs::path GetDebugLogPath() const;
         bool OpenDebugLog();
         void ShrinkDebugFile();
 
-        uint32_t GetCategoryMask() const { return logCategories.load(); }
+        uint32_t GetCategoryMask() const { return m_categories.load(); }
 
         void EnableCategory(LogFlags flag);
         bool EnableCategory(const std::string& str);

--- a/src/logging.h
+++ b/src/logging.h
@@ -1,0 +1,114 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2018 The Bitcoin developers
+// Copyright (c) 2015-2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+/**
+ * Server/client environment: argument handling, config file parsing,
+ * logging, thread wrappers
+ */
+#ifndef BITCOIN_LOGGING_H
+#define BITCOIN_LOGGING_H
+
+#include "fs.h"
+#include "tinyformat.h"
+
+#include <atomic>
+#include <vector>
+
+extern bool fPrintToConsole;
+extern bool fPrintToDebugLog;
+
+extern bool fLogTimestamps;
+extern bool fLogIPs;
+extern std::atomic<bool> fReopenDebugLog;
+
+extern std::atomic<uint32_t> logCategories;
+
+struct CLogCategoryActive
+{
+    std::string category;
+    bool active;
+};
+
+namespace BCLog {
+    enum LogFlags : uint32_t {
+        NONE        = 0,
+        NET         = (1 <<  0),
+        TOR         = (1 <<  1),
+        MEMPOOL     = (1 <<  2),
+        HTTP        = (1 <<  3),
+        BENCH       = (1 <<  4),
+        ZMQ         = (1 <<  5),
+        DB          = (1 <<  6),
+        RPC         = (1 <<  7),
+        ESTIMATEFEE = (1 <<  8),
+        ADDRMAN     = (1 <<  9),
+        SELECTCOINS = (1 << 10),
+        REINDEX     = (1 << 11),
+        CMPCTBLOCK  = (1 << 12),
+        RAND        = (1 << 13),
+        PRUNE       = (1 << 14),
+        PROXY       = (1 << 15),
+        MEMPOOLREJ  = (1 << 16),
+        LIBEVENT    = (1 << 17),
+        COINDB      = (1 << 18),
+        QT          = (1 << 19),
+        LEVELDB     = (1 << 20),
+        STAKING     = (1 << 21),
+        MASTERNODE  = (1 << 22),
+        MNBUDGET    = (1 << 23),
+        POA         = (1 << 24),
+        SUPPLY      = (1 << 25),
+        ALL         = ~(uint32_t)0,
+    };
+}
+
+/** Return true if log accepts specified category */
+static inline bool LogAcceptCategory(uint32_t category)
+{
+    return (logCategories.load(std::memory_order_relaxed) & category) != 0;
+}
+
+/** Returns a string with the supported log categories */
+std::string ListLogCategories();
+
+/** Returns a vector of the active log categories. */
+std::vector<CLogCategoryActive> ListActiveLogCategories();
+
+/** Return true if str parses as a log category and set the flags in f */
+bool GetLogCategory(uint32_t *f, const std::string *str);
+
+/** Send a string to the log output */
+int LogPrintStr(const std::string& str);
+
+/** Get format string from VA_ARGS for error reporting */
+template<typename... Args> std::string FormatStringFromLogArgs(const char *fmt, const Args&... args) { return fmt; }
+
+// Be conservative when using LogPrintf/error or other things which
+// unconditionally log to debug.log! It should not be the case that an inbound
+// peer can fill up a user's disk with debug.log entries.
+
+#define LogPrintf(...) do {                                                         \
+    std::string _log_msg_; /* Unlikely name to avoid shadowing variables */         \
+    try {                                                                           \
+        _log_msg_ = tfm::format(__VA_ARGS__);                                       \
+    } catch (tinyformat::format_error &e) {                                               \
+        /* Original format string will have newline so don't add one here */        \
+        _log_msg_ = "Error \"" + std::string(e.what()) + "\" while formatting log message: " + FormatStringFromLogArgs(__VA_ARGS__); \
+    }                                                                               \
+    LogPrintStr(_log_msg_);                                                         \
+} while(0)
+
+#define LogPrint(category, ...) do {                                                \
+    if (LogAcceptCategory((category))) {                                            \
+        LogPrintf(__VA_ARGS__);                                                     \
+    }                                                                               \
+} while(0)
+
+fs::path GetDebugLogPath();
+bool OpenDebugLog();
+void ShrinkDebugFile();
+
+#endif // BITCOIN_LOGGING_H

--- a/src/logging.h
+++ b/src/logging.h
@@ -17,12 +17,13 @@
 #include <atomic>
 #include <vector>
 
-extern bool fPrintToConsole;
-extern bool fPrintToDebugLog;
 
-extern bool fLogTimestamps;
+static const bool DEFAULT_LOGTIMEMICROS = false;
+static const bool DEFAULT_LOGIPS        = false;
+static const bool DEFAULT_LOGTIMESTAMPS = true;
+extern const char * const DEFAULT_DEBUGLOGFILE;
+
 extern bool fLogIPs;
-extern std::atomic<bool> fReopenDebugLog;
 
 extern std::atomic<uint32_t> logCategories;
 
@@ -63,7 +64,38 @@ namespace BCLog {
         SUPPLY      = (1 << 25),
         ALL         = ~(uint32_t)0,
     };
-}
+
+    class Logger
+    {
+    private:
+        /**
+         * fStartedNewLine is a state variable that will suppress printing of
+         * the timestamp when multiple calls are made that don't end in a
+         * newline.
+         */
+        std::atomic_bool fStartedNewLine{true};
+
+        std::string LogTimestampStr(const std::string& str);
+
+    public:
+        bool fPrintToConsole = false;
+        bool fPrintToDebugLog = true;
+
+        bool fLogTimestamps = DEFAULT_LOGTIMESTAMPS;
+        bool fLogTimeMicros = DEFAULT_LOGTIMEMICROS;
+
+        std::atomic<bool> fReopenDebugLog{false};
+
+        /** Send a string to the log output */
+        int LogPrintStr(const std::string &str);
+
+        /** Returns whether logs will be written to any output */
+        bool Enabled() const { return fPrintToConsole || fPrintToDebugLog; }
+    };
+
+} // namespace BCLog
+
+extern BCLog::Logger* const g_logger;
 
 /** Return true if log accepts specified category */
 static inline bool LogAcceptCategory(uint32_t category)
@@ -80,9 +112,6 @@ std::vector<CLogCategoryActive> ListActiveLogCategories();
 /** Return true if str parses as a log category and set the flags in f */
 bool GetLogCategory(uint32_t *f, const std::string *str);
 
-/** Send a string to the log output */
-int LogPrintStr(const std::string& str);
-
 /** Get format string from VA_ARGS for error reporting */
 template<typename... Args> std::string FormatStringFromLogArgs(const char *fmt, const Args&... args) { return fmt; }
 
@@ -91,14 +120,18 @@ template<typename... Args> std::string FormatStringFromLogArgs(const char *fmt, 
 // peer can fill up a user's disk with debug.log entries.
 
 #define LogPrintf(...) do {                                                         \
-    std::string _log_msg_; /* Unlikely name to avoid shadowing variables */         \
-    try {                                                                           \
-        _log_msg_ = tfm::format(__VA_ARGS__);                                       \
-    } catch (tinyformat::format_error &e) {                                               \
-        /* Original format string will have newline so don't add one here */        \
-        _log_msg_ = "Error \"" + std::string(e.what()) + "\" while formatting log message: " + FormatStringFromLogArgs(__VA_ARGS__); \
+    if(g_logger->Enabled()) {                                                       \
+        std::string _log_msg_; /* Unlikely name to avoid shadowing variables */     \
+        try {                                                                       \
+            _log_msg_ = tfm::format(__VA_ARGS__);                                   \
+        } catch (tinyformat::format_error &e) {                                     \
+            /* Original format string will have newline so don't add one here */    \
+            _log_msg_ = "Error \"" + std::string(e.what()) +                        \
+                        "\" while formatting log message: " +                       \
+                        FormatStringFromLogArgs(__VA_ARGS__);                       \
+        }                                                                           \
+        g_logger->LogPrintStr(_log_msg_);                                           \
     }                                                                               \
-    LogPrintStr(_log_msg_);                                                         \
 } while(0)
 
 #define LogPrint(category, ...) do {                                                \

--- a/src/logging.h
+++ b/src/logging.h
@@ -15,6 +15,9 @@
 #include "tinyformat.h"
 
 #include <atomic>
+#include <cstdint>
+#include <list>
+#include <mutex>
 #include <vector>
 
 
@@ -68,6 +71,10 @@ namespace BCLog {
     class Logger
     {
     private:
+        FILE* fileout = nullptr;
+        std::mutex mutexDebugLog;
+        std::list<std::string> vMsgsBeforeOpenLog;
+
         /**
          * fStartedNewLine is a state variable that will suppress printing of
          * the timestamp when multiple calls are made that don't end in a
@@ -91,6 +98,10 @@ namespace BCLog {
 
         /** Returns whether logs will be written to any output */
         bool Enabled() const { return fPrintToConsole || fPrintToDebugLog; }
+
+        fs::path GetDebugLogPath() const;
+        bool OpenDebugLog();
+        void ShrinkDebugFile();
     };
 
 } // namespace BCLog
@@ -139,9 +150,5 @@ template<typename... Args> std::string FormatStringFromLogArgs(const char *fmt, 
         LogPrintf(__VA_ARGS__);                                                     \
     }                                                                               \
 } while(0)
-
-fs::path GetDebugLogPath();
-bool OpenDebugLog();
-void ShrinkDebugFile();
 
 #endif // BITCOIN_LOGGING_H

--- a/src/logging.h
+++ b/src/logging.h
@@ -28,8 +28,6 @@ extern const char * const DEFAULT_DEBUGLOGFILE;
 
 extern bool fLogIPs;
 
-extern std::atomic<uint32_t> logCategories;
-
 struct CLogCategoryActive
 {
     std::string category;
@@ -82,6 +80,9 @@ namespace BCLog {
          */
         std::atomic_bool fStartedNewLine{true};
 
+        /** Log categories bitfield. */
+        std::atomic<uint32_t> logCategories{0};
+
         std::string LogTimestampStr(const std::string& str);
 
     public:
@@ -102,6 +103,13 @@ namespace BCLog {
         fs::path GetDebugLogPath() const;
         bool OpenDebugLog();
         void ShrinkDebugFile();
+
+        uint32_t GetCategoryMask() const { return logCategories.load(); }
+        void EnableCategory(LogFlags flag);
+        void DisableCategory(LogFlags flag);
+        bool WillLogCategory(LogFlags category) const;
+
+        bool DefaultShrinkDebugFile() const;
     };
 
 } // namespace BCLog
@@ -109,9 +117,9 @@ namespace BCLog {
 extern BCLog::Logger* const g_logger;
 
 /** Return true if log accepts specified category */
-static inline bool LogAcceptCategory(uint32_t category)
+static inline bool LogAcceptCategory(BCLog::LogFlags category)
 {
-    return (logCategories.load(std::memory_order_relaxed) & category) != 0;
+    return g_logger->WillLogCategory(category);
 }
 
 /** Returns a string with the supported log categories */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2140,9 +2140,7 @@ CAmount GetSeeSaw(const CAmount& blockValue, int nMasternodeCount, int nHeight)
 
     // Use this log to compare the masternode count for different clients
     LogPrintf("Adjusting seesaw at height %d with %d masternodes (without drift: %d) at %ld\n", nHeight,nMasternodeCount, nMasternodeCount - Params().MasternodeCountDrift(), GetTime());
-
-    if (logCategories != BCLog::NONE)
-        LogPrintf("%s: moneysupply=%s, nodecoins=%s \n", __func__, FormatMoney(nMoneySupply).c_str(), FormatMoney(mNodeCoins).c_str());
+    LogPrintf("%s: moneysupply=%s, nodecoins=%s \n", __func__, FormatMoney(nMoneySupply).c_str(), FormatMoney(mNodeCoins).c_str());
 
     CAmount ret = 0;
     if (mNodeCoins == 0) {
@@ -4282,8 +4280,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
                     REJECT_INVALID, "bad-cb-payee");
             }
         } else {
-            if (logCategories != BCLog::NONE)
-                LogPrintf("%s: Masternode payment check skipped on sync - skipping IsBlockPayeeValid()\n", __func__);
+            LogPrint(BCLog::MASTERNODE, "%s: Masternode payment check skipped on sync - skipping IsBlockPayeeValid()\n", __func__);
         }
     }
 
@@ -5780,8 +5777,7 @@ bool static ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vR
     CNodeState* state = State(pfrom->GetId());
     if (state == NULL)
         return false;
-    if (logCategories != BCLog::NONE)
-        LogPrintf("received: %s (%u bytes) peer=%d, chainheight=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->id, chainActive.Height());
+    LogPrintf("received: %s (%u bytes) peer=%d, chainheight=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->id, chainActive.Height());
     if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0) {
         LogPrintf("dropmessagestest DROPPING RECV MESSAGE\n");
         return true;
@@ -6014,8 +6010,7 @@ bool static ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vR
                 if (pfrom) {
                     pfrom->PushMessage("getblocks", chainActive.GetLocator(mapBlockIndex[inv.hash]), uint256(0));
                 }
-                if (logCategories != BCLog::NONE)
-                    printf("force request: %s\n", inv.ToString().c_str());
+                printf("force request: %s\n", inv.ToString().c_str());
             }
 
             // Track requests for our stuff
@@ -6115,9 +6110,7 @@ bool static ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vR
         // we must use CBlocks, as CBlockHeaders won't include the 0x00 nTx count at the end
         std::vector<CBlock> vHeaders;
         int nLimit = MAX_HEADERS_RESULTS;
-        if (logCategories != BCLog::NONE)
-            LogPrintf("getheaders %d to %s from peer=%d\n", (pindex ? pindex->nHeight : -1), hashStop.ToString(),
-                pfrom->id);
+        LogPrintf("getheaders %d to %s from peer=%d\n", (pindex ? pindex->nHeight : -1), hashStop.ToString(), pfrom->id);
         for (; pindex; pindex = chainActive.Next(pindex)) {
             vHeaders.push_back(pindex->GetBlockHeader());
             if (--nLimit <= 0 || pindex->GetBlockHash() == hashStop)

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1715,9 +1715,7 @@ bool CBudgetVote::SignatureValid(bool fSignatureCheck)
     CMasternode* pmn = mnodeman.Find(vin);
 
     if (pmn == NULL) {
-        if (logCategories != BCLog::NONE){
-            LogPrint(BCLog::MASTERNODE,"CBudgetVote::SignatureValid() - Unknown Masternode - %s\n", vin.prevout.hash.ToString());
-        }
+        LogPrint(BCLog::MASTERNODE,"CBudgetVote::SignatureValid() - Unknown Masternode - %s\n", vin.prevout.hash.ToString());
         return false;
     }
 

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -282,7 +282,7 @@ QString TransactionDesc::toHTML(CWallet* wallet, CWalletTx& wtx, TransactionReco
     //
     // Debug view
     //
-    if (logCategories != BCLog::NONE) {
+    if (!GetBoolArg("-shrinkdebugfile", g_logger->DefaultShrinkDebugFile())) {
         strHTML += "<hr><br>" + tr("Debug information") + "<br><br>";
         for (const CTxIn& txin : wtx.vin)
             if (wallet->IsMine(txin))

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -490,19 +490,17 @@ UniValue setmocktime(const UniValue& params, bool fHelp) {
 void EnableOrDisableLogCategories(UniValue cats, bool enable) {
     cats = cats.get_array();
     for (unsigned int i = 0; i < cats.size(); ++i) {
-        uint32_t flag = 0;
         std::string cat = cats[i].get_str();
-        if (!GetLogCategory(&flag, &cat)) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "unknown logging category " + cat);
-        }
-        if (flag == BCLog::NONE) {
-            return;
-        }
+
+        bool success;
         if (enable) {
-            g_logger->EnableCategory(static_cast<BCLog::LogFlags>(flag));
+            success = g_logger->EnableCategory(cat);
         } else {
-            g_logger->DisableCategory(static_cast<BCLog::LogFlags>(flag));
+            success = g_logger->DisableCategory(cat);
         }
+
+        if (!success)
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "unknown logging category " + cat);
     }
 }
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -487,18 +487,23 @@ UniValue setmocktime(const UniValue& params, bool fHelp) {
     return NullUniValue;
 }
 
-uint32_t getCategoryMask(UniValue cats) {
+void EnableOrDisableLogCategories(UniValue cats, bool enable) {
     cats = cats.get_array();
-    uint32_t mask = 0;
     for (unsigned int i = 0; i < cats.size(); ++i) {
         uint32_t flag = 0;
         std::string cat = cats[i].get_str();
         if (!GetLogCategory(&flag, &cat)) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "unknown logging category " + cat);
         }
-        mask |= flag;
+        if (flag == BCLog::NONE) {
+            return;
+        }
+        if (enable) {
+            g_logger->EnableCategory(static_cast<BCLog::LogFlags>(flag));
+        } else {
+            g_logger->DisableCategory(static_cast<BCLog::LogFlags>(flag));
+        }
     }
-    return mask;
 }
 
 UniValue logging(const UniValue& params, bool fHelp)
@@ -521,25 +526,27 @@ UniValue logging(const UniValue& params, bool fHelp)
         );
     }
 
-    uint32_t originalLogCategories = logCategories;
+    uint32_t original_log_categories = g_logger->GetCategoryMask();
     if (params.size() > 0 && params[0].isArray()) {
-        logCategories |= getCategoryMask(params[0]);
+        EnableOrDisableLogCategories(params[0], true);
     }
 
     if (params.size() > 1 && params[1].isArray()) {
-        logCategories &= ~getCategoryMask(params[1]);
+        EnableOrDisableLogCategories(params[1], false);
     }
+
+    uint32_t updated_log_categories = g_logger->GetCategoryMask();
+    uint32_t changed_log_categories = original_log_categories ^ updated_log_categories;
 
     // Update libevent logging if BCLog::LIBEVENT has changed.
     // If the library version doesn't allow it, UpdateHTTPServerLogging() returns false,
     // in which case we should clear the BCLog::LIBEVENT flag.
     // Throw an error if the user has explicitly asked to change only the libevent
     // flag and it failed.
-    uint32_t changedLogCategories = originalLogCategories ^ logCategories;
-    if (changedLogCategories & BCLog::LIBEVENT) {
-        if (!UpdateHTTPServerLogging(logCategories & BCLog::LIBEVENT)) {
-            logCategories &= ~BCLog::LIBEVENT;
-            if (changedLogCategories == BCLog::LIBEVENT) {
+    if (changed_log_categories & BCLog::LIBEVENT) {
+        if (!UpdateHTTPServerLogging(g_logger->WillLogCategory(BCLog::LIBEVENT))) {
+            g_logger->DisableCategory(BCLog::LIBEVENT);
+            if (changed_log_categories == BCLog::LIBEVENT) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "libevent logging cannot be updated when using libevent before v2.1.1.");
             }
         }

--- a/src/test/test_prcycoin.cpp
+++ b/src/test/test_prcycoin.cpp
@@ -34,7 +34,6 @@ struct TestingSetup {
     TestingSetup() {
         RandomInit();
         SetupEnvironment();
-        g_logger->m_print_to_file = false; // don't want to write to debug.log file
         fCheckBlockIndex = false;
         SelectParams(CBaseChainParams::MAIN);
         noui_connect();

--- a/src/test/test_prcycoin.cpp
+++ b/src/test/test_prcycoin.cpp
@@ -34,7 +34,7 @@ struct TestingSetup {
     TestingSetup() {
         RandomInit();
         SetupEnvironment();
-        g_logger->fPrintToDebugLog = false; // don't want to write to debug.log file
+        g_logger->m_print_to_file = false; // don't want to write to debug.log file
         fCheckBlockIndex = false;
         SelectParams(CBaseChainParams::MAIN);
         noui_connect();

--- a/src/test/test_prcycoin.cpp
+++ b/src/test/test_prcycoin.cpp
@@ -34,7 +34,7 @@ struct TestingSetup {
     TestingSetup() {
         RandomInit();
         SetupEnvironment();
-        fPrintToDebugLog = true; // don't want to write to debug.log file
+        g_logger->fPrintToDebugLog = false; // don't want to write to debug.log file
         fCheckBlockIndex = false;
         SelectParams(CBaseChainParams::MAIN);
         noui_connect();

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -93,7 +93,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
                 }
             }
         }
-        if (logCategories != BCLog::NONE) {
+        if (!GetBoolArg("-shrinkdebugfile", g_logger->DefaultShrinkDebugFile())) {
             for (int64_t n : vSorted)
                 LogPrintf("%+d  ", n);
             LogPrintf("|  ");

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -435,6 +435,14 @@ void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet,
     ClearDatadirCache();
 }
 
+fs::path AbsPathForConfigVal(const fs::path& path, bool net_specific)
+{
+    if (path.is_absolute()) {
+        return path;
+    }
+    return fs::absolute(path, GetDataDir(net_specific));
+}
+
 #ifndef WIN32
 fs::path GetPidFile()
 {

--- a/src/util.h
+++ b/src/util.h
@@ -60,7 +60,7 @@ bool SetupNetworking();
 template<typename... Args>
 bool error(const char* fmt, const Args&... args)
 {
-    LogPrintStr("ERROR: " + tfm::format(fmt, args...) + "\n");
+    LogPrintf("ERROR: %s\n", tfm::format(fmt, args...));
     return false;
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -185,6 +185,7 @@ void TraceThread(const char* name, Callable func)
     }
 }
 
+fs::path AbsPathForConfigVal(const boost::filesystem::path& path, bool net_specific = true);
 bool PointHashingSuccessively(const CPubKey& pk, const unsigned char* tweak, unsigned char* out);
 
 #endif // BITCOIN_UTIL_H

--- a/src/util.h
+++ b/src/util.h
@@ -8,7 +8,7 @@
 
 /**
  * Server/client environment: argument handling, config file parsing,
- * logging, thread wrappers
+ * thread wrappers
  */
 #ifndef BITCOIN_UTIL_H
 #define BITCOIN_UTIL_H
@@ -19,6 +19,7 @@
 
 #include "compat.h"
 #include "fs.h"
+#include "logging.h"
 #include "tinyformat.h"
 #include "utiltime.h"
 #include "util/threadnames.h"
@@ -47,92 +48,14 @@ extern int keysLoaded;
 extern bool fSucessfullyLoaded;
 extern std::vector<int64_t> obfuScationDenominations;
 extern std::string strBudgetMode;
-extern std::atomic<uint32_t> logCategories;
+
 extern std::map<std::string, std::string> mapArgs;
 extern std::map<std::string, std::vector<std::string> > mapMultiArgs;
-extern bool fPrintToConsole;
-extern bool fPrintToDebugLog;
+
 extern std::string strMiscWarning;
-extern bool fLogTimestamps;
-extern bool fLogIPs;
-extern volatile bool fReopenDebugLog;
 
 void SetupEnvironment();
 bool SetupNetworking();
-
-struct CLogCategoryActive
-{
-    std::string category;
-    bool active;
-};
-
-namespace BCLog {
-    enum LogFlags : uint32_t {
-        NONE        = 0,
-        NET         = (1 <<  0),
-        TOR         = (1 <<  1),
-        MEMPOOL     = (1 <<  2),
-        HTTP        = (1 <<  3),
-        BENCH       = (1 <<  4),
-        ZMQ         = (1 <<  5),
-        DB          = (1 <<  6),
-        RPC         = (1 <<  7),
-        ESTIMATEFEE = (1 <<  8),
-        ADDRMAN     = (1 <<  9),
-        SELECTCOINS = (1 << 10),
-        REINDEX     = (1 << 11),
-        CMPCTBLOCK  = (1 << 12),
-        RAND        = (1 << 13),
-        PRUNE       = (1 << 14),
-        PROXY       = (1 << 15),
-        MEMPOOLREJ  = (1 << 16),
-        LIBEVENT    = (1 << 17),
-        COINDB      = (1 << 18),
-        QT          = (1 << 19),
-        LEVELDB     = (1 << 20),
-        STAKING     = (1 << 21),
-        MASTERNODE  = (1 << 22),
-        MNBUDGET    = (1 << 23),
-        POA         = (1 << 24),
-        SUPPLY      = (1 << 25),
-        ALL         = ~(uint32_t)0,
-    };
-}
-
-/** Return true if log accepts specified category */
-static inline bool LogAcceptCategory(uint32_t category)
-{
-    return (logCategories.load(std::memory_order_relaxed) & category) != 0;
-}
-
-/** Returns a string with the log categories. */
-std::string ListLogCategories();
-/** Returns a vector of the active log categories. */
-std::vector<CLogCategoryActive> ListActiveLogCategories();
-/** Return true if str parses as a log category and set the flags in f */
-bool GetLogCategory(uint32_t *f, const std::string *str);
-/** Send a string to the log output */
-int LogPrintStr(const std::string& str);
-
-/** Get format string from VA_ARGS for error reporting */
-template<typename... Args> std::string FormatStringFromLogArgs(const char *fmt, const Args&... args) { return fmt; }
-
-#define LogPrintf(...) do {                                                         \
-    std::string _log_msg_; /* Unlikely name to avoid shadowing variables */         \
-    try {                                                                           \
-        _log_msg_ = tfm::format(__VA_ARGS__);                                       \
-    } catch (tinyformat::format_error &e) {                                               \
-        /* Original format string will have newline so don't add one here */        \
-        _log_msg_ = "Error \"" + std::string(e.what()) + "\" while formatting log message: " + FormatStringFromLogArgs(__VA_ARGS__); \
-    }                                                                               \
-    LogPrintStr(_log_msg_);                                                         \
-} while(0)
-
-#define LogPrint(category, ...) do {                                                \
-    if (LogAcceptCategory((category))) {                                            \
-        LogPrintf(__VA_ARGS__);                                                     \
-    }                                                                               \
-} while(0)
 
 template<typename... Args>
 bool error(const char* fmt, const Args&... args)
@@ -162,9 +85,7 @@ void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet, std::map
 fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
 fs::path GetTempPath();
-fs::path GetDebugLogPath();
-bool OpenDebugLog();
-void ShrinkDebugFile();
+
 void runCommand(std::string strCommand);
 
 inline bool IsSwitchChar(char c)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3949,9 +3949,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
                 if (it != mapBlockIndex.end()) {
                     pindex = it->second;
                 } else {
-                    if (logCategories != BCLog::NONE) {
-                        LogPrintf("%s: CreateCoinStake() failed to find block index\n", __func__);
-                    }
+                    LogPrintf("%s: CreateCoinStake() failed to find block index\n", __func__);
                     continue;
                 }
 


### PR DESCRIPTION
> Implemented on top of:
> 
> * [x]  [[Util] tinyformat / LogPrint backports #1449](https://github.com/PIVX-Project/PIVX/pull/1449)
> * [x]  [[Util] LogAcceptCategory: use uint32_t rather than sets of strings #1437](https://github.com/PIVX-Project/PIVX/pull/1437)
> * [x]  [[Core] Add -debugexclude option #1439](https://github.com/PIVX-Project/PIVX/pull/1439)
> * [x]  [[Util] Buffer log messages and explicitly open logs #1450](https://github.com/PIVX-Project/PIVX/pull/1450)
> * [x]  [[RPC] Add logging RPC #1451](https://github.com/PIVX-Project/PIVX/pull/1451)
> * [x]  [[Init] Add `-debuglogfile` option #1455](https://github.com/PIVX-Project/PIVX/pull/1455)
> 
> This creates a new class BCLog::Logger to encapsulate all global logging configuration and state.
> 
> Adapted from
> 
> * [MOVEONLY: Move logging code from util.{h,cpp} to new files. bitcoin/bitcoin#13021](https://github.com/bitcoin/bitcoin/pull/13021)
> * [util: Refactor logging code into a global object bitcoin/bitcoin#12954](https://github.com/bitcoin/bitcoin/pull/12954)

from https://github.com/PIVX-Project/PIVX/pull/1459
