### PR TITLE
[Testnet] Fix PoA / Remove Unused Code

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2334,18 +2334,7 @@ CAmount GetSeeSaw(const CAmount& blockValue, int nMasternodeCount, int nHeight)
 int64_t GetMasternodePayment(int nHeight, int64_t blockValue, int nMasternodeCount)
 {
     int64_t ret = 0;
-
     int64_t blockValueForSeeSaw = blockValue;
-
-    if (Params().NetworkID() == CBaseChainParams::TESTNET) {
-        if (nHeight < 200)
-            return 0;
-        if (nHeight < 4500)
-            ret = blockValue / 5;
-        else if (nHeight >= 4500) {
-            return GetSeeSaw(blockValueForSeeSaw, nMasternodeCount, nHeight);
-        }
-    }
 
     if (nHeight >= Params().LAST_POW_BLOCK()) {
         return GetSeeSaw(blockValueForSeeSaw, nMasternodeCount, nHeight);

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -837,11 +837,6 @@ CAmount CBudgetManager::GetTotalBudget(int nHeight)
 {
     if (chainActive.Tip() == NULL) return 0;
 
-    if (Params().NetworkID() == CBaseChainParams::TESTNET) {
-        CAmount nSubsidy = 500 * COIN;
-        return ((nSubsidy / 100) * 10) * 146;
-    }
-
     //get block value and calculate from that
     CAmount nSubsidy = 0;
     if (nHeight <= Params().LAST_POW_BLOCK() && nHeight >= 151200) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -515,7 +515,12 @@ CBlockTemplate* CreateNewPoABlock(const CScript& scriptPubKeyIn, const CPubKey& 
     pblock->nTime = GetAdjustedTime();
 
     //compute PoA block reward
-    CAmount nReward = pblock->posBlocksAudited.size() * 0.25 * COIN;
+    CAmount nReward;
+    if (pindexPrev->nHeight >= Params().HardFork()) {
+        nReward = pblock->posBlocksAudited.size() * 0.25 * COIN;
+    } else {
+        nReward = pblock->posBlocksAudited.size() * 0.5 * COIN;
+    }
     pblock->vtx[0].vout[0].nValue = nReward;
     pblock->vtx[0].txType = TX_TYPE_REVEAL_AMOUNT;
 


### PR DESCRIPTION
- Fix PoA Mining on Testnet
  - Wasn't checking block height for change in nReward at Params().HardFork()
- Remove unused Testnet code in GetMasternodePayment/GetTotalBudget
  - We use the same reward structure on both Mainnet and Testnet, this code is not needed