### PR TITLE
[Qt] Hide login when launched with -min

### DIFF
--- a/src/qt/prcycoin.cpp
+++ b/src/qt/prcycoin.cpp
@@ -513,7 +513,7 @@ void BitcoinApplication::initializeResult(int retval)
             window, SLOT(message(QString, QString, unsigned int)));
         QTimer::singleShot(100, paymentServer, SLOT(uiReady()));
         if (pwalletMain) {
-            if (walletModel->getEncryptionStatus() == WalletModel::Locked) {
+            if (walletModel->getEncryptionStatus() == WalletModel::Locked && !GetBoolArg("-min", false)) {
                 WalletModel::UnlockContext ctx(walletModel->requestUnlock(AskPassphraseDialog::Context::Unlock_Full, true));
                 if (ctx.isValid()) {
                     walletUnlocked = true;


### PR DESCRIPTION
Hide Unlock Wallet when launched with -min
- You still need to login to use it, but the password box is not shown when launched with these parameters
- Everything balance related is still hidden until unlocked