### PR TITLE
[Trivial] Restore ReprocessBlocks in main.cpp / Rename DisconnectBlocksAndReprocess to DisconnectBlocks

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3430,13 +3430,13 @@ bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, CBlock* 
     return true;
 }
 
-bool DisconnectBlocksAndReprocess(int blocks)
+bool DisconnectBlocks(int blocks)
 {
     LOCK(cs_main);
 
     CValidationState state;
 
-    LogPrintf("DisconnectBlocksAndReprocess: Got command to replay %d blocks\n", blocks);
+    LogPrintf("%s: Got command to replay %d blocks\n", __func__, blocks);
     for (int i = 0; i <= blocks; i++)
         DisconnectTip(state);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3430,14 +3430,14 @@ bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, CBlock* 
     return true;
 }
 
-bool DisconnectBlocks(int blocks)
+bool DisconnectBlocks(int nBlocks)
 {
     LOCK(cs_main);
 
     CValidationState state;
 
-    LogPrintf("%s: Got command to replay %d blocks\n", __func__, blocks);
-    for (int i = 0; i <= blocks; i++)
+    LogPrintf("%s: Got command to replay %d blocks\n", __func__, nBlocks);
+    for (int i = 0; i <= nBlocks; i++)
         DisconnectTip(state);
 
     return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3448,7 +3448,7 @@ void ReprocessBlocks(int nBlocks)
     std::map<uint256, int64_t>::iterator it = mapRejectedBlocks.begin();
     while (it != mapRejectedBlocks.end()) {
         //use a window twice as large as is usual for the nBlocks we want to reset
-        if ((*it).second > GetTime() - (nBlocks * 60 * 5)) {
+        if ((*it).second > GetTime() - (nBlocks * Params().TargetSpacing() * 2)) {
             BlockMap::iterator mi = mapBlockIndex.find((*it).first);
             if (mi != mapBlockIndex.end() && (*mi).second) {
                 LOCK(cs_main);

--- a/src/main.h
+++ b/src/main.h
@@ -381,7 +381,7 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex);
 bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins, bool* pfClean = NULL);
 
 /** Reprocess a number of blocks to try and get on the correct chain again **/
-bool DisconnectBlocksAndReprocess(int blocks);
+bool DisconnectBlocks(int blocks);
 
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins */
 bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins, bool fJustCheck, bool fAlreadyChecked = false);

--- a/src/main.h
+++ b/src/main.h
@@ -381,7 +381,7 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex);
 bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins, bool* pfClean = NULL);
 
 /** Reprocess a number of blocks to try and get on the correct chain again **/
-bool DisconnectBlocks(int blocks);
+bool DisconnectBlocks(int nBlocks);
 void ReprocessBlocks(int nBlocks);
 
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins */

--- a/src/main.h
+++ b/src/main.h
@@ -382,6 +382,7 @@ bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex
 
 /** Reprocess a number of blocks to try and get on the correct chain again **/
 bool DisconnectBlocks(int blocks);
+void ReprocessBlocks(int nBlocks);
 
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins */
 bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins, bool fJustCheck, bool fAlreadyChecked = false);


### PR DESCRIPTION
> Chengeset:
> 
> * ~~move ProcessSpork, GetSporkValue, IsSporkActive, ExecuteSpork and mapSporksActive to CSporkManager~~
> * ~~move Sign, CheckSignature, Relay to CSporkMessage~~
> * move ReprocessBlocks out of sporks to main.cpp / rename DisconnectBlocksAndReprocess to DisconnectBlocks
> * ~~rename SporkKey to SporkPubKey~~
> * ~~bugfix: only set strMasterPrivKey if spork signature produced by that key was verified successfully~~
> * ~~few log format changes, cleaned up includes~~
> * ~~Protect CSporkManager with critical section~~
> * ~~bugfix:  do not accept sporks with nTimeSigned way too far into the future~~
> * ~~remove unused sporks: 7, 11, 12~~
> * ~~Refactor code to get rid of repeated if/else blocks (introduce CSporkDef)~~
> 
> Mostly based off of:
> 
> * ~~[Refactor/fix spork dashpay/dash#922](https://github.com/dashpay/dash/pull/922)~~
> * ~~[Protect CSporkManager with critical section dashpay/dash#2213](https://github.com/dashpay/dash/pull/2213)~~
> * ~~[Do not accept sporks with nTimeSigned way too far into the future dashpay/dash#2578](https://github.com/dashpay/dash/pull/2578)~~
> * ~~[Remove a few sporks which are not used anymore dashpay/dash#2607](https://github.com/dashpay/dash/pull/2607)~~
> * ~~[Refactor sporks to get rid of repeated if/else blocks dashpay/dash#2946](https://github.com/dashpay/dash/pull/2946)~~

Cherry picked from https://github.com/PIVX-Project/PIVX/pull/1000 as these functions will be useful in the future.

ReprocessBlocks function was in spork.cpp which was eliminated before the code was forked.