### PR TITLE
[Upstream] [P2P] Do not set extra flags for unfiltered DNS seed results

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2010 Satoshi Nakamoto
-// Copyright (c) 2009-2014 The Bitcoin developers
+// Copyright (c) 2009-2015 The Bitcoin developers
 // Copyright (c) 2014-2015 The Dash developers
 // Copyright (c) 2015-2018 The PIVX developers
 // Copyright (c) 2018-2020 The DAPS Project developers
@@ -16,15 +16,6 @@
 #include <boost/assign/list_of.hpp>
 
 #include <assert.h>
-
-
-std::string CDNSSeedData::getHost(uint64_t requiredServiceBits) const {
-    //use default host for non-filter-capable seeds or if we use the default service bits (NODE_NETWORK)
-    if (!supportsServiceBitsFiltering || requiredServiceBits == NODE_NETWORK)
-        return host;
-
-    return strprintf("x%x.%s", requiredServiceBits, host);
-}
 
 /**
  * Main network

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2014 The Bitcoin developers
+// Copyright (c) 2009-2015 The Bitcoin developers
 // Copyright (c) 2014-2015 The Dash developers
 // Copyright (c) 2015-2018 The PIVX developers
 // Copyright (c) 2018-2020 The DAPS Project developers
@@ -20,11 +20,9 @@
 
 typedef unsigned char MessageStartChars[MESSAGE_START_SIZE];
 
-class CDNSSeedData {
-public:
+struct CDNSSeedData {
     std::string name, host;
     bool supportsServiceBitsFiltering;
-    std::string getHost(uint64_t requiredServiceBits) const;
     CDNSSeedData(const std::string& strName, const std::string& strHost, bool supportsServiceBitsFilteringIn = false) : name(strName), host(strHost), supportsServiceBitsFiltering(supportsServiceBitsFilteringIn) {}
 };
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1224,6 +1224,16 @@ void MapPort(bool) {
 
 #endif
 
+static std::string GetDNSHost(const CDNSSeedData& data, ServiceFlags* requiredServiceBits)
+{
+    //use default host for non-filter-capable seeds or if we use the default service bits (NODE_NETWORK)
+    if (!data.supportsServiceBitsFiltering || *requiredServiceBits == NODE_NETWORK) {
+        *requiredServiceBits = NODE_NETWORK;
+        return data.host;
+    }
+
+    return strprintf("x%x.%s", *requiredServiceBits, data.host);
+}
 
 void ThreadDNSAddressSeed() {
     // goal: only query DNS seeds if address need is acute
@@ -1250,7 +1260,7 @@ void ThreadDNSAddressSeed() {
             std::vector<CNetAddr> vIPs;
             std::vector<CAddress> vAdd;
             ServiceFlags requiredServiceBits = nRelevantServices;
-            if (LookupHost(seed.getHost(requiredServiceBits).c_str(), vIPs, 0, true)) {
+            if (LookupHost(GetDNSHost(seed, &requiredServiceBits).c_str(), vIPs, 0, true)) {
                 for (CNetAddr & ip : vIPs)
                 {
                     int nOneDay = 24 * 3600;


### PR DESCRIPTION
Another one as part of https://github.com/PRCYCoin/PRCYCoin/issues/4

> Backport of [bitcoin#8208](https://github.com/bitcoin/bitcoin/pull/8208) based on top of #1616 (Only the last commit is important here). Part of #1374.
> 
> Original Description:
> 
> > Any flag set in nRelevantServices would propagate to all CAddress results retrieved from the DNS seed, even if that DNS seed does not support filtering.
> > Fix this by making the name adaptation function also update the passed in flags.
> > Furthermore, move that from from DNSSeedData to net. Structs in chainparams should be data only.

from https://github.com/PIVX-Project/PIVX/pull/1618