### PR TITLE
[Wallet] Only display PaymentID if the transaction IsMine

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -69,7 +69,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
     entry.push_back(Pair("version", tx.nVersion));
     entry.push_back(Pair("locktime", (int64_t)tx.nLockTime));
     entry.push_back(Pair("txfee", ValueFromAmount(tx.nTxFee)));
-    if (tx.hasPaymentID) {
+    if (tx.hasPaymentID && pwalletMain->IsMine(tx)) {
         entry.push_back(Pair("paymentid", tx.paymentID));
     }
     entry.push_back(Pair("txType", (int64_t)tx.txType));

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -71,7 +71,7 @@ void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
     entry.push_back(Pair("time", wtx.GetTxTime()));
     entry.push_back(Pair("timereceived", (int64_t)wtx.nTimeReceived));
 
-    if (wtx.hasPaymentID) {
+    if (wtx.hasPaymentID && pwalletMain->IsMine(wtx)) {
         entry.push_back(Pair("paymentid", wtx.paymentID));
     }
 


### PR DESCRIPTION
Currently PaymentID is displayed in all raw transactions. Change the behavior to only show if the transaction `IsMine`.