### PR TITLE
[Qt] Add generateintegratedaddress button

### DIFF
--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -214,7 +214,7 @@
          </spacer>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1">
+         <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,0">
           <property name="spacing">
            <number>6</number>
           </property>
@@ -250,6 +250,16 @@
             </property>
             <property name="readOnly">
              <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pushButtonGenerate">
+            <property name="toolTip">
+             <string>Generate Integrated Address</string>
+            </property>
+            <property name="text">
+             <string/>
             </property>
            </widget>
           </item>

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -50,7 +50,10 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(QWidget* parent) : QDialog(parent, Qt::Wi
     ui->lineEditAddress->setStyleSheet("border:none; background: transparent; text-align:center;");
     ui->pushButtonCP->setStyleSheet("background:transparent;");
     ui->pushButtonCP->setIcon(QIcon(":/icons/editcopy"));
+    ui->pushButtonGenerate->setIcon(QIcon(":/icons/add"));
+    ui->pushButtonGenerate->setStyleSheet("background:transparent;");
     connect(ui->pushButtonCP, SIGNAL(clicked()), this, SLOT(copyAddress()));
+    connect(ui->pushButtonGenerate, SIGNAL(clicked()), this, SLOT(generateAddress()));
 
     //Create privacy account (wallet is unlocked first launch so !pwalletMain->IsLocked() works here)
     if (pwalletMain && !pwalletMain->IsLocked()) {
@@ -228,4 +231,12 @@ void ReceiveCoinsDialog::copyAddress(){
     CWallet* wl = model->getCWallet();
     wl->AllMyPublicAddresses(addrList, accountList);
     clipboard->setText(QString(addrList[0].c_str()));
+}
+
+void ReceiveCoinsDialog::generateAddress(){
+    uint64_t paymentID = 0;
+    QClipboard *clipboard = QApplication::clipboard();
+    std::string address;
+    address = pwalletMain->GenerateIntegratedAddressWithRandomPaymentID("masteraccount", paymentID);
+    clipboard->setText(QString(address.c_str()));
 }

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -53,6 +53,7 @@ public Q_SLOTS:
     void reject();
     void accept();
     void copyAddress();
+    void generateAddress();
 
 protected:
     virtual void keyPressEvent(QKeyEvent* event);


### PR DESCRIPTION
Add generateintegratedaddress button

Currently the only way to generate an integrated address is via Debug Console/Daemon - add a button as seen below

![image](https://user-images.githubusercontent.com/2319897/142262808-7511c741-018e-4d20-8cc0-1b03e89f4d88.png)


This could potentially be expanded upon in future with things such as
- Optional popup of address + Payment ID - allow the user to copy from there
- Expansion of the History screen to display Payment IDs
