### PR TITLE
[RPC] Add validatestealthaddress

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -319,6 +319,39 @@ UniValue validateaddress(const UniValue& params, bool fHelp)
     return ret;
 }
 
+UniValue validatestealthaddress(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw std::runtime_error(
+                "validatestealthaddress \"prcycoinstealthaddress\"\n"
+                "\nReturn information about the given prcycoin stealth address.\n"
+                "\nArguments:\n"
+                "1. \"prcycoinstealthaddress\"     (string, required) The prcycoin stealth address to validate\n"
+                "\nResult:\n"
+                "{\n"
+                "  \"isvalid\" : true|false,         (boolean) If the address is valid or not. If not, this is the only property returned.\n"
+                "}\n"
+                "\nExamples:\n" +
+                HelpExampleCli("validatestealthaddress", "\"Pap5WCV4SjVMGLyYf98MEX82ErBEMVpg9ViQ1up3aBib6Fz4841SahrRXG6eSNSLBSNvEiGuQiWKXJC3RDfmotKv15oCrh6N2Ym\"") +
+                HelpExampleRpc("validatestealthaddress", "\"Pap5WCV4SjVMGLyYf98MEX82ErBEMVpg9ViQ1up3aBib6Fz4841SahrRXG6eSNSLBSNvEiGuQiWKXJC3RDfmotKv15oCrh6N2Ym\""));
+    EnsureWallet();
+
+    std::string addr = params[0].get_str();
+
+    UniValue ret(UniValue::VOBJ);
+    CPubKey viewKey, spendKey;
+    bool hasPaymentID;
+    uint64_t paymentID;
+    bool isValid = true;
+
+    if (!CWallet::DecodeStealthAddress(addr, viewKey, spendKey, hasPaymentID, paymentID)) {
+        isValid = false;
+    }
+    ret.push_back(Pair("isvalid", isValid));
+
+    return ret;
+}
+
 /**
  * Used by addmultisigaddress / createmultisig:
  */

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -340,6 +340,7 @@ static const CRPCCommand vRPCCommands[] =
         //{"util", "createmultisig", &createmultisig, true, true, false},
         {"util", "logging", &logging, true, false, false},
         // {"util", "validateaddress", &validateaddress, true, false, false}, /* uses wallet if enabled */
+        {"util", "validatestealthaddress", &validatestealthaddress, true, false, false}, /* uses wallet if enabled */
         // {"util", "verifymessage", &verifymessage, true, false, false},
         //{"util", "estimatefee", &estimatefee, true, true, false},
         // {"util", "estimatepriority", &estimatepriority, true, true, false},

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -348,6 +348,7 @@ extern UniValue logging(const UniValue& params, bool fHelp);
 extern UniValue getversion(const UniValue& params, bool fHelp); // in rpcmisc.cpp
 extern UniValue mnsync(const UniValue& params, bool fHelp);
 extern UniValue validateaddress(const UniValue& params, bool fHelp);
+extern UniValue validatestealthaddress(const UniValue& params, bool fHelp);
 extern UniValue createmultisig(const UniValue& params, bool fHelp);
 extern UniValue verifymessage(const UniValue& params, bool fHelp);
 extern UniValue setmocktime(const UniValue& params, bool fHelp);


### PR DESCRIPTION
Similar to validateaddress (which is disabled as it does not work with Stealth addresses), verifies that a Stealth Address is valid.