### PR TITLE
[Upstream] [Consensus] Remove Old message format in CMasternodeBroadcast

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -481,8 +481,7 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
     std::string vchPubKey(pubKeyCollateralAddress.begin(), pubKeyCollateralAddress.end());
     std::string vchPubKey2(pubKeyMasternode.begin(), pubKeyMasternode.end());
 
-    HEX_DATA_STREAM_PROTOCOL(protocolVersion) << addr.ToString() << sigTime << pubKeyCollateralAddress << pubKeyMasternode << protocolVersion;
-    std::string strMessage = HEX_STR(ser);
+    std::string strMessage = GetStrMessage();
 
     if (protocolVersion < masternodePayments.GetMinMasternodePaymentsProto()) {
         LogPrint(BCLog::MASTERNODE,"mnb - ignoring outdated Masternode %s protocol version %d\n", vin.prevout.hash.ToString(), protocolVersion);
@@ -658,8 +657,7 @@ bool CMasternodeBroadcast::Sign(CKey& keyCollateralAddress)
 
     sigTime = GetAdjustedTime();
     std::string ss = addr.ToString();
-    HEX_DATA_STREAM_PROTOCOL(protocolVersion) << addr.ToString() << sigTime << pubKeyCollateralAddress << pubKeyMasternode << protocolVersion;
-    std::string strMessage = HEX_STR(ser);
+    std::string strMessage = GetStrMessage();
 
     if (!obfuScationSigner.SignMessage(strMessage, errorMessage, sig, keyCollateralAddress)) {
         LogPrint(BCLog::MASTERNODE,"CMasternodeBroadcast::Sign() - Error: %s\n", errorMessage);
@@ -678,28 +676,19 @@ bool CMasternodeBroadcast::VerifySignature()
 {
     std::string errorMessage;
 
-    if(!obfuScationSigner.VerifyMessage(pubKeyCollateralAddress, sig, GetNewStrMessage(), errorMessage)
-       && !obfuScationSigner.VerifyMessage(pubKeyCollateralAddress, sig, GetOldStrMessage(), errorMessage))
+    if(!obfuScationSigner.VerifyMessage(pubKeyCollateralAddress, sig, GetStrMessage(), errorMessage))
         return error("CMasternodeBroadcast::VerifySignature() - Error: %s", errorMessage);
 
     return true;
 }
 
-std::string CMasternodeBroadcast::GetOldStrMessage()
-{
-    HEX_DATA_STREAM_PROTOCOL(protocolVersion) << addr.ToString() << sigTime << pubKeyCollateralAddress << pubKeyMasternode << protocolVersion;
-    std::string strMessage = HEX_STR(ser);
-    return strMessage;
-}
-
-std:: string CMasternodeBroadcast::GetNewStrMessage()
+std::string CMasternodeBroadcast::GetStrMessage()
 {
     HEX_DATA_STREAM_PROTOCOL(protocolVersion) << addr.ToString() << sigTime << pubKeyCollateralAddress << pubKeyMasternode << protocolVersion;
     std::string strMessage = HEX_STR(ser);
 
     return strMessage;
 }
-
 
 CMasternodePing::CMasternodePing()
 {

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -295,8 +295,7 @@ public:
     bool Sign(CKey& keyCollateralAddress);
     bool VerifySignature();
     void Relay();
-    std::string GetOldStrMessage();
-    std::string GetNewStrMessage();
+    std::string GetStrMessage();
 
     ADD_SERIALIZE_METHODS;
 


### PR DESCRIPTION
> The new message format was introduced with protocol 70914 (v3.1.0) and the old message was retained in order to be able to still check against it during the update. After 4 more protocol upgrades we can safely assume that no masternode has MNANNOUNCE message signed with the old format so we can remove it from the code.
> 
> The function `GetOldStrMessage()` is removed and `GetNewStrMessage()` is renamed to `GetStrMessage()`.

from https://github.com/PIVX-Project/PIVX/pull/1001

Removing some duplicate and unnecessary code.
We actually never introduced a different message format, but have them as 2 duplicate functions.
- Our `GetOldStrMessage === GetNewStrMessage` anyway
- Due to above, there was a double check of the same `strMessage` in `obfuScationSigner.VerifyMessage`
- Use `GetStrMessage()` function instead of repeating the code in other functions