### PR TITLE
Update zxcvbn-cpp (Password Strength Estimation Library)

### DIFF
--- a/src/zxcvbn/scoring.cpp
+++ b/src/zxcvbn/scoring.cpp
@@ -198,8 +198,8 @@ ScoringResult most_guessable_match_sequence(const std::string & password,
     std::vector<std::reference_wrapper<Match>> optimal_match_sequence;
     if (!n) return optimal_match_sequence;
     auto k = n - 1;
-    idx_t l;
-    auto g = std::numeric_limits<guesses_t>::max();
+    idx_t l = optimal.g[k].begin()->first;
+    auto g = optimal.g[k].begin()->second;
     for (const auto & item : optimal.g[k]) {
       auto & candidate_l = item.first;
       auto & candidate_g = item.second;


### PR DESCRIPTION
Minor update to zxcvbn-cpp, the Password Strength Estimation Library we use to enforce minimum password strength
- Avoid uninitialized error when max(t.second for t in optimal.g[k]) == std::numeric_limits<guesses_t>::max()

from https://thelig.ht/code/zxcvbn-cpp/commit/9520d5628004f2f828a84d11daecfadf368444ca.html