### PR TITLE
[Qt] Move requestedRegisterNodeSignal() outside if statement

### DIFF
--- a/src/qt/prcycoin.cpp
+++ b/src/qt/prcycoin.cpp
@@ -521,7 +521,6 @@ void BitcoinApplication::initializeResult(int retval)
                         pwalletMain->WriteStakingStatus(false);
                     }
                 }
-                Q_EMIT requestedRegisterNodeSignal();
             }
             if (!walletUnlocked && walletModel->getEncryptionStatus() == WalletModel::Unencrypted) {
                 EncryptDialog dlg;
@@ -530,9 +529,9 @@ void BitcoinApplication::initializeResult(int retval)
                 dlg.setStyleSheet(GUIUtil::loadStyleSheet());
                 dlg.exec();
 
-                Q_EMIT requestedRegisterNodeSignal();
                 walletModel->updateStatus();
             }
+            Q_EMIT requestedRegisterNodeSignal();
         }
 #endif
         pollShutdownTimer->start(200);


### PR DESCRIPTION
When using the -min flag, the node would not start to sync because this was not being emitted. Move it so it will be emitted in any cases.