### PR TITLE
[Upstream] [Build] Add flag for enabling thread_local

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -181,6 +181,12 @@ AC_ARG_ENABLE([glibc-back-compat],
   [use_glibc_compat=$enableval],
   [use_glibc_compat=no])
 
+AC_ARG_ENABLE([threadlocal],
+  [AS_HELP_STRING([--enable-threadlocal],
+  [enable features that depend on the c++ thread_local keyword (currently just thread names in debug logs). (default is to enabled if there is platform support and glibc-back-compat is not enabled)])],
+  [use_thread_local=$enableval],
+  [use_thread_local=auto])
+
 AC_ARG_ENABLE([asm],
   [AS_HELP_STRING([--enable-asm],
   [Enable assembly routines (default is yes)])],


### PR DESCRIPTION
> * When aiming for glibc compatibility, don't use thread_local.
>   Ensures we're meeting the backwards compatibility target with gitian.
> * Add a flag --enable-threadlocal, which, when specified, will
>   enable/disable thread_local regardless of the value of glibc_compat.
> * MingW, Darwin, and FreeBSD have a buggy thread_local, don't use it.

Simple backport
from https://github.com/PIVX-Project/PIVX/pull/1390