### PR TITLE
[Upstream] [Output] Log network message receives as "net" debug category

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5777,7 +5777,7 @@ bool static ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vR
     CNodeState* state = State(pfrom->GetId());
     if (state == NULL)
         return false;
-    LogPrintf("received: %s (%u bytes) peer=%d, chainheight=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->id, chainActive.Height());
+    LogPrint(BCLog::NET, "received: %s (%u bytes) peer=%d, chainheight=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->id, chainActive.Height());
     if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0) {
         LogPrintf("dropmessagestest DROPPING RECV MESSAGE\n");
         return true;


### PR DESCRIPTION
This commit cleans up the excessive logging from ProcessMessage.

coming from this commit: https://github.com/furszy/PIVX/commit/d07e1a80b900161dec5f388fcd5ed1a7ec537524
(it was merged as part of another Pull Request that we have not completed yet)