### PR TITLE
[Upstream] [Refactor] Move CDiskTxPos/CBlockUndo to txdb.h/undo.h respectively

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -280,35 +280,6 @@ struct CNodeStateStats {
     std::vector<int> vHeightInFlight;
 };
 
-struct CDiskTxPos : public CDiskBlockPos {
-    unsigned int nTxOffset; // after header
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
-    {
-        READWRITE(*(CDiskBlockPos*)this);
-        READWRITE(VARINT(nTxOffset));
-    }
-
-    CDiskTxPos(const CDiskBlockPos& blockIn, unsigned int nTxOffsetIn) : CDiskBlockPos(blockIn.nFile, blockIn.nPos), nTxOffset(nTxOffsetIn)
-    {
-    }
-
-    CDiskTxPos()
-    {
-        SetNull();
-    }
-
-    void SetNull()
-    {
-        CDiskBlockPos::SetNull();
-        nTxOffset = 0;
-    }
-};
-
-
 CAmount GetMinRelayFee(const CTransaction& tx, unsigned int nBytes, bool fAllowFree);
 
 /**
@@ -369,25 +340,6 @@ bool CheckFinalTx(const CTransaction& tx, int flags = -1);
 bool IsStandardTx(const CTransaction& tx, std::string& reason);
 
 bool IsFinalTx(const CTransaction& tx, int nBlockHeight = 0, int64_t nBlockTime = 0);
-
-/** Undo information for a CBlock */
-class CBlockUndo
-{
-public:
-    std::vector<CTxUndo> vtxundo; // for all but the coinbase
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
-    {
-        READWRITE(vtxundo);
-    }
-
-    bool WriteToDisk(CDiskBlockPos& pos, const uint256& hashBlock);
-    bool ReadFromDisk(const CDiskBlockPos& pos, const uint256& hashBlock);
-};
-
 
 /**
  * Closure representing one script verification

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -26,6 +26,34 @@ static const int64_t nMaxDbCache = sizeof(void*) > 4 ? 4096 : 1024;
 //! min. -dbcache in (MiB)
 static const int64_t nMinDbCache = 4;
 
+struct CDiskTxPos : public CDiskBlockPos {
+    unsigned int nTxOffset; // after header
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
+    {
+        READWRITE(*(CDiskBlockPos*)this);
+        READWRITE(VARINT(nTxOffset));
+    }
+
+    CDiskTxPos(const CDiskBlockPos& blockIn, unsigned int nTxOffsetIn) : CDiskBlockPos(blockIn.nFile, blockIn.nPos), nTxOffset(nTxOffsetIn)
+    {
+    }
+
+    CDiskTxPos()
+    {
+        SetNull();
+    }
+
+    void SetNull()
+    {
+        CDiskBlockPos::SetNull();
+        nTxOffset = 0;
+    }
+};
+
 /** CCoinsView backed by the LevelDB coin database (chainstate/) */
 class CCoinsViewDB : public CCoinsView
 {

--- a/src/undo.h
+++ b/src/undo.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_UNDO_H
 #define BITCOIN_UNDO_H
 
+#include "chain.h"
 #include "compressor.h"
 #include "primitives/transaction.h"
 #include "serialize.h"
@@ -72,6 +73,24 @@ public:
     {
         READWRITE(vprevout);
     }
+};
+
+/** Undo information for a CBlock */
+class CBlockUndo
+{
+public:
+    std::vector<CTxUndo> vtxundo; // for all but the coinbase
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
+    {
+        READWRITE(vtxundo);
+    }
+
+    bool WriteToDisk(CDiskBlockPos& pos, const uint256& hashBlock);
+    bool ReadFromDisk(const CDiskBlockPos& pos, const uint256& hashBlock);
 };
 
 #endif // BITCOIN_UNDO_H


### PR DESCRIPTION
> This is PR is the second part of breaking up #1209 into individual narrow-focused PRs. Original commit was cherry-picked from @barrystyle's initial pre-squashed branch (reference branch is at https://github.com/Fuzzbawls/PIVX/commits/pr-1209)
> 
> Here `CDiskTxPos` and `CBlockUndo` are moved out of `main.h` into more appropriate files, namely `txdb.h` and `undo.h`.

from https://github.com/PIVX-Project/PIVX/pull/1319