### PR TITLE
[Qt] New Privacy Settings

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1068,6 +1068,12 @@ void BitcoinGUI::gotoOptionsPage()
 
 void BitcoinGUI::gotoSendCoinsPage(QString addr)
 {
+    QSettings settings;
+    if (settings.value("fLockSendStaking", false).toBool()) {
+       sendCoinsAction->setChecked(false);
+       LogPrintf("Attempt to go to Send tab blocked.\n");
+       return;
+    }
     sendCoinsAction->setChecked(true);
     if (walletFrame) walletFrame->gotoSendCoinsPage(addr);
 }

--- a/src/qt/forms/optionspage.ui
+++ b/src/qt/forms/optionspage.ui
@@ -624,6 +624,29 @@
          </layout>
         </widget>
        </item>
+       <item>
+        <widget class="QGroupBox" name="privacygroupBox">
+         <property name="title">
+          <string>Privacy Settings</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_7">
+          <item>
+           <widget class="QCheckBox" name="hideBalanceStaking">
+            <property name="text">
+             <string>Hide Balance when unlocked for Staking</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="lockSendStaking">
+            <property name="text">
+             <string>Lock &quot;Send&quot; tab when unlocked for Staking</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
       </layout>
      </widget>
     </widget>

--- a/src/qt/historypage.cpp
+++ b/src/qt/historypage.cpp
@@ -235,6 +235,8 @@ void HistoryPage::updateTableData(CWallet* wallet)
                 case 3: /*amount*/
                     if (wallet->IsLocked()) {
                         cell->setData(0, QString("Locked; Hidden"));
+                    } else if (settings.value("fHideBalance", false).toBool()) {
+                        cell->setData(0, QString("Hidden"));
                     } else {
                         cell->setData(0, data);
                     }

--- a/src/qt/historypage.h
+++ b/src/qt/historypage.h
@@ -60,6 +60,7 @@ private:
     QTimeEdit* timeEditFrom;
 
     QString allAddressString="All";
+    QSettings settings;
 
     void initWidgets();
     void connectWidgets();

--- a/src/qt/optionspage.h
+++ b/src/qt/optionspage.h
@@ -102,6 +102,8 @@ private Q_SLOTS:
     void minimizeOnClose_clicked(int);
     void changeDigits(int);
     void alwaysRequest2FA_clicked(int);
+    void hideBalanceStaking_clicked(int);
+    void lockSendStaking_clicked(int);
     void checkForUnlock();
 };
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -21,7 +21,6 @@
 
 #include <QAbstractItemDelegate>
 #include <QPainter>
-#include <QSettings>
 #include <QTimer>
 #include <QtMath>
 
@@ -175,6 +174,10 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
         ui->labelBalance->setText("Locked; Hidden");
         ui->labelUnconfirmed->setText("Locked; Hidden");
         ui->btnLockUnlock->setStyleSheet("border-image: url(:/images/lock) 0 0 0 0 stretch stretch; width: 20px;");
+    } else if (settings.value("fHideBalance", false).toBool()) {
+        ui->labelBalance_2->setText("Hidden");
+        ui->labelBalance->setText("Hidden");
+        ui->labelUnconfirmed->setText("Hidden");
     } else {
         if (stkStatus && !nLastCoinStakeSearchInterval && !fLiteMode) {
             ui->labelBalance_2->setText("Enabling Staking...");
@@ -268,7 +271,6 @@ void OverviewPage::setWalletModel(WalletModel* model)
     updateDisplayUnit();
 
     // Hide orphans
-    QSettings settings;
     hideOrphans(settings.value("fHideOrphans", false).toBool());
 }
 
@@ -493,6 +495,8 @@ void OverviewPage::updateRecentTransactions() {
                     int64_t txTime = wtx.GetComputedTxTime();
                     if (pwalletMain->IsLocked()) {
                         entry->setData(txTime, "Locked; Hidden", "Locked; Hidden", "Locked; Hidden", "Locked; Hidden");
+                    } else if (settings.value("fHideBalance", false).toBool()) {
+                        entry->setData(txTime, "Hidden", "Hidden", "Hidden", "Hidden");
                     } else {
                         entry->setData(txTime, txs[i]["address"] , txs[i]["amount"], txs[i]["id"], txs[i]["type"]);
                     }

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -12,6 +12,7 @@
 #include <QElapsedTimer>
 #include <QDialog>
 #include <QSizeGrip>
+#include <QSettings>
 
 class ClientModel;
 class TransactionFilterProxy;
@@ -84,6 +85,7 @@ private:
     QWidget* balanceSyncCircle;
     QWidget* balanceAnimSyncCircle;
     bool isSyncingBalance=true;
+    QSettings settings;
 
     void initSyncCircle(float percentOfParent);
     void moveSyncCircle(QWidget* anchor, QWidget* animated, int deltaRadius, float degreesPerSecond, float angleOffset=0);

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -124,6 +124,8 @@ void SendCoinsDialog::setBalance(const CAmount& balance, const CAmount& unconfir
     int status = model->getEncryptionStatus();
     if (status == WalletModel::Locked || status == WalletModel::UnlockedForStakingOnly) {
         ui->labelBalance->setText("Locked; Hidden");
+    } else if (settings.value("fHideBalance", false).toBool()) {
+        ui->labelBalance->setText("Hidden");
     } else {
         ui->labelBalance->setText(BitcoinUnits::formatHtmlWithUnit(0, balance, false, BitcoinUnits::separatorAlways));
     }

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -138,6 +138,11 @@ void WalletFrame::gotoOptionsPage()
 
 void WalletFrame::gotoSendCoinsPage(QString addr)
 {
+    QSettings settings;
+    if (settings.value("fLockSendStaking", false).toBool()) {
+       LogPrintf("Attempt to go to Send tab.\n");
+       return;
+    }
     QMap<QString, WalletView*>::const_iterator i;
     for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
         i.value()->gotoSendCoinsPage(addr);

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -9,6 +9,7 @@
 
 #include <QFrame>
 #include <QMap>
+#include <QSettings>
 
 class BitcoinGUI;
 class ClientModel;


### PR DESCRIPTION
Some useful settings for the QT wallet when being used on a shared PC or just for extra privacy.

- Hide Balance when unlocked for Staking
- Lock "Send"tab when unlocked for Staking

New Settings:
![image](https://user-images.githubusercontent.com/2319897/141516324-4e731603-1671-4364-be66-5dbeed180afd.png)

Overview when in use:
![image](https://user-images.githubusercontent.com/2319897/141516306-340b3ae7-9780-4150-90f9-35483649d18c.png)

Attempts to access Send tab when setting enabled is logged in debug.log
![image](https://user-images.githubusercontent.com/2319897/141516517-10fd02b7-8b88-4496-9617-dd39e333bc29.png)
