### PR TITLE
[Qt] Only show notifications when synced to prevent spam

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1302,6 +1302,8 @@ void BitcoinGUI::incomingTransaction(const QString& date, int unit, const CAmoun
 {
     // Only send notifications when not disabled
     if (!bdisableSystemnotifications) {
+        // Only show notifications when synced to prevent spam
+        if (!masternodeSync.IsSynced()) return;
         // On new transaction, make an info balloon
         message((amount) < 0 ? (pwalletMain->fMultiSendNotify == true ? tr("Sent MultiSend transaction") : tr("Sent transaction")) : tr("Incoming transaction"),
             tr("Date: %1\n"


### PR DESCRIPTION
As mentioned in the Testnet channel, when you are syncing a node that has received a lot of rewards/transactions while the wallet was closed will get spammed with a large number of notifications. Fix this by checking if we are synced.