### PR TITLE
[Qt] Add PaymentID to revealtxdialog Dialog

### DIFF
--- a/src/qt/forms/revealtxdialog.ui
+++ b/src/qt/forms/revealtxdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>675</width>
-    <height>252</height>
+    <height>290</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -225,6 +225,52 @@
      </item>
      <item>
       <widget class="QLabel" name="lblTxFee">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>415</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutTxPaymentID" stretch="0,1,5">
+     <item>
+      <widget class="QPushButton" name="pushButtonCopyTxPaymentID">
+       <property name="toolTip">
+        <string>Copy Payment ID to clipboard</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_6">
+       <property name="minimumSize">
+        <size>
+         <width>83</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Payment ID</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="lblTxPaymentID">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
          <horstretch>0</horstretch>

--- a/src/qt/historypage.cpp
+++ b/src/qt/historypage.cpp
@@ -146,6 +146,11 @@ void HistoryPage::on_cellClicked(int row, int column)
                 }
                 txdlg.setTxAmount(amount);
                 txdlg.setTxFee(tx.nTxFee);
+                if (tx.hasPaymentID) {
+                    txdlg.setTxPaymentID(tx.paymentID);
+                } else {
+                    txdlg.setTxPaymentID(0);
+                }
             }
         }
         std::string txdlgMsg = "Request from Sender (if applicable)";

--- a/src/qt/revealtxdialog.cpp
+++ b/src/qt/revealtxdialog.cpp
@@ -29,6 +29,10 @@ RevealTxDialog::RevealTxDialog(QWidget *parent) :
     ui->pushButtonCopyTxFee->setStyleSheet("background:transparent;");
     ui->pushButtonCopyTxFee->setIcon(QIcon(":/icons/editcopy"));
     connect(ui->pushButtonCopyTxFee, SIGNAL(clicked()), this, SLOT(copyTxFee()));
+
+    ui->pushButtonCopyTxPaymentID->setStyleSheet("background:transparent;");
+    ui->pushButtonCopyTxPaymentID->setIcon(QIcon(":/icons/editcopy"));
+    connect(ui->pushButtonCopyTxPaymentID, SIGNAL(clicked()), this, SLOT(copyTxPaymentID()));
 }
 
 RevealTxDialog::~RevealTxDialog()
@@ -63,6 +67,16 @@ void RevealTxDialog::setTxFee(CAmount fee)
     ui->lblTxFee->setText(BitcoinUnits::formatHtmlWithUnit(0, fee, false, BitcoinUnits::separatorAlways));
 }
 
+void RevealTxDialog::setTxPaymentID(uint64_t paymentID)
+{
+    if (paymentID == 0) {
+        ui->pushButtonCopyTxPaymentID->hide();
+        ui->label_6->hide();
+        ui->lblTxPaymentID->hide();
+    }
+    ui->lblTxPaymentID->setText(QString::number(paymentID));
+}
+
 void RevealTxDialog::on_buttonBox_accepted()
 {
 
@@ -91,4 +105,9 @@ void RevealTxDialog::copyTxAmount(){
 void RevealTxDialog::copyTxFee(){
     QClipboard *clipboard = QApplication::clipboard();
     clipboard->setText(ui->lblTxFee->text());
+}
+
+void RevealTxDialog::copyTxPaymentID(){
+    QClipboard *clipboard = QApplication::clipboard();
+    clipboard->setText(ui->lblTxPaymentID->text());
 }

--- a/src/qt/revealtxdialog.h
+++ b/src/qt/revealtxdialog.h
@@ -21,6 +21,7 @@ public:
     void setTxPrivKey(QString strPrivKey);
     void setTxAmount(QString amount);
     void setTxFee(CAmount fee);
+    void setTxPaymentID(uint64_t paymentID);
 
 private Q_SLOTS:
     void on_buttonBox_accepted();
@@ -29,6 +30,7 @@ private Q_SLOTS:
     void copyPrivateKey();
     void copyTxAmount();
     void copyTxFee();
+    void copyTxPaymentID();
 
 private:
     Ui::RevealTxDialog *ui;


### PR DESCRIPTION
- Add PaymentID to revealtxdialog Dialog
  - if there is no Payment ID, that line will be hidden

![image](https://user-images.githubusercontent.com/2319897/142289944-3898dce3-966c-4278-8f02-03c456106453.png)
