### PR TITLE
[Trivial] Move additional GetSeeSaw log to "supply" category

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2140,7 +2140,7 @@ CAmount GetSeeSaw(const CAmount& blockValue, int nMasternodeCount, int nHeight)
 
     // Use this log to compare the masternode count for different clients
     LogPrintf("Adjusting seesaw at height %d with %d masternodes (without drift: %d) at %ld\n", nHeight,nMasternodeCount, nMasternodeCount - Params().MasternodeCountDrift(), GetTime());
-    LogPrintf("%s: moneysupply=%s, nodecoins=%s \n", __func__, FormatMoney(nMoneySupply).c_str(), FormatMoney(mNodeCoins).c_str());
+    LogPrint(BCLog::SUPPLY, "%s: moneysupply=%s, nodecoins=%s \n", __func__, FormatMoney(nMoneySupply).c_str(), FormatMoney(mNodeCoins).c_str());
 
     CAmount ret = 0;
     if (mNodeCoins == 0) {


### PR DESCRIPTION
This one slid through when changing the Logging categories recently, so move additional GetSeeSaw log to "supply" category

ex. `GetSeeSaw: moneysupply=60666317.50, nodecoins=1200000.00 `