### PR TITLE
[Trivial] Remove IsKeyImageSpend2 / Rename IsKeyImageSpend1 to IsSpentKeyImage

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -260,7 +260,7 @@ double GetPriority(const CTransaction& tx, int nHeight)
     return 1000000000 + tx.ComputePriority(dResult);
 }
 
-bool IsKeyImageSpend1(const std::string& kiHex, const uint256& againsHash)
+bool IsSpentKeyImage(const std::string& kiHex, const uint256& againsHash)
 {
     if (kiHex.empty()) return false;
     std::vector<uint256> bhs;
@@ -1562,7 +1562,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
             // Check key images not duplicated with what in db
             for (const CTxIn& txin : tx.vin) {
                 const CKeyImage& keyImage = txin.keyImage;
-                if (IsKeyImageSpend1(keyImage.GetHex(), uint256())) {
+                if (IsSpentKeyImage(keyImage.GetHex(), uint256())) {
                     return state.Invalid(error("AcceptToMemoryPool : key image already spent"),
                         REJECT_DUPLICATE, "bad-txns-inputs-spent");
                 }
@@ -3031,7 +3031,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             for (CTxIn in : tx.vin) {
                 const CKeyImage& keyImage = in.keyImage;
                 std::string kh = keyImage.GetHex();
-                if (IsKeyImageSpend1(kh, bh)) {
+                if (IsSpentKeyImage(kh, bh)) {
                     //remove transaction from the pool?
                     return state.Invalid(error("ConnectBlock() : key image already spent"),
                         REJECT_DUPLICATE, "bad-txns-inputs-spent");
@@ -4602,7 +4602,7 @@ bool ProcessNewBlock(CValidationState& state, CNode* pfrom, CBlock* pblock, CDis
     // Duplicate stake allowed only when there is orphan child block
     // Key image will be checked later for duplicate stake
     /*if (pblock->IsProofOfStake() && setStakeSeen.count(pblock->GetProofOfStake())) {
-        if (IsKeyImageSpend1(pblock->vtx[1].vin[0].keyImage.GetHex(), pblock->hashPrevBlock))
+        if (IsSpentKeyImage(pblock->vtx[1].vin[0].keyImage.GetHex(), pblock->hashPrevBlock))
             return error("ProcessNewBlock() : duplicate proof-of-stake (%s, %d) for block %s", pblock->GetProofOfStake().first.ToString().c_str(), pblock->GetProofOfStake().second, pblock->GetHash().ToString().c_str());
     }*/
     // NovaCoin: check proof-of-stake block signature

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -598,27 +598,6 @@ bool VerifyRingSignatureWithTxFee(const CTransaction& tx, CBlockIndex* pindex)
     return HexStr(tx.c.begin(), tx.c.end()) == HexStr(C, C + 32);
 }
 
-bool IsKeyImageSpend2(const std::string& kiHex, const uint256& bh)
-{
-    CBlock block;
-    CBlockIndex* pblockindex = mapBlockIndex[bh];
-
-    if (pblockindex && ReadBlockFromDisk(block, pblockindex)) {
-        for (size_t i = 0; i < block.vtx.size(); i++) {
-            for (size_t j = 0; j < block.vtx[i].vin.size(); j++) {
-                if (block.vtx[i].vin[j].keyImage.GetHex() == kiHex) {
-                    LogPrintf("%s: keyimage %s spent in block hash %s", __func__, kiHex, bh.GetHex());
-                    if (pwalletMain) {
-                        pwalletMain->keyImagesSpends[kiHex] = true;
-                    }
-                    return true;
-                }
-            }
-        }
-    }
-    return false;
-}
-
 bool ReVerifyPoSBlock(CBlockIndex* pindex)
 {
     LOCK(cs_main);

--- a/src/main.h
+++ b/src/main.h
@@ -264,7 +264,6 @@ bool CheckKeyImageSpendInMainChain(const std::string& kiHex, int& confirmations)
 
 double GetPriority(const CTransaction& tx, int nHeight);
 
-bool IsKeyImageSpend2(const std::string&, const uint256& bh);
 uint256 GetTxSignatureHash(const CTransaction& tx);
 uint256 GetTxInSignatureHash(const CTxIn& txin);
 bool VerifyShnorrKeyImageTx(const CTransaction& tx);

--- a/src/main.h
+++ b/src/main.h
@@ -259,7 +259,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
 
 bool AcceptableInputs(CTxMemPool& pool, CValidationState& state, const CTransaction& tx, bool fLimitFree, bool* pfMissingInputs, bool fRejectInsaneFee = false, bool isDSTX = false);
 
-bool IsKeyImageSpend1(const std::string& kiHex, const uint256& againsHash);
+bool IsSpentKeyImage(const std::string& kiHex, const uint256& againsHash);
 bool CheckKeyImageSpendInMainChain(const std::string& kiHex, int& confirmations);
 
 double GetPriority(const CTransaction& tx, int nHeight);

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -212,7 +212,7 @@ void CMasternode::Check(bool forceCheck)
             TRY_LOCK(cs_main, lockMain);
             if (!lockMain) return;
 
-            if (IsKeyImageSpend1(vin.keyImage.GetHex(), uint256())) {
+            if (IsSpentKeyImage(vin.keyImage.GetHex(), uint256())) {
                 activeState = MASTERNODE_VIN_SPENT;
                 return;
             }

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -1011,7 +1011,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
         CValidationState state;
 
-        bool fAcceptable = !IsKeyImageSpend1(vin.keyImage.GetHex(), uint256());
+        bool fAcceptable = !IsSpentKeyImage(vin.keyImage.GetHex(), uint256());
 
         if (fAcceptable) {
             if (GetInputAge(vin) < MASTERNODE_MIN_CONFIRMATIONS) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -263,7 +263,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, const CPubKey& txP
             // Check key images not duplicated with what in db
             for (const CTxIn& txin : tx.vin) {
                 const CKeyImage& keyImage = txin.keyImage;
-                if (IsKeyImageSpend1(keyImage.GetHex(), uint256())) {
+                if (IsSpentKeyImage(keyImage.GetHex(), uint256())) {
                     fKeyImageCheck = false;
                     break;
                 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -777,7 +777,7 @@ bool CWallet::IsSpent(const uint256& hash, unsigned int n)
 
     std::string outString = outpoint.hash.GetHex() + std::to_string(outpoint.n);
     CKeyImage ki = outpointToKeyImages[outString];
-    if (IsKeyImageSpend1(ki.GetHex(), uint256())) {
+    if (IsSpentKeyImage(ki.GetHex(), uint256())) {
         return true;
     }
 


### PR DESCRIPTION
- Remove unused IsKeyImageSpend2
- Rename IsKeyImageSpend1 to IsSpentKeyImage - This better aligns with current IsSpent naming