### PR TITLE
[Qt] Fix -Wformat-invalid-specifier warning for 2FA

### DIFF
--- a/src/qt/2faqrdialog.cpp
+++ b/src/qt/2faqrdialog.cpp
@@ -73,9 +73,9 @@ void TwoFAQRDialog::update()
     QSettings settings;
     int digits = settings.value("2fadigits").toInt();
     if (digits == 8) {
-        uri.sprintf("otpauth://totp/PRCY:QT%20Wallet?secret=%s&issuer=prcycoin&algorithm=SHA1&digits=8&period=30", addr.c_str());
+        uri.sprintf("otpauth://totp/PRCY:QT Wallet?secret=%s&issuer=prcycoin&algorithm=SHA1&digits=8&period=30", addr.c_str());
     } else if (digits == 6) {
-        uri.sprintf("otpauth://totp/PRCY:QT%20Wallet?secret=%s&issuer=prcycoin&algorithm=SHA1&digits=6&period=30", addr.c_str());
+        uri.sprintf("otpauth://totp/PRCY:QT Wallet?secret=%s&issuer=prcycoin&algorithm=SHA1&digits=6&period=30", addr.c_str());
     }
 
     infoText = "Recovery Key: ";


### PR DESCRIPTION
This warning was coming up due to use %20 for the spacing when it was not needed as the uri is a string.