### PR TITLE
[Upstream] [Consensus] Require standard transactions for testnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -352,7 +352,7 @@ public:
         fMiningRequiresPeers = true;
         fAllowMinDifficultyBlocks = false;
         fDefaultConsistencyChecks = false;
-        fRequireStandard = false;
+        fRequireStandard = true;
         fMineBlocksOnDemand = false;
         fTestnetToBeDeprecatedFieldRPC = true;
 


### PR DESCRIPTION
Simple backport
> This brings testnet more in-line with the consensus requirements that are present on mainnet.

from https://github.com/PIVX-Project/PIVX/pull/551