### PR TITLE
[Upstream] [Core][Cleanup] Add IsRegTestNet() function in chainparams

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -23,7 +23,7 @@ void CActiveMasternode::ManageStatus()
     LogPrint(BCLog::MASTERNODE, "CActiveMasternode::ManageStatus() - Begin\n");
 
     //need correct blocks to send ping
-    if (Params().NetworkID() != CBaseChainParams::REGTEST && !masternodeSync.IsBlockchainSynced()) {
+    if (!Params().IsRegTestNet() && !masternodeSync.IsBlockchainSynced()) {
         status = ACTIVE_MASTERNODE_SYNC_IN_PROCESS;
         LogPrint(BCLog::MASTERNODE, "CActiveMasternode::ManageStatus() - %s\n", GetStatus());
         return;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -104,6 +104,7 @@ public:
     int64_t StartMasternodePayments() const { return nStartMasternodePayments; }
     int64_t Budget_Fee_Confirmations() const { return nBudget_Fee_Confirmations; }
     CBaseChainParams::Network NetworkID() const { return networkID; }
+    bool IsRegTestNet() const { return NetworkID() == CBaseChainParams::REGTEST; }
     int ExtCoinType() const { return nExtCoinType; }
 
     /** Height or Time Based Activations **/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4118,6 +4118,8 @@ bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, bool f
         return state.DoS(50, error("CheckBlockHeader() : proof of work failed"),
             REJECT_INVALID, "high-hash");
 
+    if (Params().IsRegTestNet()) return true;
+
     //PoA specific header checks
     //Check that the header is valid for PoA mining, this check will use a PoA consensus rule
     if (block.IsPoABlockByVersion() && !CheckPoABlockMinedHash(block)) {

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -229,6 +229,7 @@ void CMasternodeSync::ClearFulfilledRequest()
 void CMasternodeSync::Process()
 {
     static int tick = 0;
+    const bool isRegTestNet = Params().IsRegTestNet();
 
     if (tick++ % MASTERNODE_SYNC_TIMEOUT != 0) return;
 
@@ -253,14 +254,13 @@ void CMasternodeSync::Process()
 
     if (RequestedMasternodeAssets == MASTERNODE_SYNC_INITIAL) GetNextAsset();
 
-    if (Params().NetworkID() != CBaseChainParams::REGTEST &&
-        !IsBlockchainSynced()) return;
+    if (!isRegTestNet && !IsBlockchainSynced()) return;
 
     TRY_LOCK(cs_vNodes, lockRecv);
     if (!lockRecv) return;
 
     for (CNode* pnode : vNodes) {
-        if (Params().NetworkID() == CBaseChainParams::REGTEST) {
+        if (isRegTestNet) {
             if (RequestedMasternodeAttempt < 4) {
                 mnodeman.DsegUpdate(pnode);
             } else if (RequestedMasternodeAttempt < 6) {

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -312,7 +312,7 @@ bool CMasternode::IsValidNetAddr()
 {
     // TODO: regtest is fine with any addresses for now,
     // should probably be a bit smarter if one day we start to implement tests for this
-    return Params().NetworkID() == CBaseChainParams::REGTEST ||
+    return Params().IsRegTestNet() ||
            (IsReachable(addr) && addr.IsRoutable());
 }
 
@@ -636,7 +636,7 @@ bool CMasternodeBroadcast::CheckInputsAndAdd(int& nDoS)
     }
 
     bool isLocal = addr.IsRFC1918() || addr.IsLocal();
-    if (Params().NetworkID() == CBaseChainParams::REGTEST) isLocal = false;
+    if (Params().IsRegTestNet()) isLocal = false;
 
     if (!isLocal) Relay();
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -697,7 +697,7 @@ CMasternode* CMasternodeMan::GetMasternodeByRank(int nRank, int64_t nBlockHeight
 void CMasternodeMan::ProcessMasternodeConnections()
 {
     //we don't care about this for regtest
-    if (Params().NetworkID() == CBaseChainParams::REGTEST) return;
+    if (Params().IsRegTestNet()) return;
 
     LOCK(cs_vNodes);
     for (CNode* pnode : vNodes) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -379,9 +379,10 @@ CNode *FindNode(const std::string &addrName) {
 
 CNode *FindNode(const CService &addr) {
     LOCK(cs_vNodes);
+    const bool isRegTestNet = Params().IsRegTestNet();
     for (CNode * pnode : vNodes)
     {
-        if (Params().NetworkID() == CBaseChainParams::REGTEST) {
+        if (isRegTestNet) {
             //if using regtest, just check the IP
             if ((CNetAddr) pnode->addr == (CNetAddr) addr)
                 return (pnode);


### PR DESCRIPTION
> This removes many explicit checks `Params().NetworkID() != CBaseChainParams::REGTEST` / `Params().NetworkID() == CBaseChainParams::REGTEST` making the code more readable.

https://github.com/PIVX-Project/PIVX/pull/1282

Used in an upcoming PR.