### PR TITLE
[Qt] Add Generated Integrated Address to dropdown on "Receive" tab

### DIFF
--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -238,5 +238,7 @@ void ReceiveCoinsDialog::generateAddress(){
     QClipboard *clipboard = QApplication::clipboard();
     std::string address;
     address = pwalletMain->GenerateIntegratedAddressWithRandomPaymentID("masteraccount", paymentID);
+    ui->reqAddress->addItem(QString(address.c_str()));
+    ui->reqAddress->setCurrentIndex(ui->reqAddress->count() - 1);
     clipboard->setText(QString(address.c_str()));
 }


### PR DESCRIPTION
Add Generated Integrated Address to dropdown when the user clicks the `+` icon

![image](https://user-images.githubusercontent.com/2319897/143624280-984de60e-a134-47b2-963e-5a8955706f00.png)
