### PR TITLE
[Upstream] [Net] Remove unused RecvLine function.

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -74,7 +74,6 @@ unsigned int ReceiveFloodSize();
 unsigned int SendBufferSize();
 
 void AddOneShot(std::string strDest);
-bool RecvLine(SOCKET hSocket, std::string& strLine);
 void AddressCurrentlyConnected(const CService& addr);
 CNode* FindNode(const CNetAddr& ip);
 CNode* FindNode(const CSubNet& subNet);


### PR DESCRIPTION
> Removing the `RecvLine` unused function in net.cpp.

Simple cleanup from https://github.com/PIVX-Project/PIVX/pull/2133
