### PR TITLE
[RPC] Add sendalltostealthaddress

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -40,6 +40,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
         {"rescan", 0},
         {"rescanwallettransactions", 0},
         {"sendtostealthaddress", 1},
+        {"sendalltostealthaddress", 1},
         {"sendtoaddressix", 1},
         {"settxfee", 0},
         {"getreceivedbyaddress", 1},

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -398,6 +398,7 @@ static const CRPCCommand vRPCCommands[] =
         {"wallet", "getdecoyconfirmation", &getdecoyconfirmation, true, false, true},
         {"wallet", "decodestealthaddress", &decodestealthaddress, true, false, true},
         {"wallet", "sendtostealthaddress", &sendtostealthaddress, false, false, true},
+        {"wallet", "sendalltostealthaddress", &sendalltostealthaddress, false, false, true},
         {"wallet", "getbalance", &getbalance, false, false, true},
         {"wallet", "getbalances", &getbalances, false, false, true},
         {"wallet", "generateintegratedaddress", &generateintegratedaddress, true, false, false},

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -258,6 +258,7 @@ extern UniValue setdecoyconfirmation(const UniValue& params, bool fHelp);
 extern UniValue getdecoyconfirmation(const UniValue& params, bool fHelp);
 extern UniValue decodestealthaddress(const UniValue& params, bool fHelp);
 extern UniValue sendtostealthaddress(const UniValue& params, bool fHelp);
+extern UniValue sendalltostealthaddress(const UniValue& params, bool fHelp);
 extern UniValue createprivacysubaddress(const UniValue& params, bool fHelp);
 extern UniValue getwalletinfo(const UniValue& params, bool fHelp);
 extern UniValue gettxcount(const UniValue& params, bool fHelp);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2781,6 +2781,34 @@ UniValue sendtostealthaddress(const UniValue& params, bool fHelp)
     return wtx.GetHash().GetHex();
 }
 
+UniValue sendalltostealthaddress(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw std::runtime_error(
+                "sendalltostealthaddress \"prcystealthaddress\"\n"
+                "\nSend all PRCY to stealth address\n" +
+                HelpRequiringPassphrase() +
+                "\nArguments:\n"
+                "1. \"prcystealthaddress\"  (string, required) The prcycoin stealth address to send to.\n"
+                "\nResult:\n"
+                "\"transactionid\"  (string) The transaction id.\n"
+                "\nExamples:\n" +
+                HelpExampleCli("sendalltostealthaddress", "\"Pap5WCV4SjVMGLyYf98MEX82ErBEMVpg9ViQ1up3aBib6Fz4841SahrRXG6eSNSLBSNvEiGuQiWKXJC3RDfmotKv15oCrh6N2Ym\" 0.1"));
+
+    std::string stealthAddr = params[0].get_str();
+
+    EnsureWalletIsUnlocked();
+
+    // Wallet comments
+    CWalletTx wtx;
+
+    if (!pwalletMain->SendAll(stealthAddr)) {
+        throw JSONRPCError(RPC_WALLET_ERROR,
+                           "Cannot create transaction.");
+    }
+    return wtx.GetHash().GetHex();
+}
+
 UniValue setdecoyconfirmation(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)


### PR DESCRIPTION
`sendalltostealthaddress StealthAddress`
Sends the remaining balance of the wallet to an address

Makes it much easier to sweep an old wallet