### PR TITLE
[Fix] Missed return in OpenNetworkConnection

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1493,6 +1493,8 @@ bool OpenNetworkConnection(const CAddress& addrConnect, bool fCountFailure, CSem
     pnode->fNetworkNode = true;
     if (fOneShot)
         pnode->fOneShot = true;
+
+    return true;
 }
 
 void ThreadMessageHandler() {


### PR DESCRIPTION
This was causing the crash on macOS after #142 