### PR TITLE
[Upstream] uint256 to arith_uint256 migration (Second step).

### DIFF
--- a/contrib/prcycoin-qt.pro
+++ b/contrib/prcycoin-qt.pro
@@ -64,6 +64,7 @@ INCLUDEPATH += . \
 HEADERS += src/activemasternode.h \
            src/addrman.h \
            src/allocators.h \
+           src/arith_uint256.h \
            src/amount.h \
            src/base58.h \
            src/bignum.h \
@@ -133,6 +134,7 @@ HEADERS += src/activemasternode.h \
            src/txdb.h \
            src/txmempool.h \
            src/uint256.h \
+           src/uint512.h \
            src/blob_uint256.h \
            src/undo.h \
            src/util.h \

--- a/contrib/prcycoin-qt.pro
+++ b/contrib/prcycoin-qt.pro
@@ -133,6 +133,7 @@ HEADERS += src/activemasternode.h \
            src/txdb.h \
            src/txmempool.h \
            src/uint256.h \
+           src/blob_uint256.h \
            src/undo.h \
            src/util.h \
            src/utilmoneystr.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -83,6 +83,7 @@ BITCOIN_CORE_H = \
   activemasternode.h \
   addrman.h \
   allocators.h \
+  arith_uint256.h \
   amount.h \
   base58.h \
   bignum.h \
@@ -174,6 +175,7 @@ BITCOIN_CORE_H = \
   guiinterface.h \
   guiinterfaceutil.h \
   uint256.h \
+  uint512.h \
   blob_uint256.h \
   undo.h \
   util.h \
@@ -375,6 +377,7 @@ libbitcoin_common_a_SOURCES = \
 libbitcoin_util_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 libbitcoin_util_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_util_a_SOURCES = \
+  arith_uint256.cpp \
   allocators.cpp \
   chainparamsbase.cpp \
   clientversion.cpp \
@@ -482,6 +485,7 @@ prcycoin_tx_LDADD += $(BOOST_LIBS) $(CRYPTO_LIBS)
 if BUILD_BITCOIN_LIBS
 include_HEADERS = script/bitcoinconsensus.h
 libbitcoinconsensus_la_SOURCES = \
+  arith_uint256.cpp \
   allocators.cpp \
   primitives/transaction.cpp \
   crypto/hmac_sha512.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -174,6 +174,7 @@ BITCOIN_CORE_H = \
   guiinterface.h \
   guiinterfaceutil.h \
   uint256.h \
+  blob_uint256.h \
   undo.h \
   util.h \
   util/macros.h \
@@ -387,6 +388,7 @@ libbitcoin_util_a_SOURCES = \
   support/cleanse.cpp \
   sync.cpp \
   uint256.cpp \
+  blob_uint256.cpp \
   util.cpp \
   util/threadnames.cpp \
   utilmoneystr.cpp \
@@ -496,6 +498,7 @@ libbitcoinconsensus_la_SOURCES = \
   script/interpreter.cpp \
   script/bitcoinconsensus.cpp \
   uint256.cpp \
+  blob_uint256.cpp \
   utilstrencodings.cpp
 
 if GLIBC_BACK_COMPAT

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -27,6 +27,7 @@ BITCOIN_TEST_SUITE = \
   test/test_prcycoin.cpp
 # test_prcycoin binary #
 BITCOIN_TESTS =\
+  test/arith_uint256_tests.cpp \
   test/addrman_tests.cpp \
   test/allocator_tests.cpp \
   test/base32_tests.cpp \

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -288,7 +288,7 @@ bool CActiveMasternode::GetMasterNodeVin(CTxIn& vin, CPubKey& pubkey, CKey& secr
     // Find the vin
     if (!strTxHash.empty()) {
         // Let's find it
-        uint256 txHash(strTxHash);
+        uint256 txHash(uint256S(strTxHash));
         int outputIndex;
         try {
             outputIndex = std::stoi(strOutputIndex.c_str());

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -11,22 +11,22 @@
 
 int CAddrInfo::GetTriedBucket(const uint256& nKey) const
 {
-    uint64_t hash1 = (CHashWriter(SER_GETHASH, 0) << nKey << GetKey()).GetHash().GetLow64();
-    uint64_t hash2 = (CHashWriter(SER_GETHASH, 0) << nKey << GetGroup() << (hash1 % ADDRMAN_TRIED_BUCKETS_PER_GROUP)).GetHash().GetLow64();
+    uint64_t hash1 = (CHashWriter(SER_GETHASH, 0) << nKey << GetKey()).GetHash().GetCheapHash();
+    uint64_t hash2 = (CHashWriter(SER_GETHASH, 0) << nKey << GetGroup() << (hash1 % ADDRMAN_TRIED_BUCKETS_PER_GROUP)).GetHash().GetCheapHash();
     return hash2 % ADDRMAN_TRIED_BUCKET_COUNT;
 }
 
 int CAddrInfo::GetNewBucket(const uint256& nKey, const CNetAddr& src) const
 {
     std::vector<unsigned char> vchSourceGroupKey = src.GetGroup();
-    uint64_t hash1 = (CHashWriter(SER_GETHASH, 0) << nKey << GetGroup() << vchSourceGroupKey).GetHash().GetLow64();
-    uint64_t hash2 = (CHashWriter(SER_GETHASH, 0) << nKey << vchSourceGroupKey << (hash1 % ADDRMAN_NEW_BUCKETS_PER_SOURCE_GROUP)).GetHash().GetLow64();
+    uint64_t hash1 = (CHashWriter(SER_GETHASH, 0) << nKey << GetGroup() << vchSourceGroupKey).GetHash().GetCheapHash();
+    uint64_t hash2 = (CHashWriter(SER_GETHASH, 0) << nKey << vchSourceGroupKey << (hash1 % ADDRMAN_NEW_BUCKETS_PER_SOURCE_GROUP)).GetHash().GetCheapHash();
     return hash2 % ADDRMAN_NEW_BUCKET_COUNT;
 }
 
 int CAddrInfo::GetBucketPosition(const uint256& nKey, bool fNew, int nBucket) const
 {
-    uint64_t hash1 = (CHashWriter(SER_GETHASH, 0) << nKey << (fNew ? 'N' : 'K') << nBucket << GetKey()).GetHash().GetLow64();
+    uint64_t hash1 = (CHashWriter(SER_GETHASH, 0) << nKey << (fNew ? 'N' : 'K') << nBucket << GetKey()).GetHash().GetCheapHash();
     return hash1 % ADDRMAN_BUCKET_SIZE;
 }
 

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -478,7 +478,7 @@ public:
 
     ~CAddrMan()
     {
-        nKey = uint256();
+        nKey = UINT256_ZERO;
     }
 
     //! Return the number of (unique) addresses in all tables.

--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -202,6 +202,15 @@ std::string base_uint<BITS>::ToString() const
 }
 
 template <unsigned int BITS>
+std::string base_uint<BITS>::ToStringReverseEndian() const
+{
+    char psz[sizeof(pn) * 2 + 1];
+    for (unsigned int i = 0; i < sizeof(pn); i++)
+        sprintf(psz + i * 2, "%02x", ((unsigned char*)pn)[i]);
+    return std::string(psz, psz + sizeof(pn) * 2);
+}
+
+template <unsigned int BITS>
 unsigned int base_uint<BITS>::bits() const
 {
     for (int pos = WIDTH - 1; pos >= 0; pos--) {
@@ -249,6 +258,15 @@ template std::string base_uint<256>::ToString() const;
 template void base_uint<256>::SetHex(const char*);
 template void base_uint<256>::SetHex(const std::string&);
 template unsigned int base_uint<256>::bits() const;
+template std::string base_uint<256>::ToStringReverseEndian() const;
+
+// Explicit instantiations for base_uint<512>
+template base_uint<512>::base_uint(const std::string&);
+template base_uint<512>& base_uint<512>::operator<<=(unsigned int);
+template base_uint<512>& base_uint<512>::operator>>=(unsigned int);
+template std::string base_uint<512>::GetHex() const;
+template std::string base_uint<512>::ToString() const;
+template std::string base_uint<512>::ToStringReverseEndian() const;
 
 // This implementation directly uses shifts instead of going
 // through an intermediate MPI representation.
@@ -355,35 +373,4 @@ uint64_t arith_uint256::GetHash(const arith_uint256& salt) const
     HashFinal(a, b, c);
 
     return ((((uint64_t)b) << 32) | c);
-}
-
-blob_uint256 ArithToUint256(const arith_uint256 &a)
-{
-    blob_uint256 b;
-    for(int x=0; x<a.WIDTH; ++x)
-        WriteLE32(b.begin() + x*4, a.pn[x]);
-    return b;
-}
-arith_uint256 UintToArith256(const blob_uint256 &a)
-{
-    arith_uint256 b;
-    for(int x=0; x<b.WIDTH; ++x)
-        b.pn[x] = ReadLE32(a.begin() + x*4);
-    return b;
-}
-
-blob_uint512 ArithToUint512(const arith_uint512 &a)
-{
-    blob_uint512 b;
-    for(int x=0; x<a.WIDTH; ++x)
-        WriteLE32(b.begin() + x*4, a.pn[x]);
-    return b;
-}
-
-arith_uint512 UintToArith512(const blob_uint512 &a)
-{
-    arith_uint512 b;
-    for(int x=0; x<b.WIDTH; ++x)
-        b.pn[x] = ReadLE32(a.begin() + x*4);
-    return b;
 }

--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -1,0 +1,389 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "arith_uint256.h"
+
+#include "crypto/common.h"
+#include "utilstrencodings.h"
+
+#include <stdio.h>
+#include <string.h>
+
+template <unsigned int BITS>
+base_uint<BITS>::base_uint(const std::string& str)
+{
+    SetHex(str);
+}
+
+template <unsigned int BITS>
+base_uint<BITS>::base_uint(const std::vector<unsigned char>& vch)
+{
+    if (vch.size() != sizeof(pn))
+        throw uint_error("Converting vector of wrong size to base_uint");
+    memcpy(pn, &vch[0], sizeof(pn));
+}
+
+template <unsigned int BITS>
+base_uint<BITS>& base_uint<BITS>::operator<<=(unsigned int shift)
+{
+    base_uint<BITS> a(*this);
+    for (int i = 0; i < WIDTH; i++)
+        pn[i] = 0;
+    int k = shift / 32;
+    shift = shift % 32;
+    for (int i = 0; i < WIDTH; i++) {
+        if (i + k + 1 < WIDTH && shift != 0)
+            pn[i + k + 1] |= (a.pn[i] >> (32 - shift));
+        if (i + k < WIDTH)
+            pn[i + k] |= (a.pn[i] << shift);
+    }
+    return *this;
+}
+
+template <unsigned int BITS>
+base_uint<BITS>& base_uint<BITS>::operator>>=(unsigned int shift)
+{
+    base_uint<BITS> a(*this);
+    for (int i = 0; i < WIDTH; i++)
+        pn[i] = 0;
+    int k = shift / 32;
+    shift = shift % 32;
+    for (int i = 0; i < WIDTH; i++) {
+        if (i - k - 1 >= 0 && shift != 0)
+            pn[i - k - 1] |= (a.pn[i] << (32 - shift));
+        if (i - k >= 0)
+            pn[i - k] |= (a.pn[i] >> shift);
+    }
+    return *this;
+}
+
+template <unsigned int BITS>
+base_uint<BITS>& base_uint<BITS>::operator*=(uint32_t b32)
+{
+    uint64_t carry = 0;
+    for (int i = 0; i < WIDTH; i++) {
+        uint64_t n = carry + (uint64_t)b32 * pn[i];
+        pn[i] = n & 0xffffffff;
+        carry = n >> 32;
+    }
+    return *this;
+}
+
+template <unsigned int BITS>
+base_uint<BITS>& base_uint<BITS>::operator*=(const base_uint& b)
+{
+    base_uint<BITS> a = *this;
+    *this = 0;
+    for (int j = 0; j < WIDTH; j++) {
+        uint64_t carry = 0;
+        for (int i = 0; i + j < WIDTH; i++) {
+            uint64_t n = carry + pn[i + j] + (uint64_t)a.pn[j] * b.pn[i];
+            pn[i + j] = n & 0xffffffff;
+            carry = n >> 32;
+        }
+    }
+    return *this;
+}
+
+template <unsigned int BITS>
+base_uint<BITS>& base_uint<BITS>::operator/=(const base_uint& b)
+{
+    base_uint<BITS> div = b;     // make a copy, so we can shift.
+    base_uint<BITS> num = *this; // make a copy, so we can subtract.
+    *this = 0;                   // the quotient.
+    int num_bits = num.bits();
+    int div_bits = div.bits();
+    if (div_bits == 0)
+        throw uint_error("Division by zero");
+    if (div_bits > num_bits) // the result is certainly 0.
+        return *this;
+    int shift = num_bits - div_bits;
+    div <<= shift; // shift so that div and num align.
+    while (shift >= 0) {
+        if (num >= div) {
+            num -= div;
+            pn[shift / 32] |= (1 << (shift & 31)); // set a bit of the result.
+        }
+        div >>= 1; // shift back.
+        shift--;
+    }
+    // num now contains the remainder of the division.
+    return *this;
+}
+
+template <unsigned int BITS>
+int base_uint<BITS>::CompareTo(const base_uint<BITS>& b) const
+{
+    for (int i = WIDTH - 1; i >= 0; i--) {
+        if (pn[i] < b.pn[i])
+            return -1;
+        if (pn[i] > b.pn[i])
+            return 1;
+    }
+    return 0;
+}
+
+template <unsigned int BITS>
+bool base_uint<BITS>::EqualTo(uint64_t b) const
+{
+    for (int i = WIDTH - 1; i >= 2; i--) {
+        if (pn[i])
+            return false;
+    }
+    if (pn[1] != (b >> 32))
+        return false;
+    if (pn[0] != (b & 0xfffffffful))
+        return false;
+    return true;
+}
+
+template <unsigned int BITS>
+double base_uint<BITS>::getdouble() const
+{
+    double ret = 0.0;
+    double fact = 1.0;
+    for (int i = 0; i < WIDTH; i++) {
+        ret += fact * pn[i];
+        fact *= 4294967296.0;
+    }
+    return ret;
+}
+
+template <unsigned int BITS>
+std::string base_uint<BITS>::GetHex() const
+{
+    char psz[sizeof(pn) * 2 + 1];
+    for (unsigned int i = 0; i < sizeof(pn); i++)
+        sprintf(psz + i * 2, "%02x", ((unsigned char*)pn)[sizeof(pn) - i - 1]);
+    return std::string(psz, psz + sizeof(pn) * 2);
+}
+
+template <unsigned int BITS>
+void base_uint<BITS>::SetHex(const char* psz)
+{
+    memset(pn, 0, sizeof(pn));
+
+    // skip leading spaces
+    while (isspace(*psz))
+        psz++;
+
+    // skip 0x
+    if (psz[0] == '0' && tolower(psz[1]) == 'x')
+        psz += 2;
+
+    // hex string to uint
+    const char* pbegin = psz;
+    while (::HexDigit(*psz) != -1)
+        psz++;
+    psz--;
+    unsigned char* p1 = (unsigned char*)pn;
+    unsigned char* pend = p1 + WIDTH * 4;
+    while (psz >= pbegin && p1 < pend) {
+        *p1 = ::HexDigit(*psz--);
+        if (psz >= pbegin) {
+            *p1 |= ((unsigned char)::HexDigit(*psz--) << 4);
+            p1++;
+        }
+    }
+}
+
+template <unsigned int BITS>
+void base_uint<BITS>::SetHex(const std::string& str)
+{
+    SetHex(str.c_str());
+}
+
+template <unsigned int BITS>
+std::string base_uint<BITS>::ToString() const
+{
+    return (GetHex());
+}
+
+template <unsigned int BITS>
+unsigned int base_uint<BITS>::bits() const
+{
+    for (int pos = WIDTH - 1; pos >= 0; pos--) {
+        if (pn[pos]) {
+            for (int bits = 31; bits > 0; bits--) {
+                if (pn[pos] & 1 << bits)
+                    return 32 * pos + bits + 1;
+            }
+            return 32 * pos + 1;
+        }
+    }
+    return 0;
+}
+
+// Explicit instantiations for base_uint<160>
+template base_uint<160>::base_uint(const std::string&);
+template base_uint<160>::base_uint(const std::vector<unsigned char>&);
+template base_uint<160>& base_uint<160>::operator<<=(unsigned int);
+template base_uint<160>& base_uint<160>::operator>>=(unsigned int);
+template base_uint<160>& base_uint<160>::operator*=(uint32_t b32);
+template base_uint<160>& base_uint<160>::operator*=(const base_uint<160>& b);
+template base_uint<160>& base_uint<160>::operator/=(const base_uint<160>& b);
+template int base_uint<160>::CompareTo(const base_uint<160>&) const;
+template bool base_uint<160>::EqualTo(uint64_t) const;
+template double base_uint<160>::getdouble() const;
+template std::string base_uint<160>::GetHex() const;
+template std::string base_uint<160>::ToString() const;
+template void base_uint<160>::SetHex(const char*);
+template void base_uint<160>::SetHex(const std::string&);
+template unsigned int base_uint<160>::bits() const;
+
+// Explicit instantiations for base_uint<256>
+template base_uint<256>::base_uint(const std::string&);
+template base_uint<256>::base_uint(const std::vector<unsigned char>&);
+template base_uint<256>& base_uint<256>::operator<<=(unsigned int);
+template base_uint<256>& base_uint<256>::operator>>=(unsigned int);
+template base_uint<256>& base_uint<256>::operator*=(uint32_t b32);
+template base_uint<256>& base_uint<256>::operator*=(const base_uint<256>& b);
+template base_uint<256>& base_uint<256>::operator/=(const base_uint<256>& b);
+template int base_uint<256>::CompareTo(const base_uint<256>&) const;
+template bool base_uint<256>::EqualTo(uint64_t) const;
+template double base_uint<256>::getdouble() const;
+template std::string base_uint<256>::GetHex() const;
+template std::string base_uint<256>::ToString() const;
+template void base_uint<256>::SetHex(const char*);
+template void base_uint<256>::SetHex(const std::string&);
+template unsigned int base_uint<256>::bits() const;
+
+// This implementation directly uses shifts instead of going
+// through an intermediate MPI representation.
+arith_uint256& arith_uint256::SetCompact(uint32_t nCompact, bool* pfNegative, bool* pfOverflow)
+{
+    int nSize = nCompact >> 24;
+    uint32_t nWord = nCompact & 0x007fffff;
+    if (nSize <= 3) {
+        nWord >>= 8 * (3 - nSize);
+        *this = nWord;
+    } else {
+        *this = nWord;
+        *this <<= 8 * (nSize - 3);
+    }
+    if (pfNegative)
+        *pfNegative = nWord != 0 && (nCompact & 0x00800000) != 0;
+    if (pfOverflow)
+        *pfOverflow = nWord != 0 && ((nSize > 34) ||
+                                     (nWord > 0xff && nSize > 33) ||
+                                     (nWord > 0xffff && nSize > 32));
+    return *this;
+}
+
+uint32_t arith_uint256::GetCompact(bool fNegative) const
+{
+    int nSize = (bits() + 7) / 8;
+    uint32_t nCompact = 0;
+    if (nSize <= 3) {
+        nCompact = GetLow64() << 8 * (3 - nSize);
+    } else {
+        arith_uint256 bn = *this >> 8 * (nSize - 3);
+        nCompact = bn.GetLow64();
+    }
+    // The 0x00800000 bit denotes the sign.
+    // Thus, if it is already set, divide the mantissa by 256 and increase the exponent.
+    if (nCompact & 0x00800000) {
+        nCompact >>= 8;
+        nSize++;
+    }
+    assert((nCompact & ~0x007fffff) == 0);
+    assert(nSize < 256);
+    nCompact |= nSize << 24;
+    nCompact |= (fNegative && (nCompact & 0x007fffff) ? 0x00800000 : 0);
+    return nCompact;
+}
+
+static void inline HashMix(uint32_t& a, uint32_t& b, uint32_t& c)
+{
+    // Taken from lookup3, by Bob Jenkins.
+    a -= c;
+    a ^= ((c << 4) | (c >> 28));
+    c += b;
+    b -= a;
+    b ^= ((a << 6) | (a >> 26));
+    a += c;
+    c -= b;
+    c ^= ((b << 8) | (b >> 24));
+    b += a;
+    a -= c;
+    a ^= ((c << 16) | (c >> 16));
+    c += b;
+    b -= a;
+    b ^= ((a << 19) | (a >> 13));
+    a += c;
+    c -= b;
+    c ^= ((b << 4) | (b >> 28));
+    b += a;
+}
+
+static void inline HashFinal(uint32_t& a, uint32_t& b, uint32_t& c)
+{
+    // Taken from lookup3, by Bob Jenkins.
+    c ^= b;
+    c -= ((b << 14) | (b >> 18));
+    a ^= c;
+    a -= ((c << 11) | (c >> 21));
+    b ^= a;
+    b -= ((a << 25) | (a >> 7));
+    c ^= b;
+    c -= ((b << 16) | (b >> 16));
+    a ^= c;
+    a -= ((c << 4) | (c >> 28));
+    b ^= a;
+    b -= ((a << 14) | (a >> 18));
+    c ^= b;
+    c -= ((b << 24) | (b >> 8));
+}
+
+uint64_t arith_uint256::GetHash(const arith_uint256& salt) const
+{
+    uint32_t a, b, c;
+    a = b = c = 0xdeadbeef + (WIDTH << 2);
+
+    a += pn[0] ^ salt.pn[0];
+    b += pn[1] ^ salt.pn[1];
+    c += pn[2] ^ salt.pn[2];
+    HashMix(a, b, c);
+    a += pn[3] ^ salt.pn[3];
+    b += pn[4] ^ salt.pn[4];
+    c += pn[5] ^ salt.pn[5];
+    HashMix(a, b, c);
+    a += pn[6] ^ salt.pn[6];
+    b += pn[7] ^ salt.pn[7];
+    HashFinal(a, b, c);
+
+    return ((((uint64_t)b) << 32) | c);
+}
+
+blob_uint256 ArithToUint256(const arith_uint256 &a)
+{
+    blob_uint256 b;
+    for(int x=0; x<a.WIDTH; ++x)
+        WriteLE32(b.begin() + x*4, a.pn[x]);
+    return b;
+}
+arith_uint256 UintToArith256(const blob_uint256 &a)
+{
+    arith_uint256 b;
+    for(int x=0; x<b.WIDTH; ++x)
+        b.pn[x] = ReadLE32(a.begin() + x*4);
+    return b;
+}
+
+blob_uint512 ArithToUint512(const arith_uint512 &a)
+{
+    blob_uint512 b;
+    for(int x=0; x<a.WIDTH; ++x)
+        WriteLE32(b.begin() + x*4, a.pn[x]);
+    return b;
+}
+
+arith_uint512 UintToArith512(const blob_uint512 &a)
+{
+    arith_uint512 b;
+    for(int x=0; x<b.WIDTH; ++x)
+        b.pn[x] = ReadLE32(a.begin() + x*4);
+    return b;
+}

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -1,0 +1,379 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_ARITH_UINT256_H
+#define BITCOIN_ARITH_UINT256_H
+
+#include "blob_uint256.h"
+#include "uint512.h"
+#include <assert.h>
+#include <cstring>
+#include <stdexcept>
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+class blob_uint512;
+class blob_uint256;
+
+class uint_error : public std::runtime_error {
+public:
+    explicit uint_error(const std::string& str) : std::runtime_error(str) {}
+};
+
+/** Template base class for unsigned big integers. */
+template<unsigned int BITS>
+class base_uint
+{
+public:
+    enum { WIDTH=BITS/32 };
+    uint32_t pn[WIDTH];
+
+    base_uint()
+    {
+        for (int i = 0; i < WIDTH; i++)
+            pn[i] = 0;
+    }
+
+    base_uint(const base_uint& b)
+    {
+        for (int i = 0; i < WIDTH; i++)
+            pn[i] = b.pn[i];
+    }
+
+    base_uint& operator=(const base_uint& b)
+    {
+        for (int i = 0; i < WIDTH; i++)
+            pn[i] = b.pn[i];
+        return *this;
+    }
+
+    base_uint(uint64_t b)
+    {
+        pn[0] = (unsigned int)b;
+        pn[1] = (unsigned int)(b >> 32);
+        for (int i = 2; i < WIDTH; i++)
+            pn[i] = 0;
+    }
+
+    explicit base_uint(const std::string& str);
+    explicit base_uint(const std::vector<unsigned char>& vch);
+
+    bool operator!() const
+    {
+        for (int i = 0; i < WIDTH; i++)
+            if (pn[i] != 0)
+                return false;
+        return true;
+    }
+
+    const base_uint operator~() const
+    {
+        base_uint ret;
+        for (int i = 0; i < WIDTH; i++)
+            ret.pn[i] = ~pn[i];
+        return ret;
+    }
+
+    const base_uint operator-() const
+    {
+        base_uint ret;
+        for (int i = 0; i < WIDTH; i++)
+            ret.pn[i] = ~pn[i];
+        ret++;
+        return ret;
+    }
+
+    double getdouble() const;
+
+    base_uint& operator=(uint64_t b)
+    {
+        pn[0] = (unsigned int)b;
+        pn[1] = (unsigned int)(b >> 32);
+        for (int i = 2; i < WIDTH; i++)
+            pn[i] = 0;
+        return *this;
+    }
+
+    base_uint& operator^=(const base_uint& b)
+    {
+        for (int i = 0; i < WIDTH; i++)
+            pn[i] ^= b.pn[i];
+        return *this;
+    }
+
+    base_uint& operator&=(const base_uint& b)
+    {
+        for (int i = 0; i < WIDTH; i++)
+            pn[i] &= b.pn[i];
+        return *this;
+    }
+
+    base_uint& operator|=(const base_uint& b)
+    {
+        for (int i = 0; i < WIDTH; i++)
+            pn[i] |= b.pn[i];
+        return *this;
+    }
+
+    base_uint& operator^=(uint64_t b)
+    {
+        pn[0] ^= (unsigned int)b;
+        pn[1] ^= (unsigned int)(b >> 32);
+        return *this;
+    }
+
+    base_uint& operator|=(uint64_t b)
+    {
+        pn[0] |= (unsigned int)b;
+        pn[1] |= (unsigned int)(b >> 32);
+        return *this;
+    }
+
+    base_uint& operator<<=(unsigned int shift);
+    base_uint& operator>>=(unsigned int shift);
+
+    base_uint& operator+=(const base_uint& b)
+    {
+        uint64_t carry = 0;
+        for (int i = 0; i < WIDTH; i++)
+        {
+            uint64_t n = carry + pn[i] + b.pn[i];
+            pn[i] = n & 0xffffffff;
+            carry = n >> 32;
+        }
+        return *this;
+    }
+
+    base_uint& operator-=(const base_uint& b)
+    {
+        *this += -b;
+        return *this;
+    }
+
+    base_uint& operator+=(uint64_t b64)
+    {
+        base_uint b;
+        b = b64;
+        *this += b;
+        return *this;
+    }
+
+    base_uint& operator-=(uint64_t b64)
+    {
+        base_uint b;
+        b = b64;
+        *this += -b;
+        return *this;
+    }
+
+    base_uint& operator*=(uint32_t b32);
+    base_uint& operator*=(const base_uint& b);
+    base_uint& operator/=(const base_uint& b);
+
+    base_uint& operator++()
+    {
+        // prefix operator
+        int i = 0;
+        while (++pn[i] == 0 && i < WIDTH-1)
+            i++;
+        return *this;
+    }
+
+    const base_uint operator++(int)
+    {
+        // postfix operator
+        const base_uint ret = *this;
+        ++(*this);
+        return ret;
+    }
+
+    base_uint& operator--()
+    {
+        // prefix operator
+        int i = 0;
+        while (--pn[i] == (uint32_t)-1 && i < WIDTH-1)
+            i++;
+        return *this;
+    }
+
+    const base_uint operator--(int)
+    {
+        // postfix operator
+        const base_uint ret = *this;
+        --(*this);
+        return ret;
+    }
+
+    int CompareTo(const base_uint& b) const;
+    bool EqualTo(uint64_t b) const;
+
+    friend inline const base_uint operator+(const base_uint& a, const base_uint& b) { return base_uint(a) += b; }
+    friend inline const base_uint operator-(const base_uint& a, const base_uint& b) { return base_uint(a) -= b; }
+    friend inline const base_uint operator*(const base_uint& a, const base_uint& b) { return base_uint(a) *= b; }
+    friend inline const base_uint operator/(const base_uint& a, const base_uint& b) { return base_uint(a) /= b; }
+    friend inline const base_uint operator|(const base_uint& a, const base_uint& b) { return base_uint(a) |= b; }
+    friend inline const base_uint operator&(const base_uint& a, const base_uint& b) { return base_uint(a) &= b; }
+    friend inline const base_uint operator^(const base_uint& a, const base_uint& b) { return base_uint(a) ^= b; }
+    friend inline const base_uint operator>>(const base_uint& a, int shift) { return base_uint(a) >>= shift; }
+    friend inline const base_uint operator<<(const base_uint& a, int shift) { return base_uint(a) <<= shift; }
+    friend inline const base_uint operator*(const base_uint& a, uint32_t b) { return base_uint(a) *= b; }
+    friend inline bool operator==(const base_uint& a, const base_uint& b) { return memcmp(a.pn, b.pn, sizeof(a.pn)) == 0; }
+    friend inline bool operator!=(const base_uint& a, const base_uint& b) { return memcmp(a.pn, b.pn, sizeof(a.pn)) != 0; }
+    friend inline bool operator>(const base_uint& a, const base_uint& b) { return a.CompareTo(b) > 0; }
+    friend inline bool operator<(const base_uint& a, const base_uint& b) { return a.CompareTo(b) < 0; }
+    friend inline bool operator>=(const base_uint& a, const base_uint& b) { return a.CompareTo(b) >= 0; }
+    friend inline bool operator<=(const base_uint& a, const base_uint& b) { return a.CompareTo(b) <= 0; }
+    friend inline bool operator==(const base_uint& a, uint64_t b) { return a.EqualTo(b); }
+    friend inline bool operator!=(const base_uint& a, uint64_t b) { return !a.EqualTo(b); }
+
+    std::string GetHex() const;
+    void SetHex(const char* psz);
+    void SetHex(const std::string& str);
+    std::string ToString() const;
+
+    unsigned char* begin()
+    {
+        return (unsigned char*)&pn[0];
+    }
+
+    unsigned char* end()
+    {
+        return (unsigned char*)&pn[WIDTH];
+    }
+
+    const unsigned char* begin() const
+    {
+        return (unsigned char*)&pn[0];
+    }
+
+    const unsigned char* end() const
+    {
+        return (unsigned char*)&pn[WIDTH];
+    }
+
+    unsigned int size() const
+    {
+        return sizeof(pn);
+    }
+
+    /**
+     * Returns the position of the highest bit set plus one, or zero if the
+     * value is zero.
+     */
+    unsigned int bits() const;
+
+    uint64_t GetLow64() const
+    {
+        assert(WIDTH >= 2);
+        return pn[0] | (uint64_t)pn[1] << 32;
+    }
+
+    unsigned int GetSerializeSize(int nType, int nVersion) const
+    {
+        return sizeof(pn);
+    }
+
+    template<typename Stream>
+    void Serialize(Stream& s, int nType, int nVersion) const
+    {
+        s.write((char*)pn, sizeof(pn));
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream& s, int nType, int nVersion)
+    {
+        s.read((char*)pn, sizeof(pn));
+    }
+
+    // Temporary for migration to blob160/256
+    uint64_t GetCheapHash() const
+    {
+        return GetLow64();
+    }
+    void SetNull()
+    {
+        memset(pn, 0, sizeof(pn));
+    }
+    bool IsNull() const
+    {
+        for (int i = 0; i < WIDTH; i++)
+            if (pn[i] != 0)
+                return false;
+        return true;
+    }
+};
+
+/** 160-bit unsigned big integer. */
+class arith_uint160 : public base_uint<160> {
+public:
+    arith_uint160() {}
+    arith_uint160(const base_uint<160>& b) : base_uint<160>(b) {}
+    arith_uint160(uint64_t b) : base_uint<160>(b) {}
+    explicit arith_uint160(const std::string& str) : base_uint<160>(str) {}
+    explicit arith_uint160(const std::vector<unsigned char>& vch) : base_uint<160>(vch) {}
+};
+
+/** 256-bit unsigned big integer. */
+class arith_uint256 : public base_uint<256> {
+public:
+    arith_uint256() {}
+    arith_uint256(const base_uint<256>& b) : base_uint<256>(b) {}
+    arith_uint256(uint64_t b) : base_uint<256>(b) {}
+    explicit arith_uint256(const std::string& str) : base_uint<256>(str) {}
+    explicit arith_uint256(const std::vector<unsigned char>& vch) : base_uint<256>(vch) {}
+
+    /**
+     * The "compact" format is a representation of a whole
+     * number N using an unsigned 32bit number similar to a
+     * floating point format.
+     * The most significant 8 bits are the unsigned exponent of base 256.
+     * This exponent can be thought of as "number of bytes of N".
+     * The lower 23 bits are the mantissa.
+     * Bit number 24 (0x800000) represents the sign of N.
+     * N = (-1^sign) * mantissa * 256^(exponent-3)
+     *
+     * Satoshi's original implementation used BN_bn2mpi() and BN_mpi2bn().
+     * MPI uses the most significant bit of the first byte as sign.
+     * Thus 0x1234560000 is compact (0x05123456)
+     * and  0xc0de000000 is compact (0x0600c0de)
+     *
+     * Bitcoin only uses this "compact" format for encoding difficulty
+     * targets, which are unsigned 256bit quantities.  Thus, all the
+     * complexities of the sign bit and using base 256 are probably an
+     * implementation accident.
+     */
+    arith_uint256& SetCompact(uint32_t nCompact, bool *pfNegative = NULL, bool *pfOverflow = NULL);
+    uint32_t GetCompact(bool fNegative = false) const;
+
+    uint64_t GetHash(const arith_uint256& salt) const;
+
+    uint32_t Get32(int n = 0) const { return pn[2 * n]; }
+};
+
+/** 512-bit unsigned big integer. */
+class arith_uint512 : public base_uint<512> {
+public:
+    arith_uint512() {}
+    arith_uint512(const base_uint<512>& b) : base_uint<512>(b) {}
+    arith_uint512(uint64_t b) : base_uint<512>(b) {}
+    explicit arith_uint512(const std::string& str) : base_uint<512>(str) {}
+    explicit arith_uint512(const std::vector<unsigned char>& vch) : base_uint<512>(vch) {}
+
+    uint64_t GetHash(const arith_uint256& salt) const;
+
+    friend arith_uint512 UintToArith512(const blob_uint512 &a);
+    friend blob_uint512 ArithToUint512(const arith_uint512 &a);
+
+};
+
+blob_uint256 ArithToUint256(const arith_uint256 &);
+arith_uint256 UintToArith256(const blob_uint256 &);
+blob_uint512 ArithToUint512(const arith_uint512 &);
+arith_uint512 UintToArith512(const blob_uint512 &);
+
+const arith_uint256 ARITH_UINT256_ZERO = arith_uint256();
+
+#endif // BITCOIN_UINT256_H

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -17,6 +17,8 @@
 
 class blob_uint512;
 class blob_uint256;
+class uint256;
+class uint512;
 
 class uint_error : public std::runtime_error {
 public:
@@ -233,6 +235,7 @@ public:
     void SetHex(const char* psz);
     void SetHex(const std::string& str);
     std::string ToString() const;
+    std::string ToStringReverseEndian() const;
 
     unsigned char* begin()
     {
@@ -259,6 +262,15 @@ public:
         return sizeof(pn);
     }
 
+    uint64_t Get64(int n = 0) const
+    {
+        return pn[2 * n] | (uint64_t)pn[2 * n + 1] << 32;
+    }
+
+    uint32_t Get32(int n = 0) const
+    {
+        return pn[2 * n];
+    }
     /**
      * Returns the position of the highest bit set plus one, or zero if the
      * value is zero.
@@ -304,6 +316,14 @@ public:
                 return false;
         return true;
     }
+
+    friend class uint160;
+    friend class uint256;
+    friend class uint512;
+
+    friend class arith_uint160;
+    friend class arith_uint256;
+    friend class arith_uint512;
 };
 
 /** 160-bit unsigned big integer. */
@@ -364,15 +384,14 @@ public:
 
     uint64_t GetHash(const arith_uint256& salt) const;
 
-    friend arith_uint512 UintToArith512(const blob_uint512 &a);
-    friend blob_uint512 ArithToUint512(const arith_uint512 &a);
+    //friend arith_uint512 UintToArith512(const blob_uint512 &a);
+    //friend blob_uint512 ArithToUint512(const arith_uint512 &a);
 
 };
 
-blob_uint256 ArithToUint256(const arith_uint256 &);
-arith_uint256 UintToArith256(const blob_uint256 &);
-blob_uint512 ArithToUint512(const arith_uint512 &);
-arith_uint512 UintToArith512(const blob_uint512 &);
+/** Old classes definitions */
+
+/** End classes definitions */
 
 const arith_uint256 ARITH_UINT256_ZERO = arith_uint256();
 

--- a/src/bip38.cpp
+++ b/src/bip38.cpp
@@ -35,7 +35,7 @@ void DecryptAES(uint256 encryptedIn, uint256 decryptionKey, uint256& output)
 void ComputePreFactor(std::string strPassphrase, std::string strSalt, uint256& prefactor)
 {
     //passfactor is the scrypt hash of passphrase and ownersalt (NOTE this needs to handle alt cases too in the future)
-    uint64_t s = uint256(ReverseEndianString(strSalt)).Get64();
+    uint64_t s = uint256S(ReverseEndianString(strSalt)).GetCheapHash();
     scrypt_hash(strPassphrase.c_str(), strPassphrase.size(), BEGIN(s), strSalt.size() / 2, BEGIN(prefactor), 16384, 8, 8, 32);
 }
 
@@ -58,7 +58,7 @@ void ComputeSeedBPass(CPubKey passpoint, std::string strAddressHash, std::string
 {
     // Derive decryption key for seedb using scrypt with passpoint, addresshash, and ownerentropy
     std::string salt = ReverseEndianString(strAddressHash + strOwnerSalt);
-    uint256 s2(salt);
+    uint256 s2(uint256S(salt));
     scrypt_hash(BEGIN(passpoint), HexStr(passpoint).size() / 2, BEGIN(s2), salt.size() / 2, BEGIN(seedBPass), 1024, 1, 1, 64);
 }
 
@@ -83,7 +83,7 @@ std::string BIP38_Encrypt(std::string strAddress, std::string strPassphrase, uin
     std::string strAddressHash = AddressToBip38Hash(strAddress);
 
     uint512 hashed;
-    uint64_t salt = uint256(ReverseEndianString(strAddressHash)).Get64();
+    uint64_t salt = uint256S(ReverseEndianString(strAddressHash)).GetCheapHash();
     scrypt_hash(strPassphrase.c_str(), strPassphrase.size(), BEGIN(salt), strAddressHash.size() / 2, BEGIN(hashed), 16384, 8, 8, 64);
 
     uint256 derivedHalf1(hashed.ToString().substr(64, 64));
@@ -154,11 +154,11 @@ bool BIP38_Decrypt(std::string strPassphrase, std::string strEncryptedKey, uint2
     if (type == uint256(0x42)) {
         uint512 hashed;
         encryptedPart1 = uint256(ReverseEndianString(strKey.substr(14, 32)));
-        uint64_t salt = uint256(ReverseEndianString(strAddressHash)).Get64();
+        uint64_t salt = uint256S(ReverseEndianString(strAddressHash)).GetCheapHash();
         scrypt_hash(strPassphrase.c_str(), strPassphrase.size(), BEGIN(salt), strAddressHash.size() / 2, BEGIN(hashed), 16384, 8, 8, 64);
 
-        uint256 derivedHalf1(hashed.ToString().substr(64, 64));
-        uint256 derivedHalf2(hashed.ToString().substr(0, 64));
+        uint256 derivedHalf1(uint256S(hashed.ToString().substr(64, 64)));
+        uint256 derivedHalf2(uint256S(hashed.ToString().substr(0, 64)));
 
         uint256 decryptedPart1;
         DecryptAES(encryptedPart1, derivedHalf2, decryptedPart1);
@@ -200,8 +200,8 @@ bool BIP38_Decrypt(std::string strPassphrase, std::string strEncryptedKey, uint2
     ComputeSeedBPass(passpoint, strAddressHash, ownersalt, seedBPass);
 
     //get derived halfs, being mindful for endian switch
-    uint256 derivedHalf1(seedBPass.ToString().substr(64, 64));
-    uint256 derivedHalf2(seedBPass.ToString().substr(0, 64));
+    uint256 derivedHalf1(uint256S(seedBPass.ToString().substr(64, 64)));
+    uint256 derivedHalf2(uint256S(seedBPass.ToString().substr(0, 64)));
 
     /** Decrypt encryptedpart2 using AES256Decrypt to yield the last 8 bytes of seedb and the last 8 bytes of encryptedpart1. **/
     uint256 decryptedPart2;

--- a/src/blob_uint256.cpp
+++ b/src/blob_uint256.cpp
@@ -1,0 +1,146 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "blob_uint256.h"
+
+#include "utilstrencodings.h"
+
+#include <stdio.h>
+#include <string.h>
+
+template <unsigned int BITS>
+base_blob<BITS>::base_blob(const std::vector<unsigned char>& vch)
+{
+    assert(vch.size() == sizeof(data));
+    memcpy(data, &vch[0], sizeof(data));
+}
+
+template <unsigned int BITS>
+std::string base_blob<BITS>::GetHex() const
+{
+    char psz[sizeof(data) * 2 + 1];
+    for (unsigned int i = 0; i < sizeof(data); i++)
+        sprintf(psz + i * 2, "%02x", data[sizeof(data) - i - 1]);
+    return std::string(psz, psz + sizeof(data) * 2);
+}
+
+template <unsigned int BITS>
+void base_blob<BITS>::SetHex(const char* psz)
+{
+    memset(data, 0, sizeof(data));
+
+    // skip leading spaces
+    while (isspace(*psz))
+        psz++;
+
+    // skip 0x
+    if (psz[0] == '0' && tolower(psz[1]) == 'x')
+        psz += 2;
+
+    // hex string to uint
+    const char* pbegin = psz;
+    while (::HexDigit(*psz) != -1)
+        psz++;
+    psz--;
+    unsigned char* p1 = (unsigned char*)data;
+    unsigned char* pend = p1 + WIDTH * 4;
+    while (psz >= pbegin && p1 < pend) {
+        *p1 = ::HexDigit(*psz--);
+        if (psz >= pbegin) {
+            *p1 |= ((unsigned char)::HexDigit(*psz--) << 4);
+            p1++;
+        }
+    }
+}
+
+template <unsigned int BITS>
+void base_blob<BITS>::SetHex(const std::string& str)
+{
+    SetHex(str.c_str());
+}
+
+template <unsigned int BITS>
+std::string base_blob<BITS>::ToString() const
+{
+    return GetHex();
+}
+
+// Explicit instantiations for base_blob<160>
+template base_blob<160>::base_blob(const std::vector<unsigned char>&);
+template std::string base_blob<160>::GetHex() const;
+template std::string base_blob<160>::ToString() const;
+template void base_blob<160>::SetHex(const char*);
+template void base_blob<160>::SetHex(const std::string&);
+
+// Explicit instantiations for base_blob<256>
+template base_blob<256>::base_blob(const std::vector<unsigned char>&);
+template std::string base_blob<256>::GetHex() const;
+template std::string base_blob<256>::ToString() const;
+template void base_blob<256>::SetHex(const char*);
+template void base_blob<256>::SetHex(const std::string&);
+
+static void inline HashMix(uint32_t& a, uint32_t& b, uint32_t& c)
+{
+    // Taken from lookup3, by Bob Jenkins.
+    a -= c;
+    a ^= ((c << 4) | (c >> 28));
+    c += b;
+    b -= a;
+    b ^= ((a << 6) | (a >> 26));
+    a += c;
+    c -= b;
+    c ^= ((b << 8) | (b >> 24));
+    b += a;
+    a -= c;
+    a ^= ((c << 16) | (c >> 16));
+    c += b;
+    b -= a;
+    b ^= ((a << 19) | (a >> 13));
+    a += c;
+    c -= b;
+    c ^= ((b << 4) | (b >> 28));
+    b += a;
+}
+
+static void inline HashFinal(uint32_t& a, uint32_t& b, uint32_t& c)
+{
+    // Taken from lookup3, by Bob Jenkins.
+    c ^= b;
+    c -= ((b << 14) | (b >> 18));
+    a ^= c;
+    a -= ((c << 11) | (c >> 21));
+    b ^= a;
+    b -= ((a << 25) | (a >> 7));
+    c ^= b;
+    c -= ((b << 16) | (b >> 16));
+    a ^= c;
+    a -= ((c << 4) | (c >> 28));
+    b ^= a;
+    b -= ((a << 14) | (a >> 18));
+    c ^= b;
+    c -= ((b << 24) | (b >> 8));
+}
+
+uint64_t uint256::GetHash(const uint256& salt) const
+{
+    uint32_t a, b, c;
+    const uint32_t *pn = (const uint32_t*)data;
+    const uint32_t *salt_pn = (const uint32_t*)salt.data;
+    a = b = c = 0xdeadbeef + (WIDTH << 2);
+
+    a += pn[0] ^ salt_pn[0];
+    b += pn[1] ^ salt_pn[1];
+    c += pn[2] ^ salt_pn[2];
+    HashMix(a, b, c);
+    a += pn[3] ^ salt_pn[3];
+    b += pn[4] ^ salt_pn[4];
+    c += pn[5] ^ salt_pn[5];
+    HashMix(a, b, c);
+    a += pn[6] ^ salt_pn[6];
+    b += pn[7] ^ salt_pn[7];
+    HashFinal(a, b, c);
+
+    return ((((uint64_t)b) << 32) | c);
+}

--- a/src/blob_uint256.cpp
+++ b/src/blob_uint256.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 #include "blob_uint256.h"
 
@@ -45,7 +45,7 @@ void base_blob<BITS>::SetHex(const char* psz)
         psz++;
     psz--;
     unsigned char* p1 = (unsigned char*)data;
-    unsigned char* pend = p1 + WIDTH * 4;
+    unsigned char* pend = p1 + WIDTH;
     while (psz >= pbegin && p1 < pend) {
         *p1 = ::HexDigit(*psz--);
         if (psz >= pbegin) {
@@ -128,7 +128,7 @@ uint64_t blob_uint256::GetHash(const blob_uint256& salt) const
     uint32_t a, b, c;
     const uint32_t *pn = (const uint32_t*)data;
     const uint32_t *salt_pn = (const uint32_t*)salt.data;
-    a = b = c = 0xdeadbeef + (WIDTH << 2);
+    a = b = c = 0xdeadbeef + WIDTH;
 
     a += pn[0] ^ salt_pn[0];
     b += pn[1] ^ salt_pn[1];

--- a/src/blob_uint256.cpp
+++ b/src/blob_uint256.cpp
@@ -123,7 +123,7 @@ static void inline HashFinal(uint32_t& a, uint32_t& b, uint32_t& c)
     c -= ((b << 24) | (b >> 8));
 }
 
-uint64_t uint256::GetHash(const uint256& salt) const
+uint64_t blob_uint256::GetHash(const blob_uint256& salt) const
 {
     uint32_t a, b, c;
     const uint32_t *pn = (const uint32_t*)data;

--- a/src/blob_uint256.h
+++ b/src/blob_uint256.h
@@ -1,0 +1,164 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Copyright (c) 2014-2015 The Dash developers
+// Copyright (c) 2015-2018 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PRCY_BLOB_UINT256_H
+#define PRCY_BLOB_UINT256_H
+
+#include <assert.h>
+#include <cstring>
+#include <stdexcept>
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+/** Template base class for fixed-sized opaque blobs. */
+template<unsigned int BITS>
+class base_blob
+{
+protected:
+    enum { WIDTH=BITS/8 };
+    uint8_t data[WIDTH];
+
+public:
+
+    base_blob()
+    {
+        SetNull();
+    }
+
+    explicit base_blob(const std::vector<unsigned char>& vch);
+
+    bool IsNull() const
+    {
+        for (int i = 0; i < WIDTH; i++)
+            if (data[i] != 0)
+                return false;
+        return true;
+    }
+
+    void SetNull()
+    {
+        memset(data, 0, sizeof(data));
+    }
+
+    friend inline bool operator==(const base_blob& a, const base_blob& b) { return memcmp(a.data, b.data, sizeof(a.data)) == 0; }
+    friend inline bool operator!=(const base_blob& a, const base_blob& b) { return memcmp(a.data, b.data, sizeof(a.data)) != 0; }
+    friend inline bool operator<(const base_blob& a, const base_blob& b) { return memcmp(a.data, b.data, sizeof(a.data)) < 0; }
+
+    std::string GetHex() const;
+    void SetHex(const char* psz);
+    void SetHex(const std::string& str);
+    std::string ToString() const;
+
+    unsigned char* begin()
+    {
+        return &data[0];
+    }
+
+    unsigned char* end()
+    {
+        return &data[WIDTH];
+    }
+
+    const unsigned char* begin() const
+    {
+        return &data[0];
+    }
+
+    const unsigned char* end() const
+    {
+        return &data[WIDTH];
+    }
+
+    unsigned int size() const
+    {
+        return sizeof(data);
+    }
+
+    unsigned int GetSerializeSize(int nType, int nVersion) const
+    {
+        return sizeof(data);
+    }
+
+    template<typename Stream>
+    void Serialize(Stream& s, int nType, int nVersion) const
+    {
+        s.write((char*)data, sizeof(data));
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream& s, int nType, int nVersion)
+    {
+        s.read((char*)data, sizeof(data));
+    }
+};
+
+/** 160-bit opaque blob.
+ * @note This type is called uint160 for historical reasons only. It is an opaque
+ * blob of 160 bits and has no integer operations.
+ */
+class uint160 : public base_blob<160> {
+public:
+    uint160() {}
+    uint160(const base_blob<160>& b) : base_blob<160>(b) {}
+    explicit uint160(const std::vector<unsigned char>& vch) : base_blob<160>(vch) {}
+};
+
+/** 256-bit opaque blob.
+ * @note This type is called uint256 for historical reasons only. It is an
+ * opaque blob of 256 bits and has no integer operations. Use arith_uint256 if
+ * those are required.
+ */
+class uint256 : public base_blob<256> {
+public:
+    uint256() {}
+    uint256(const base_blob<256>& b) : base_blob<256>(b) {}
+    explicit uint256(const std::vector<unsigned char>& vch) : base_blob<256>(vch) {}
+
+    /** A cheap hash function that just returns 64 bits from the result, it can be
+     * used when the contents are considered uniformly random. It is not appropriate
+     * when the value can easily be influenced from outside as e.g. a network adversary could
+     * provide values to trigger worst-case behavior.
+     * @note The result of this function is not stable between little and big endian.
+     */
+    uint64_t GetCheapHash() const
+    {
+        uint64_t result;
+        memcpy((void*)&result, (void*)data, 8);
+        return result;
+    }
+
+    /** A more secure, salted hash function.
+     * @note This hash is not stable between little and big endian.
+     */
+    uint64_t GetHash(const uint256& salt) const;
+};
+
+/* uint256 from const char *.
+ * This is a separate function because the constructor uint256(const char*) can result
+ * in dangerously catching uint256(0).
+ */
+inline uint256 uint256S(const char *str)
+{
+    uint256 rv;
+    rv.SetHex(str);
+    return rv;
+}
+/* uint256 from std::string.
+ * This is a separate function because the constructor uint256(const std::string &str) can result
+ * in dangerously catching uint256(0) via std::string(const char*).
+ */
+inline uint256 uint256S(const std::string& str)
+{
+    return blob_uint256S(str.c_str());
+}
+
+/** constant uint256 instances */
+const uint256 UINT256_ZERO = uint256();
+const uint256 UINT256_ONE = uint256S("0000000000000000000000000000000000000000000000000000000000000001");
+
+#endif // PRCY_BLOB_UINT256_H

--- a/src/blob_uint256.h
+++ b/src/blob_uint256.h
@@ -19,11 +19,10 @@
 template<unsigned int BITS>
 class base_blob
 {
-protected:
+public:
+    // todo: make this protected
     enum { WIDTH=BITS/8 };
     uint8_t data[WIDTH];
-
-public:
 
     base_blob()
     {
@@ -101,11 +100,11 @@ public:
  * @note This type is called uint160 for historical reasons only. It is an opaque
  * blob of 160 bits and has no integer operations.
  */
-class uint160 : public base_blob<160> {
+class blob_uint160 : public base_blob<160> {
 public:
-    uint160() {}
-    uint160(const base_blob<160>& b) : base_blob<160>(b) {}
-    explicit uint160(const std::vector<unsigned char>& vch) : base_blob<160>(vch) {}
+    blob_uint160() {}
+    blob_uint160(const base_blob<160>& b) : base_blob<160>(b) {}
+    explicit blob_uint160(const std::vector<unsigned char>& vch) : base_blob<160>(vch) {}
 };
 
 /** 256-bit opaque blob.
@@ -113,11 +112,11 @@ public:
  * opaque blob of 256 bits and has no integer operations. Use arith_uint256 if
  * those are required.
  */
-class uint256 : public base_blob<256> {
+class blob_uint256 : public base_blob<256> {
 public:
-    uint256() {}
-    uint256(const base_blob<256>& b) : base_blob<256>(b) {}
-    explicit uint256(const std::vector<unsigned char>& vch) : base_blob<256>(vch) {}
+    blob_uint256() {}
+    blob_uint256(const base_blob<256>& b) : base_blob<256>(b) {}
+    explicit blob_uint256(const std::vector<unsigned char>& vch) : base_blob<256>(vch) {}
 
     /** A cheap hash function that just returns 64 bits from the result, it can be
      * used when the contents are considered uniformly random. It is not appropriate
@@ -135,16 +134,16 @@ public:
     /** A more secure, salted hash function.
      * @note This hash is not stable between little and big endian.
      */
-    uint64_t GetHash(const uint256& salt) const;
+    uint64_t GetHash(const blob_uint256& salt) const;
 };
 
 /* uint256 from const char *.
  * This is a separate function because the constructor uint256(const char*) can result
  * in dangerously catching uint256(0).
  */
-inline uint256 uint256S(const char *str)
+inline blob_uint256 blob_uint256S(const char *str)
 {
-    uint256 rv;
+    blob_uint256 rv;
     rv.SetHex(str);
     return rv;
 }
@@ -152,13 +151,13 @@ inline uint256 uint256S(const char *str)
  * This is a separate function because the constructor uint256(const std::string &str) can result
  * in dangerously catching uint256(0) via std::string(const char*).
  */
-inline uint256 uint256S(const std::string& str)
+inline blob_uint256 blob_uint256S(const std::string& str)
 {
     return blob_uint256S(str.c_str());
 }
 
 /** constant uint256 instances */
-const uint256 UINT256_ZERO = uint256();
-const uint256 UINT256_ONE = uint256S("0000000000000000000000000000000000000000000000000000000000000001");
+const blob_uint256 BLOB_UINT256_ZERO = blob_uint256();
+const blob_uint256 BLOB_UINT256_ONE = blob_uint256S("0000000000000000000000000000000000000000000000000000000000000001");
 
 #endif // PRCY_BLOB_UINT256_H

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -68,14 +68,14 @@ uint256 CBlockIndex::GetBlockTrust() const
     uint256 bnTarget;
     bnTarget.SetCompact(nBits);
     if (bnTarget <= 0)
-        return 0;
+        return UINT256_ZERO;
 
     if (IsProofOfStake()) {
         // Return trust score as usual
         return (uint256(1) << 256) / (bnTarget + 1);
     } else {
         // Calculate work amount for block
-        uint256 bnPoWTrust = ((~uint256(0) >> 20) / (bnTarget + 1));
+        uint256 bnPoWTrust = ((~UINT256_ZERO >> 20) / (bnTarget + 1));
         return bnPoWTrust > 1 ? bnPoWTrust : 1;
     }
 }

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -72,7 +72,7 @@ uint256 CBlockIndex::GetBlockTrust() const
 
     if (IsProofOfStake()) {
         // Return trust score as usual
-        return (uint256(1) << 256) / (bnTarget + 1);
+        return (UINT256_ONE << 256) / (bnTarget + 1);
     } else {
         // Calculate work amount for block
         uint256 bnPoWTrust = ((~UINT256_ZERO >> 20) / (bnTarget + 1));

--- a/src/chain.h
+++ b/src/chain.h
@@ -409,7 +409,7 @@ public:
 
     unsigned int GetStakeEntropyBit() const
     {
-        unsigned int nEntropyBit = ((GetBlockHash().Get64()) & 1);
+        unsigned int nEntropyBit = ((GetBlockHash().GetCheapHash()) & 1);
         if (GetBoolArg("-printstakemodifier", false))
             LogPrintf("GetStakeEntropyBit: nHeight=%u hashBlock=%s nEntropyBit=%u\n", nHeight, GetBlockHash().ToString().c_str(), nEntropyBit);
 

--- a/src/chain.h
+++ b/src/chain.h
@@ -263,15 +263,15 @@ public:
         nStakeTime = 0;
 
         nVersion = 0;
-        hashMerkleRoot = uint256();
+        hashMerkleRoot = UINT256_ZERO;
         nTime = 0;
         nBits = 0;
         nNonce = 0;
-        nAccumulatorCheckpoint = 0;
+        nAccumulatorCheckpoint = UINT256_ZERO;
 
-        hashPoAMerkleRoot = uint256();
-        minedHash = uint256();
-        hashPrevPoABlock = uint256();
+        hashPoAMerkleRoot = UINT256_ZERO;
+        minedHash = UINT256_ZERO;
+        hashPrevPoABlock = UINT256_ZERO;
     }
 
     CBlockIndex()
@@ -292,13 +292,13 @@ public:
             nAccumulatorCheckpoint = block.nAccumulatorCheckpoint;
 
         //Proof of Stake
-        bnChainTrust = uint256();
+        bnChainTrust = UINT256_ZERO;
         nMint = 0;
         nMoneySupply = 0;
         nFlags = 0;
         nStakeModifier = 0;
         nStakeModifierChecksum = 0;
-        hashProofOfStake = uint256();
+        hashProofOfStake = UINT256_ZERO;
 
         if (block.IsProofOfAudit()) {
             SetProofOfAudit();
@@ -491,13 +491,13 @@ public:
 
     CDiskBlockIndex()
     {
-        hashPrev = uint256();
-        hashNext = uint256();
+        hashPrev = UINT256_ZERO;
+        hashNext = UINT256_ZERO;
     }
 
     explicit CDiskBlockIndex(const CBlockIndex* pindex) : CBlockIndex(*pindex)
     {
-        hashPrev = (pprev ? pprev->GetBlockHash() : uint256(0));
+        hashPrev = (pprev ? pprev->GetBlockHash() : UINT256_ZERO);
         if (IsProofOfAudit()) {
             hashPoAMerkleRoot = pindex->hashPoAMerkleRoot;
             minedHash = pindex->minedHash;
@@ -539,7 +539,7 @@ public:
         } else {
             const_cast<CDiskBlockIndex*>(this)->prevoutStake.SetNull();
             const_cast<CDiskBlockIndex*>(this)->nStakeTime = 0;
-            const_cast<CDiskBlockIndex*>(this)->hashProofOfStake = uint256();
+            const_cast<CDiskBlockIndex*>(this)->hashProofOfStake = UINT256_ZERO;
         }
 
         // block header

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -29,35 +29,35 @@
  */
 static Checkpoints::MapCheckpoints mapCheckpoints =
     boost::assign::map_list_of
-    (0, uint256("000006957e238ff4e6bcf00c8a7d1b3e7249c0a2109b0391d8740821a40c1d8c"))
-    (500, uint256("00214da9b906c7c14558395b9bc88293301e6e5f87a714194079dd651293fadb")) // Final POW Block
-    (561, uint256("54872c72e81b34117bc5a6095d6f1b8d85746992d2513d7adc90a2aceed1651e")) // First PoA Block
-    (562, uint256("0f00d3a6636c8a265724764da082fdef8106fce7057dfdda94ab6537f7211b4f")) // First Block after PoA
-    (14905, uint256("6389ecdb851500d9467b41a54d02c58b1542bfc2d5c99339821c89d25135a4b0")) // Chain split
-    (17128, uint256("98d76615ef96b3ced1d9902715ba432393335b791b2256936883c323f0bb91f4"))
-    (17133, uint256("d9dcec83e8a675db0f7b6d28fde591f494a1b0766f7cb56ea8d8cb95348f835b"))
-    (17150, uint256("bad4dccf8fd86f00d6c215802d39342e4de64e21155b76b38f0182ba7d96edd2"))
-    (17153, uint256("4e63d92ac5209f0a342c2e74098778bbe36324de66734ff41132c7f3db3ad628"))
-    (18375, uint256("c291cf0a7bcd73a91c6f68d28dc6ce9e1acee973fd134f4250c1ee80bf3d0c03"))
-    (18813, uint256("ccf401e6fb24f34c105b2f693c2eb75c2ba7a2a4e3ffbbfe152e98ae9806d418"))
-    (18814, uint256("f8092b5c474cc260edb7c378c4f7e2123b007a55018d32f97b9b729f729067ae"))
-    (19317, uint256("0bd530827eff9bdc79893739c02c14c02bb35a39b943eaeeb72e04767e0597a5"))    
-    (19400, uint256("cdeebfe4fdeda461ab2025d08248e89b13a1e970c76b91ac2788837c147e6f33"))
-    (77852, uint256("e6ec3ddccfb6bd378ca3cf5cc292c011ec235536a9edbb8c3fdbe17abd921d44"))
-    (98715, uint256("04b3cfde139af89ddacf3cb790daf734e4953119c4a58da9b8f07be888271670"))
-    (98768, uint256("43f42aaba4a1e8f7a4981b7d8620e5967974b0bbdee4ae22e42f14585be3a52f"))
-    (105629, uint256("82ae47c00a0338f33a41b8505162cabaa4740f2187feb07f4ee4bc6138461acb"))
-    (129267, uint256("773de63a6ef8cd4d56769a0efc8625fa617bbac34802019b3a211bbe390f34a6"))
-    (132020, uint256("d93d3f4b85dd3f3995d010966f8e0163f324bfe3e748507fadf472a14c76ce36"))
-    (133535, uint256("33d415384dc2d181f9cd0208d6c8664dfdbfb95a061a639220b4ea253df7788c"))
-    (140352, uint256("cdef2002ee6d10a0a8e85ba47329455773245e6008aa691416b63d7ec3aef78d"))
-    (155115, uint256("ea78ac399244d06b407ff349ba71747d8c672ccd54216317abc28dbca04c71e5")) // A PoA block was rejected here, avoid it
-    (155116, uint256("929d16db920af3df60cf2e869ee08d174f7d476d65e53cbf07d54b7d1cca2380")) // First PoA Block after fix/difficulty bump
-    (193949, uint256("98ed9238e67297071a13b6e62fa17c5c992998a295ea7535cdcd4c3dda8aeab3")) // First PoA Block after fix/difficulty bump
-    (260162, uint256("97d593c9ebbcc219eeed822f05ba4291e7dcc4c3667836dbfe29667fe31808a7"))
-    (369757, uint256("445cc1e7abeca5bd13669704241efb9c045bf414d80c5173c7f80018381ba5a3"))
-    (370034, uint256("2c98b9b6fc800b0ba9836669c1474a95d1e4afd2a91edbec25d3bc05636deab3"))
-    (385916, uint256("05c5ff466e345d9ab1a8a029b748f130c8707b8c4ce9dd315fc7f6760d1857c8"))
+    (0, uint256S("000006957e238ff4e6bcf00c8a7d1b3e7249c0a2109b0391d8740821a40c1d8c"))
+    (500, uint256S("00214da9b906c7c14558395b9bc88293301e6e5f87a714194079dd651293fadb")) // Final POW Block
+    (561, uint256S("54872c72e81b34117bc5a6095d6f1b8d85746992d2513d7adc90a2aceed1651e")) // First PoA Block
+    (562, uint256S("0f00d3a6636c8a265724764da082fdef8106fce7057dfdda94ab6537f7211b4f")) // First Block after PoA
+    (14905, uint256S("6389ecdb851500d9467b41a54d02c58b1542bfc2d5c99339821c89d25135a4b0")) // Chain split
+    (17128, uint256S("98d76615ef96b3ced1d9902715ba432393335b791b2256936883c323f0bb91f4"))
+    (17133, uint256S("d9dcec83e8a675db0f7b6d28fde591f494a1b0766f7cb56ea8d8cb95348f835b"))
+    (17150, uint256S("bad4dccf8fd86f00d6c215802d39342e4de64e21155b76b38f0182ba7d96edd2"))
+    (17153, uint256S("4e63d92ac5209f0a342c2e74098778bbe36324de66734ff41132c7f3db3ad628"))
+    (18375, uint256S("c291cf0a7bcd73a91c6f68d28dc6ce9e1acee973fd134f4250c1ee80bf3d0c03"))
+    (18813, uint256S("ccf401e6fb24f34c105b2f693c2eb75c2ba7a2a4e3ffbbfe152e98ae9806d418"))
+    (18814, uint256S("f8092b5c474cc260edb7c378c4f7e2123b007a55018d32f97b9b729f729067ae"))
+    (19317, uint256S("0bd530827eff9bdc79893739c02c14c02bb35a39b943eaeeb72e04767e0597a5"))
+    (19400, uint256S("cdeebfe4fdeda461ab2025d08248e89b13a1e970c76b91ac2788837c147e6f33"))
+    (77852, uint256S("e6ec3ddccfb6bd378ca3cf5cc292c011ec235536a9edbb8c3fdbe17abd921d44"))
+    (98715, uint256S("04b3cfde139af89ddacf3cb790daf734e4953119c4a58da9b8f07be888271670"))
+    (98768, uint256S("43f42aaba4a1e8f7a4981b7d8620e5967974b0bbdee4ae22e42f14585be3a52f"))
+    (105629, uint256S("82ae47c00a0338f33a41b8505162cabaa4740f2187feb07f4ee4bc6138461acb"))
+    (129267, uint256S("773de63a6ef8cd4d56769a0efc8625fa617bbac34802019b3a211bbe390f34a6"))
+    (132020, uint256S("d93d3f4b85dd3f3995d010966f8e0163f324bfe3e748507fadf472a14c76ce36"))
+    (133535, uint256S("33d415384dc2d181f9cd0208d6c8664dfdbfb95a061a639220b4ea253df7788c"))
+    (140352, uint256S("cdef2002ee6d10a0a8e85ba47329455773245e6008aa691416b63d7ec3aef78d"))
+    (155115, uint256S("ea78ac399244d06b407ff349ba71747d8c672ccd54216317abc28dbca04c71e5")) // A PoA block was rejected here, avoid it
+    (155116, uint256S("929d16db920af3df60cf2e869ee08d174f7d476d65e53cbf07d54b7d1cca2380")) // First PoA Block after fix/difficulty bump
+    (193949, uint256S("98ed9238e67297071a13b6e62fa17c5c992998a295ea7535cdcd4c3dda8aeab3")) // First PoA Block after fix/difficulty bump
+    (260162, uint256S("97d593c9ebbcc219eeed822f05ba4291e7dcc4c3667836dbfe29667fe31808a7"))
+    (369757, uint256S("445cc1e7abeca5bd13669704241efb9c045bf414d80c5173c7f80018381ba5a3"))
+    (370034, uint256S("2c98b9b6fc800b0ba9836669c1474a95d1e4afd2a91edbec25d3bc05636deab3"))
+    (385916, uint256S("05c5ff466e345d9ab1a8a029b748f130c8707b8c4ce9dd315fc7f6760d1857c8"))
     ;
 static const Checkpoints::CCheckpointData data = {
     &mapCheckpoints,
@@ -68,7 +68,7 @@ static const Checkpoints::CCheckpointData data = {
 };
 
 static Checkpoints::MapCheckpoints mapCheckpointsTestnet =
-    boost::assign::map_list_of(0, uint256("000001488be8bb442cd72cb737ade49a31de90dbbe5dce36f7d7e07f5dde2b77"));
+    boost::assign::map_list_of(0, uint256S("000001488be8bb442cd72cb737ade49a31de90dbbe5dce36f7d7e07f5dde2b77"));
 static const Checkpoints::CCheckpointData dataTestnet = {
     &mapCheckpointsTestnet,
     0,
@@ -76,7 +76,7 @@ static const Checkpoints::CCheckpointData dataTestnet = {
     0};
 
 static Checkpoints::MapCheckpoints mapCheckpointsRegtest =
-    boost::assign::map_list_of(0, uint256("690cbb5c7ae999de1de49948a3c109d3b15fe4de4297980de8ff0cbfe3c7823a"));
+    boost::assign::map_list_of(0, uint256S("690cbb5c7ae999de1de49948a3c109d3b15fe4de4297980de8ff0cbfe3c7823a"));
 static const Checkpoints::CCheckpointData dataRegtest = {
     &mapCheckpointsRegtest,
     0,
@@ -188,8 +188,8 @@ public:
 
 
         hashGenesisBlock = genesis.GetHash();
-        assert(hashGenesisBlock == uint256("000006957e238ff4e6bcf00c8a7d1b3e7249c0a2109b0391d8740821a40c1d8c"));
-        assert(genesis.hashMerkleRoot == uint256("cd01f1ca20c22b336f1ee83af9fd8b7facbf42083bf3bed49af045f5cadc9cd4"));
+        assert(hashGenesisBlock == uint256S("000006957e238ff4e6bcf00c8a7d1b3e7249c0a2109b0391d8740821a40c1d8c"));
+        assert(genesis.hashMerkleRoot == uint256S("cd01f1ca20c22b336f1ee83af9fd8b7facbf42083bf3bed49af045f5cadc9cd4"));
 
         // nodes with support for servicebits filtering should be at the top
         vSeeds.push_back(CDNSSeedData("seed.prcycoin.com", "seed.prcycoin.com"));          // Single node address
@@ -318,7 +318,7 @@ public:
         }
 
         hashGenesisBlock = genesis.GetHash();
-        assert(hashGenesisBlock == uint256("000001488be8bb442cd72cb737ade49a31de90dbbe5dce36f7d7e07f5dde2b77"));
+        assert(hashGenesisBlock == uint256S("000001488be8bb442cd72cb737ade49a31de90dbbe5dce36f7d7e07f5dde2b77"));
 
         vFixedSeeds.clear();
         vSeeds.clear();
@@ -420,7 +420,7 @@ public:
         hashGenesisBlock = genesis.GetHash();
         nDefaultPort = 51476;
 
-        assert(hashGenesisBlock == uint256("690cbb5c7ae999de1de49948a3c109d3b15fe4de4297980de8ff0cbfe3c7823a"));
+        assert(hashGenesisBlock == uint256S("690cbb5c7ae999de1de49948a3c109d3b15fe4de4297980de8ff0cbfe3c7823a"));
 
         vFixedSeeds.clear(); //! Testnet mode doesn't have any fixed seeds.
         vSeeds.clear();      //! Testnet mode doesn't have any DNS seeds.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -100,7 +100,7 @@ public:
         pchMessageStart[2] = 0xa6;
         pchMessageStart[3] = 0x90;
         nDefaultPort = 59682;
-        bnProofOfWorkLimit = ~uint256(0) >> 1; // PRCYcoin starting difficulty is 1 / 2^12
+        bnProofOfWorkLimit = ~UINT256_ZERO >> 1; // PRCYcoin starting difficulty is 1 / 2^12
         nSubsidyHalvingInterval = 210000;
         nMaxReorganizationDepth = 100;
         nEnforceBlockUpgradeMajority = 8100; // 75%
@@ -148,7 +148,7 @@ public:
         txNew.vout[0].nValue = 0 * COIN;
         txNew.vout[0].scriptPubKey = CScript() << ParseHex("04b78f63269234b741668d85b57ba11edec2ee20f15719db180d5d6a37c4e9db0c494390fb54925934bc7b29f148a372c00273bbd5c939830d7d2941de6ce44b8b") << OP_CHECKSIG;
         genesis.vtx.push_back(txNew);
-        genesis.hashPrevBlock = 0;
+        genesis.hashPrevBlock.SetNull();
         genesis.hashMerkleRoot = genesis.BuildMerkleTree();
         genesis.nVersion = 1;
         genesis.nTime = 1610409600; // 1/12/2021 @ 12:00am (GMT)
@@ -383,7 +383,7 @@ public:
         nMinerThreads = 1;
         nTargetTimespan = 24 * 60 * 60; // Prcycoin: 1 day
         nTargetSpacing = 1 * 60;        // Prcycoin: 1 minutes
-        bnProofOfWorkLimit = ~uint256(0) >> 1;
+        bnProofOfWorkLimit = ~UINT256_ZERO >> 1;
         genesis.nTime = 1608422399;
         genesis.nBits = 0x207fffff;
         genesis.nNonce = 12361;

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -56,7 +56,7 @@ bool CCoins::Spend(const COutPoint& out, CTxInUndo& undo)
 bool CCoins::Spend(int nPos)
 {
     CTxInUndo undo;
-    COutPoint out(0, nPos);
+    COutPoint out(UINT256_ZERO, nPos);
     return Spend(out, undo);
 }
 

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -63,7 +63,7 @@ bool CCoins::Spend(int nPos)
 
 bool CCoinsView::GetCoins(const uint256& txid, CCoins& coins) const { return false; }
 bool CCoinsView::HaveCoins(const uint256& txid) const { return false; }
-uint256 CCoinsView::GetBestBlock() const { return uint256(0); }
+uint256 CCoinsView::GetBestBlock() const { return UINT256_ZERO; }
 bool CCoinsView::BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock) { return false; }
 bool CCoinsView::GetStats(CCoinsStats& stats) const { return false; }
 
@@ -78,7 +78,7 @@ bool CCoinsViewBacked::GetStats(CCoinsStats& stats) const { return base->GetStat
 
 CCoinsKeyHasher::CCoinsKeyHasher() : salt(GetRandHash()) {}
 
-CCoinsViewCache::CCoinsViewCache(CCoinsView* baseIn) : CCoinsViewBacked(baseIn), hasModifier(false), hashBlock(0) {}
+CCoinsViewCache::CCoinsViewCache(CCoinsView* baseIn) : CCoinsViewBacked(baseIn), hasModifier(false) {}
 
 CCoinsViewCache::~CCoinsViewCache()
 {
@@ -154,7 +154,7 @@ bool CCoinsViewCache::HaveCoins(const uint256& txid) const
 
 uint256 CCoinsViewCache::GetBestBlock() const
 {
-    if (hashBlock == uint256(0))
+    if (hashBlock.IsNull())
         hashBlock = base->GetBestBlock();
     return hashBlock;
 }

--- a/src/coins.h
+++ b/src/coins.h
@@ -329,7 +329,7 @@ struct CCoinsStats {
     uint256 hashSerialized;
     CAmount nTotalAmount;
 
-    CCoinsStats() : nHeight(0), hashBlock(0), nTransactions(0), nTransactionOutputs(0), nSerializedSize(0), hashSerialized(0), nTotalAmount(0) {}
+    CCoinsStats() : nHeight(0), nTransactions(0), nTransactionOutputs(0), nSerializedSize(0), nTotalAmount(0) {}
 };
 
 

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -133,7 +133,7 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry)
     }
     entry.pushKV("vout", vout);
 
-    if (hashBlock != 0)
+    if (!hashBlock.IsNull())
         entry.pushKV("blockhash", hashBlock.GetHex());
 
     entry.pushKV("hex", EncodeHexTx(tx)); // the hex-encoded transaction. used the name "hex" to be consistent with the verbose output of "getrawtransaction".

--- a/src/hdchain.cpp
+++ b/src/hdchain.cpp
@@ -12,7 +12,7 @@
 bool CHDChain::SetNull()
 {
     nVersion = CURRENT_VERSION;
-    id = uint256();
+    id = UINT256_ZERO;
     fCrypted = false;
     vchSeed.clear();
     vchMnemonic.clear();
@@ -22,7 +22,7 @@ bool CHDChain::SetNull()
 
 bool CHDChain::IsNull() const
 {
-    return vchSeed.empty() || id == uint256();
+    return vchSeed.empty() || id == UINT256_ZERO;
 }
 
 void CHDChain::SetCrypted(bool fCryptedIn)

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -83,7 +83,7 @@ static bool SelectBlockFromCandidates(
     bool fModifierV2 = false;
     bool fFirstRun = true;
     bool fSelected = false;
-    uint256 hashBest = 0;
+    uint256 hashBest;
     *pindexSelected = (const CBlockIndex*)0;
     for (const PAIRTYPE(int64_t, uint256) & item : vSortedByTimestamp) {
         if (!mapBlockIndex.count(item.second))
@@ -107,7 +107,7 @@ static bool SelectBlockFromCandidates(
         if(fModifierV2)
             hashProof = pindex->GetBlockHash();
         else
-            hashProof = pindex->IsProofOfStake() ? 0 : pindex->GetBlockHash();
+            hashProof = pindex->IsProofOfStake() ? UINT256_ZERO : pindex->GetBlockHash();
 
         CDataStream ss(SER_GETHASH, 0);
         ss << hashProof << nStakeModifierPrev;
@@ -418,7 +418,7 @@ unsigned int GetStakeModifierChecksum(const CBlockIndex* pindex)
     ss << pindex->nFlags << pindex->hashProofOfStake << pindex->nStakeModifier;
     uint256 hashChecksum = Hash(ss.begin(), ss.end());
     hashChecksum >>= (256 - 32);
-    return hashChecksum.Get64();
+    return hashChecksum.GetCheapHash();
 }
 
 // Check stake modifier hard checkpoints

--- a/src/main.h
+++ b/src/main.h
@@ -109,7 +109,7 @@ static const int64_t DEFAULT_MAX_TIP_AGE = 24 * 60 * 60;
 //static const std::string FOUNDATION_WALLET = "PandirQr3T895NCsDrSKdCD4TJ324z3VDB8Amcj6wx2kKdB7LztTDefdvP4QTMdgGA72W7SHzQeFzLTo2sikmmbd19E5C8UZbbi";
 
 struct BlockHasher {
-    size_t operator()(const uint256& hash) const { return hash.GetLow64(); }
+    size_t operator()(const uint256& hash) const { return hash.GetCheapHash(); }
 };
 
 extern CScript COINBASE_FLAGS;

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -72,7 +72,7 @@ bool IsBudgetCollateralValid(uint256 nTxCollateralHash, uint256 nExpectedHash, s
     */
 
     int conf = GetIXConfirmations(nTxCollateralHash);
-    if (nBlockHash != uint256(0)) {
+    if (nBlockHash != UINT256_ZERO) {
         BlockMap::iterator mi = mapBlockIndex.find(nBlockHash);
         if (mi != mapBlockIndex.end() && (*mi).second) {
             CBlockIndex* pindex = (*mi).second;
@@ -205,7 +205,7 @@ void CBudgetManager::SubmitFinalBudget()
         return;
     }
 
-    if (nBlockHash != uint256(0)) {
+    if (nBlockHash != UINT256_ZERO) {
         BlockMap::iterator mi = mapBlockIndex.find(nBlockHash);
         if (mi != mapBlockIndex.end() && (*mi).second) {
             CBlockIndex* pindex = (*mi).second;

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -284,7 +284,7 @@ public:
     {
         payee = CScript();
         nAmount = 0;
-        nProposalHash = 0;
+        nProposalHash = UINT256_ZERO;
     }
 
     ADD_SERIALIZE_METHODS;

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -488,7 +488,7 @@ bool CMasternodePayments::IsScheduled(CMasternode& mn, int nNotBlockHeight)
 
 bool CMasternodePayments::AddWinningMasternode(CMasternodePaymentWinner& winnerIn)
 {
-    uint256 blockHash = 0;
+    uint256 blockHash;
     if (!GetBlockHash(blockHash, winnerIn.nBlockHeight - 100)) {
         return false;
     }

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -266,7 +266,7 @@ void CMasternodeSync::Process()
             } else if (RequestedMasternodeAttempt < 6) {
                 int nMnCount = mnodeman.CountEnabled();
                 pnode->PushMessage(NetMsgType::GETMNWINNERS, nMnCount); //sync payees
-                uint256 n = 0;
+                uint256 n;
                 pnode->PushMessage(NetMsgType::BUDGETVOTESYNC, n); //sync masternode votes
             } else {
                 RequestedMasternodeAssets = MASTERNODE_SYNC_FINISHED;
@@ -355,7 +355,7 @@ void CMasternodeSync::Process()
 
                 if (RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD * 3) return;
 
-                uint256 n = 0;
+                uint256 n;
                 pnode->PushMessage(NetMsgType::BUDGETVOTESYNC, n); //sync masternode votes
                 RequestedMasternodeAttempt++;
 

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -158,14 +158,14 @@ bool CMasternode::UpdateFromNewBroadcast(CMasternodeBroadcast& mnb)
 //
 uint256 CMasternode::CalculateScore(int mod, int64_t nBlockHeight)
 {
-    if (chainActive.Tip() == NULL) return 0;
+    if (chainActive.Tip() == NULL) return UINT256_ZERO;
 
     uint256 hash;
     uint256 aux = vin.prevout.hash + vin.prevout.n;
 
     if (!GetBlockHash(hash, nBlockHeight)) {
         LogPrint(BCLog::MASTERNODE,"CalculateScore ERROR - nHeight %d - Returned 0\n", nBlockHeight);
-        return 0;
+        return UINT256_ZERO;
     }
 
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
@@ -206,7 +206,7 @@ void CMasternode::Check(bool forceCheck)
             TRY_LOCK(cs_main, lockMain);
             if (!lockMain) return;
 
-            if (IsSpentKeyImage(vin.keyImage.GetHex(), uint256())) {
+            if (IsSpentKeyImage(vin.keyImage.GetHex(), UINT256_ZERO)) {
                 activeState = MASTERNODE_VIN_SPENT;
                 return;
             }

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -160,7 +160,7 @@ uint256 CMasternode::CalculateScore(int mod, int64_t nBlockHeight)
 {
     if (chainActive.Tip() == NULL) return 0;
 
-    uint256 hash = 0;
+    uint256 hash;
     uint256 aux = vin.prevout.hash + vin.prevout.n;
 
     if (!GetBlockHash(hash, nBlockHeight)) {
@@ -612,7 +612,7 @@ bool CMasternodeBroadcast::CheckInputsAndAdd(int& nDoS)
 
     // verify that sig time is legit in past
     // should be at least not earlier than block when 1000 PRCY tx got MASTERNODE_MIN_CONFIRMATIONS
-    uint256 hashBlock = 0;
+    uint256 hashBlock = UINT256_ZERO;
     CTransaction tx2;
     GetTransaction(vin.prevout.hash, tx2, hashBlock, true);
     BlockMap::iterator mi = mapBlockIndex.find(hashBlock);
@@ -694,7 +694,7 @@ std::string CMasternodeBroadcast::GetStrMessage()
 CMasternodePing::CMasternodePing()
 {
     vin = CTxIn();
-    blockHash = uint256(0);
+    blockHash = UINT256_ZERO;
     sigTime = 0;
     vchSig = std::vector<unsigned char>();
 }

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -516,7 +516,7 @@ CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight
     //  -- (chance per block * chances before IsScheduled will fire)
     int nTenthNetwork = CountEnabled() / 10;
     int nCountTenth = 0;
-    uint256 nHigh = 0;
+    uint256 nHigh;
     for (PAIRTYPE(int64_t, CTxIn) & s : vecMasternodeLastPaid) {
         CMasternode* pmn = Find(s.second);
         if (!pmn) break;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -595,7 +595,7 @@ int CMasternodeMan::GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight, in
     int64_t nMasternode_Age = 0;
 
     //make sure we know about this block
-    uint256 hash = 0;
+    uint256 hash;
     if (!GetBlockHash(hash, nBlockHeight)) return -1;
 
     // scan for winner
@@ -634,7 +634,7 @@ std::vector<std::pair<int, CMasternode> > CMasternodeMan::GetMasternodeRanks(int
     std::vector<std::pair<int, CMasternode> > vecMasternodeRanks;
 
     //make sure we know about this block
-    uint256 hash = 0;
+    uint256 hash;
     if (!GetBlockHash(hash, nBlockHeight)) return vecMasternodeRanks;
 
     // scan for winner

--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -81,7 +81,7 @@ uint256 CPartialMerkleTree::TraverseAndExtract(int height, unsigned int pos, uns
     if (nBitsUsed >= vBits.size()) {
         // overflowed the bits array - failure
         fBad = true;
-        return 0;
+        return UINT256_ZERO;
     }
     bool fParentOfMatch = vBits[nBitsUsed++];
     if (height == 0 || !fParentOfMatch) {
@@ -89,7 +89,7 @@ uint256 CPartialMerkleTree::TraverseAndExtract(int height, unsigned int pos, uns
         if (nHashUsed >= vHash.size()) {
             // overflowed the hash array - failure
             fBad = true;
-            return 0;
+            return UINT256_ZERO;
         }
         const uint256& hash = vHash[nHashUsed++];
         if (height == 0 && fParentOfMatch) // in case of height 0, we have a matched txid
@@ -129,16 +129,16 @@ uint256 CPartialMerkleTree::ExtractMatches(std::vector<uint256>& vMatch)
     vMatch.clear();
     // An empty set will not work
     if (nTransactions == 0)
-        return 0;
+        return UINT256_ZERO;
     // check for excessively high numbers of transactions
     if (nTransactions > MAX_BLOCK_SIZE_CURRENT / 60) // 60 is the lower bound for the size of a serialized CTransaction
-        return 0;
+        return UINT256_ZERO;
     // there can never be more hashes provided than one for every txid
     if (vHash.size() > nTransactions)
-        return 0;
+        return UINT256_ZERO;
     // there must be at least one bit per node in the partial tree, and at least one node per hash
     if (vBits.size() < vHash.size())
-        return 0;
+        return UINT256_ZERO;
     // calculate height of tree
     int nHeight = 0;
     while (CalcTreeWidth(nHeight) > 1)
@@ -148,12 +148,12 @@ uint256 CPartialMerkleTree::ExtractMatches(std::vector<uint256>& vMatch)
     uint256 hashMerkleRoot = TraverseAndExtract(nHeight, 0, nBitsUsed, nHashUsed, vMatch);
     // verify that no problems occured during the tree traversal
     if (fBad)
-        return 0;
+        return UINT256_ZERO;
     // verify that all bits were consumed (except for the padding caused by serializing it as a byte sequence)
     if ((nBitsUsed + 7) / 8 != (vBits.size() + 7) / 8)
-        return 0;
+        return UINT256_ZERO;
     // verify that all hashes were consumed
     if (nHashUsed != vHash.size())
-        return 0;
+        return UINT256_ZERO;
     return hashMerkleRoot;
 }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -263,7 +263,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, const CPubKey& txP
             // Check key images not duplicated with what in db
             for (const CTxIn& txin : tx.vin) {
                 const CKeyImage& keyImage = txin.keyImage;
-                if (IsSpentKeyImage(keyImage.GetHex(), uint256())) {
+                if (IsSpentKeyImage(keyImage.GetHex(), UINT256_ZERO)) {
                     fKeyImageCheck = false;
                     break;
                 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2063,7 +2063,7 @@ CNode::CNode(SOCKET hSocketIn, CAddress addrIn, std::string addrNameIn, bool fIn
     nRefCount = 0;
     nSendSize = 0;
     nSendOffset = 0;
-    hashContinue = 0;
+    hashContinue = UINT256_ZERO;
     nStartingHeight = -1;
     fGetAddr = false;
     fRelayTxes = false;

--- a/src/poa.cpp
+++ b/src/poa.cpp
@@ -51,7 +51,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     }
 
     if (pindexLast->nHeight > Params().LAST_POW_BLOCK()) {
-        uint256 bnTargetLimit = (~uint256(0) >> 24);
+        uint256 bnTargetLimit = (~UINT256_ZERO >> 24);
         int64_t nTargetSpacing = 60;
         int64_t nTargetTimespan = 60 * 40;
 
@@ -151,7 +151,7 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits)
     bnTarget.SetCompact(nBits, &fNegative, &fOverflow);
 
     // Check range
-    if (fNegative || bnTarget == 0 || fOverflow || bnTarget > Params().ProofOfWorkLimit())
+    if (fNegative || bnTarget.IsNull() || fOverflow || bnTarget > Params().ProofOfWorkLimit())
         return error("CheckProofOfWork(): nBits below minimum work");
 
     // Check proof of work matches claimed amount
@@ -167,8 +167,8 @@ uint256 GetBlockProof(const CBlockIndex& block)
     bool fNegative;
     bool fOverflow;
     bnTarget.SetCompact(block.nBits, &fNegative, &fOverflow);
-    if (fNegative || fOverflow || bnTarget == 0)
-        return 0;
+    if (fNegative || fOverflow || bnTarget.IsNull())
+        return UINT256_ZERO;
     // We need to compute 2**256 / (bnTarget+1), but we can't represent 2**256
     // as it's too large for a uint256. However, as 2**256 is at least as large
     // as bnTarget+1, it is equal to ((2**256 - bnTarget - 1) / (bnTarget+1)) + 1,

--- a/src/prcycoin-tx.cpp
+++ b/src/prcycoin-tx.cpp
@@ -321,7 +321,7 @@ static bool findSighashFlags(int& flags, const std::string& flagStr)
 uint256 ParseHashUO(std::map<std::string, UniValue>& o, std::string strKey)
 {
     if (!o.count(strKey))
-        return 0;
+        return UINT256_ZERO;
     return ParseHashUV(o[strKey], strKey);
 }
 
@@ -490,7 +490,7 @@ static void MutateTx(CMutableTransaction& tx, const std::string& command, const 
 static void OutputTxJSON(const CTransaction& tx)
 {
     UniValue entry(UniValue::VOBJ);
-    TxToUniv(tx, 0, entry);
+    TxToUniv(tx, UINT256_ZERO, entry);
 
     std::string jsonOutput = entry.write(4);
     fprintf(stdout, "%s\n", jsonOutput.c_str());

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -75,7 +75,7 @@ uint256 CBlockHeader::ComputeMinedHash() const
             BEGIN(nBits), END(nBits),
             BEGIN(nNonce), END(nNonce));
     }
-    return uint256();
+    return UINT256_ZERO;
 }
 
 uint256 CBlockHeader::GetHash() const
@@ -220,7 +220,7 @@ std::vector<uint256> CBlock::GetPoAMerkleBranch(int nIndex) const
 uint256 CBlock::CheckMerkleBranch(uint256 hash, const std::vector<uint256>& vMerkleBranch, int nIndex)
 {
     if (nIndex == -1)
-        return uint256();
+        return UINT256_ZERO;
     for (std::vector<uint256>::const_iterator it(vMerkleBranch.begin()); it != vMerkleBranch.end(); ++it)
     {
         if (nIndex & 1)
@@ -235,7 +235,7 @@ uint256 CBlock::CheckMerkleBranch(uint256 hash, const std::vector<uint256>& vMer
 uint256 CBlock::CheckPoAMerkleBranch(uint256 mhash, const std::vector<uint256>& poaMerkleBranch, int nIndex)
 {
     if (nIndex == -1)
-        return uint256();
+        return UINT256_ZERO;
     for (std::vector<uint256>::const_iterator it(poaMerkleBranch.begin()); it != poaMerkleBranch.end(); ++it)
     {
         if (nIndex & 1)

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -154,7 +154,7 @@ uint256 CBlock::BuildMerkleTree(bool* fMutated) const
     if (fMutated) {
         *fMutated = mutated;
     }
-    return (vMerkleTree.empty() ? uint256() : vMerkleTree.back());
+    return (vMerkleTree.empty() ? UINT256_ZERO : vMerkleTree.back());
 }
 
 uint256 CBlock::BuildPoAMerkleTree(bool* fMutated) const
@@ -182,7 +182,7 @@ uint256 CBlock::BuildPoAMerkleTree(bool* fMutated) const
     if (fMutated) {
         *fMutated = mutated;
     }
-    return (poaMerkleTree.empty() ? uint256() : poaMerkleTree.back());
+    return (poaMerkleTree.empty() ? UINT256_ZERO : poaMerkleTree.back());
 }
 
 std::vector<uint256> CBlock::GetMerkleBranch(int nIndex) const

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -121,7 +121,7 @@ public:
         nTime = 0;
         nBits = 0;
         nNonce = 0;
-        nAccumulatorCheckpoint = 0;
+        nAccumulatorCheckpoint.SetNull();
     }
 
     bool IsNull() const

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -115,7 +115,7 @@ void CTransaction::UpdateHash() const
     *const_cast<uint256*>(&hash) = SerializeHash(*this);
 }
 
-CTransaction::CTransaction() : hash(), nVersion(CTransaction::CURRENT_VERSION), vin(), vout(), nLockTime(0), hasPaymentID(0), paymentID(0), txType(TX_TYPE_FULL), nTxFee(0) { }
+CTransaction::CTransaction() : nVersion(CTransaction::CURRENT_VERSION), vin(), vout(), nLockTime(0), hasPaymentID(0), paymentID(0), txType(TX_TYPE_FULL), nTxFee(0) { }
 
 CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion), vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime), hasPaymentID(tx.hasPaymentID), paymentID(tx.paymentID), txType(tx.txType), bulletproofs(tx.bulletproofs), nTxFee(tx.nTxFee), c(tx.c), S(tx.S), ntxFeeKeyImage(tx.ntxFeeKeyImage) {
     UpdateHash();

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -206,7 +206,7 @@ void CAddress::Init()
 CInv::CInv()
 {
     type = 0;
-    hash = 0;
+    hash.SetNull();
 }
 
 CInv::CInv(int typeIn, const uint256& hashIn)

--- a/src/qt/blockexplorer.cpp
+++ b/src/qt/blockexplorer.cpp
@@ -451,7 +451,7 @@ bool BlockExplorer::switchTo(const QString& query)
 
     // If the query is neither an integer nor a block hash, assume a transaction hash
     CTransaction tx;
-    uint256 hashBlock = 0;
+    uint256 hashBlock = UINT256_ZERO;
     if (GetTransaction(hash, tx, hashBlock, true)) {
         setContent(TxToString(hashBlock, tx));
         return true;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -343,7 +343,7 @@ static bool rest_tx(HTTPRequest *req, const std::string &strURIPart) {
         return RESTERR(req, HTTP_BAD_REQUEST, "Invalid hash: " + hashStr);
 
     CTransaction tx;
-    uint256 hashBlock = uint256();
+    uint256 hashBlock = UINT256_ZERO;
     if (!GetTransaction(hash, tx, hashBlock, true))
         return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -517,7 +517,7 @@ UniValue getblock(const UniValue& params, bool fHelp)
             HelpExampleCli("getblock", "\"00000000000fd08c2fb661d2fcb0d49abb3a91e5f27082ce64feed3b4dede2e2\"") + HelpExampleRpc("getblock", "\"00000000000fd08c2fb661d2fcb0d49abb3a91e5f27082ce64feed3b4dede2e2\""));
 
     std::string strHash = params[0].get_str();
-    uint256 hash(strHash);
+    uint256 hash(uint256S(strHash));
 
     bool fVerbose = true;
     if (params.size() > 1)
@@ -568,7 +568,7 @@ UniValue getblockheader(const UniValue& params, bool fHelp)
             HelpExampleCli("getblockheader", "\"00000000000fd08c2fb661d2fcb0d49abb3a91e5f27082ce64feed3b4dede2e2\"") + HelpExampleRpc("getblockheader", "\"00000000000fd08c2fb661d2fcb0d49abb3a91e5f27082ce64feed3b4dede2e2\""));
 
     std::string strHash = params[0].get_str();
-    uint256 hash(strHash);
+    uint256 hash(uint256S(strHash));
 
     bool fVerbose = true;
     if (params.size() > 1)
@@ -669,7 +669,7 @@ UniValue gettxout(const UniValue& params, bool fHelp)
     UniValue ret(UniValue::VOBJ);
 
     std::string strHash = params[0].get_str();
-    uint256 hash(strHash);
+    uint256 hash(uint256S(strHash));
     int n = params[1].get_int();
     bool fMempool = true;
     if (params.size() > 2)
@@ -1024,7 +1024,7 @@ UniValue invalidateblock(const UniValue& params, bool fHelp)
             HelpExampleCli("invalidateblock", "\"blockhash\"") + HelpExampleRpc("invalidateblock", "\"blockhash\""));
 
     std::string strHash = params[0].get_str();
-    uint256 hash(strHash);
+    uint256 hash(uint256S(strHash));
     CValidationState state;
 
     {
@@ -1096,7 +1096,7 @@ UniValue reconsiderblock(const UniValue& params, bool fHelp)
             HelpExampleCli("reconsiderblock", "\"blockhash\"") + HelpExampleRpc("reconsiderblock", "\"blockhash\""));
 
     std::string strHash = params[0].get_str();
-    uint256 hash(strHash);
+    uint256 hash(uint256S(strHash));
     CValidationState state;
 
     {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -109,7 +109,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     for (const CTransaction& tx : block.vtx) {
         if (txDetails) {
             UniValue objTx(UniValue::VOBJ);
-            TxToJSON(tx, uint256(0), objTx);
+            TxToJSON(tx, UINT256_ZERO, objTx);
             txs.push_back(objTx);
         } else
             txs.push_back(tx.GetHash().GetHex());

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -764,7 +764,7 @@ UniValue mnfinalbudget(const UniValue& params, bool fHelp)
             throw std::runtime_error("Correct usage is 'mnfinalbudget vote-many BUDGET_HASH'");
 
         std::string strHash = params[1].get_str();
-        uint256 hash(strHash);
+        uint256 hash(uint256S(strHash));
 
         int success = 0;
         int failed = 0;
@@ -836,7 +836,7 @@ UniValue mnfinalbudget(const UniValue& params, bool fHelp)
             throw std::runtime_error("Correct usage is 'mnfinalbudget vote BUDGET_HASH'");
 
         std::string strHash = params[1].get_str();
-        uint256 hash(strHash);
+        uint256 hash(uint256S(strHash));
 
         CPubKey pubKeyMasternode;
         CKey keyMasternode;
@@ -894,7 +894,7 @@ UniValue mnfinalbudget(const UniValue& params, bool fHelp)
             throw std::runtime_error("Correct usage is 'mnbudget getvotes budget-hash'");
 
         std::string strHash = params[1].get_str();
-        uint256 hash(strHash);
+        uint256 hash(uint256S(strHash));
 
         UniValue obj(UniValue::VOBJ);
 

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -118,7 +118,7 @@ UniValue preparebudget(const UniValue& params, bool fHelp)
     //*************************************************************************
 
     // create transaction 15 minutes into the future, to allow for confirmation time
-    CBudgetProposalBroadcast budgetProposalBroadcast(strProposalName, strURL, nPaymentCount, scriptPubKey, nAmount, nBlockStart, 0);
+    CBudgetProposalBroadcast budgetProposalBroadcast(strProposalName, strURL, nPaymentCount, scriptPubKey, nAmount, nBlockStart, UINT256_ZERO);
 
     std::string strError = "";
     if (!budgetProposalBroadcast.IsValid(strError, false))

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -453,7 +453,7 @@ UniValue startmasternode (const UniValue& params, bool fHelp)
             int nIndex;
             if(!mne.castOutputIndex(nIndex))
                 continue;
-            CTxIn vin = CTxIn(uint256(mne.getTxHash()), uint32_t(nIndex));
+            CTxIn vin = CTxIn(uint256S(mne.getTxHash()), uint32_t(nIndex));
             CMasternode* pmn = mnodeman.Find(vin);
             CMasternodeBroadcast mnb;
 
@@ -633,7 +633,7 @@ UniValue listmasternodeconf (const UniValue& params, bool fHelp)
         int nIndex;
         if(!mne.castOutputIndex(nIndex))
             continue;
-        CTxIn vin = CTxIn(uint256(mne.getTxHash()), uint32_t(nIndex));
+        CTxIn vin = CTxIn(uint256S(mne.getTxHash()), uint32_t(nIndex));
         CMasternode* pmn = mnodeman.Find(vin);
 
         std::string strStatus = pmn ? pmn->Status() : "MISSING";

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -828,7 +828,7 @@ UniValue getmasternodescores (const UniValue& params, bool fHelp)
 
     std::vector<CMasternode> vMasternodes = mnodeman.GetFullMasternodeVector();
     for (int nHeight = chainActive.Tip()->nHeight - nLast; nHeight < chainActive.Tip()->nHeight + 20; nHeight++) {
-        uint256 nHigh = 0;
+        uint256 nHigh;
         CMasternode* pBestMasternode = NULL;
         for (CMasternode& mn : vMasternodes) {
             uint256 n = mn.CalculateScore(1, nHeight - 100);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -323,7 +323,7 @@ UniValue getrawtransaction(const UniValue& params, bool fHelp)
         EnsureWalletIsUnlocked();
 
     CTransaction tx;
-    uint256 hashBlock = 0;
+    uint256 hashBlock = UINT256_ZERO;
     if (!GetTransaction(hash, tx, hashBlock, true))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available about transaction");
     std::string strHex = EncodeHexTx(tx);
@@ -580,7 +580,7 @@ UniValue decoderawtransaction(const UniValue& params, bool fHelp)
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
 
     UniValue result(UniValue::VOBJ);
-    TxToJSON(tx, 0, result);
+    TxToJSON(tx, UINT256_ZERO, result);
 
     return result;
 }

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1078,14 +1078,14 @@ uint256 SignatureHash(const CScript& scriptCode, const CTransaction& txTo, unsig
 {
     if (nIn >= txTo.vin.size()) {
         //  nIn out of range
-        return 1;
+        return UINT256_ONE;
     }
 
     // Check for invalid use of SIGHASH_SINGLE
     if ((nHashType & 0x1f) == SIGHASH_SINGLE) {
         if (nIn >= txTo.vout.size()) {
             //  nOut out of range
-            return 1;
+            return UINT256_ONE;
         }
     }
 

--- a/src/test/Checkpoints_tests.cpp
+++ b/src/test/Checkpoints_tests.cpp
@@ -19,8 +19,8 @@ BOOST_FIXTURE_TEST_SUITE(Checkpoints_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(sanity)
 {
-    uint256 p259201 = uint256("0x1c9121bf9329a6234bfd1ea2d91515f19cd96990725265253f4b164283ade5dd");
-    uint256 p623933 = uint256("0xc7aafa648a0f1450157dc93bd4d7448913a85b7448f803b4ab970d91fc2a7da7");
+    uint256 p259201 = uint256S("0x1c9121bf9329a6234bfd1ea2d91515f19cd96990725265253f4b164283ade5dd");
+    uint256 p623933 = uint256S("0xc7aafa648a0f1450157dc93bd4d7448913a85b7448f803b4ab970d91fc2a7da7");
     //BOOST_CHECK(Checkpoints::CheckBlock(259201, p259201));
     //BOOST_CHECK(Checkpoints::CheckBlock(623933, p623933));
 

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -1,0 +1,845 @@
+// Copyright (c) 2011-2013 The Bitcoin Core developers
+// Copyright (c) 2017-2019 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <boost/test/unit_test.hpp>
+#include <stdint.h>
+#include <sstream>
+#include <iomanip>
+#include <limits>
+#include <cmath>
+#include "uint256.h"
+#include "arith_uint256.h"
+#include <string>
+#include "version.h"
+#include "test/test_prcycoin.h"
+
+BOOST_FIXTURE_TEST_SUITE(arith_uint256_tests, BasicTestingSetup)
+
+/// Convert vector to arith_uint256, via uint256 blob
+inline arith_uint256 arith_uint256V(const std::vector<unsigned char>& vch)
+{
+    return UintToArith256(uint256(vch));
+}
+
+const unsigned char R1Array[] =
+    "\x9c\x52\x4a\xdb\xcf\x56\x11\x12\x2b\x29\x12\x5e\x5d\x35\xd2\xd2"
+    "\x22\x81\xaa\xb5\x33\xf0\x08\x32\xd5\x56\xb1\xf9\xea\xe5\x1d\x7d";
+const char R1ArrayHex[] = "7D1DE5EAF9B156D53208F033B5AA8122D2d2355d5e12292b121156cfdb4a529c";
+const double R1Ldouble = 0.4887374590559308955; // R1L equals roughly R1Ldouble * 2^256
+const double R1Sdouble = 0.7096329412477836074;
+const arith_uint256 R1L = arith_uint256(std::vector<unsigned char>(R1Array,R1Array+32));
+const arith_uint160 R1S = arith_uint160(std::vector<unsigned char>(R1Array,R1Array+20));
+const uint64_t R1LLow64 = 0x121156cfdb4a529cULL;
+
+const unsigned char R2Array[] =
+    "\x70\x32\x1d\x7c\x47\xa5\x6b\x40\x26\x7e\x0a\xc3\xa6\x9c\xb6\xbf"
+    "\x13\x30\x47\xa3\x19\x2d\xda\x71\x49\x13\x72\xf0\xb4\xca\x81\xd7";
+const arith_uint256 R2L = arith_uint256(std::vector<unsigned char>(R2Array,R2Array+32));
+const arith_uint160 R2S = arith_uint160(std::vector<unsigned char>(R2Array,R2Array+20));
+
+const char R1LplusR2L[] = "549FB09FEA236A1EA3E31D4D58F1B1369288D204211CA751527CFC175767850C";
+
+const unsigned char ZeroArray[] =
+    "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+const arith_uint256 ZeroL = arith_uint256(std::vector<unsigned char>(ZeroArray,ZeroArray+32));
+const arith_uint160 ZeroS = arith_uint160(std::vector<unsigned char>(ZeroArray,ZeroArray+20));
+
+const unsigned char OneArray[] =
+    "\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+const arith_uint256 OneL = arith_uint256(std::vector<unsigned char>(OneArray,OneArray+32));
+const arith_uint160 OneS = arith_uint160(std::vector<unsigned char>(OneArray,OneArray+20));
+
+const unsigned char MaxArray[] =
+    "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+    "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff";
+const arith_uint256 MaxL = arith_uint256(std::vector<unsigned char>(MaxArray,MaxArray+32));
+const arith_uint160 MaxS = arith_uint160(std::vector<unsigned char>(MaxArray,MaxArray+20));
+
+const arith_uint256 HalfL = (OneL << 255);
+const arith_uint160 HalfS = (OneS << 159);
+std::string ArrayToString(const unsigned char A[], unsigned int width)
+{
+    std::stringstream Stream;
+    Stream << std::hex;
+    for (unsigned int i = 0; i < width; ++i)
+    {
+        Stream<<std::setw(2)<<std::setfill('0')<<(unsigned int)A[width-i-1];
+    }
+    return Stream.str();
+}
+
+BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
+{
+    BOOST_CHECK(1 == 0+1);
+    // constructor arith_uint256(vector<char>):
+    BOOST_CHECK(R1L.ToString() == ArrayToString(R1Array,32));
+    BOOST_CHECK(R1S.ToString() == ArrayToString(R1Array,20));
+    BOOST_CHECK(R2L.ToString() == ArrayToString(R2Array,32));
+    BOOST_CHECK(R2S.ToString() == ArrayToString(R2Array,20));
+    BOOST_CHECK(ZeroL.ToString() == ArrayToString(ZeroArray,32));
+    BOOST_CHECK(ZeroS.ToString() == ArrayToString(ZeroArray,20));
+    BOOST_CHECK(OneL.ToString() == ArrayToString(OneArray,32));
+    BOOST_CHECK(OneS.ToString() == ArrayToString(OneArray,20));
+    BOOST_CHECK(MaxL.ToString() == ArrayToString(MaxArray,32));
+    BOOST_CHECK(MaxS.ToString() == ArrayToString(MaxArray,20));
+    BOOST_CHECK(OneL.ToString() != ArrayToString(ZeroArray,32));
+    BOOST_CHECK(OneS.ToString() != ArrayToString(ZeroArray,20));
+
+    // == and !=
+    BOOST_CHECK(R1L != R2L && R1S != R2S);
+    BOOST_CHECK(ZeroL != OneL && ZeroS != OneS);
+    BOOST_CHECK(OneL != ZeroL && OneS != ZeroS);
+    BOOST_CHECK(MaxL != ZeroL && MaxS != ZeroS);
+    BOOST_CHECK(~MaxL == ZeroL && ~MaxS == ZeroS);
+    BOOST_CHECK( ((R1L ^ R2L) ^ R1L) == R2L);
+    BOOST_CHECK( ((R1S ^ R2S) ^ R1S) == R2S);
+
+    uint64_t Tmp64 = 0xc4dab720d9c7acaaULL;
+    for (unsigned int i = 0; i < 256; ++i)
+    {
+        BOOST_CHECK(ZeroL != (OneL << i));
+        BOOST_CHECK((OneL << i) != ZeroL);
+        BOOST_CHECK(R1L != (R1L ^ (OneL << i)));
+        BOOST_CHECK(((arith_uint256(Tmp64) ^ (OneL << i) ) != Tmp64 ));
+    }
+    BOOST_CHECK(ZeroL == (OneL << 256));
+
+    for (unsigned int i = 0; i < 160; ++i)
+    {
+        BOOST_CHECK(ZeroS != (OneS << i));
+        BOOST_CHECK((OneS << i) != ZeroS);
+        BOOST_CHECK(R1S != (R1S ^ (OneS << i)));
+        BOOST_CHECK(((arith_uint160(Tmp64) ^ (OneS << i) ) != Tmp64 ));
+    }
+    BOOST_CHECK(ZeroS == (OneS << 256));
+
+    // String Constructor and Copy Constructor
+    BOOST_CHECK(arith_uint256("0x"+R1L.ToString()) == R1L);
+    BOOST_CHECK(arith_uint256("0x"+R2L.ToString()) == R2L);
+    BOOST_CHECK(arith_uint256("0x"+ZeroL.ToString()) == ZeroL);
+    BOOST_CHECK(arith_uint256("0x"+OneL.ToString()) == OneL);
+    BOOST_CHECK(arith_uint256("0x"+MaxL.ToString()) == MaxL);
+    BOOST_CHECK(arith_uint256(R1L.ToString()) == R1L);
+    BOOST_CHECK(arith_uint256("   0x"+R1L.ToString()+"   ") == R1L);
+    BOOST_CHECK(arith_uint256("") == ZeroL);
+    BOOST_CHECK(R1L == arith_uint256(R1ArrayHex));
+    BOOST_CHECK(arith_uint256(R1L) == R1L);
+    BOOST_CHECK((arith_uint256(R1L^R2L)^R2L) == R1L);
+    BOOST_CHECK(arith_uint256(ZeroL) == ZeroL);
+    BOOST_CHECK(arith_uint256(OneL) == OneL);
+
+    BOOST_CHECK(arith_uint160("0x"+R1S.ToString()) == R1S);
+    BOOST_CHECK(arith_uint160("0x"+R2S.ToString()) == R2S);
+    BOOST_CHECK(arith_uint160("0x"+ZeroS.ToString()) == ZeroS);
+    BOOST_CHECK(arith_uint160("0x"+OneS.ToString()) == OneS);
+    BOOST_CHECK(arith_uint160("0x"+MaxS.ToString()) == MaxS);
+    BOOST_CHECK(arith_uint160(R1S.ToString()) == R1S);
+    BOOST_CHECK(arith_uint160("   0x"+R1S.ToString()+"   ") == R1S);
+    BOOST_CHECK(arith_uint160("") == ZeroS);
+    BOOST_CHECK(R1S == arith_uint160(R1ArrayHex));
+
+    BOOST_CHECK(arith_uint160(R1S) == R1S);
+    BOOST_CHECK((arith_uint160(R1S^R2S)^R2S) == R1S);
+    BOOST_CHECK(arith_uint160(ZeroS) == ZeroS);
+    BOOST_CHECK(arith_uint160(OneS) == OneS);
+
+    // uint64_t constructor
+    BOOST_CHECK( (R1L & arith_uint256("0xffffffffffffffff")) == arith_uint256(R1LLow64));
+    BOOST_CHECK(ZeroL == arith_uint256(0));
+    BOOST_CHECK(OneL == arith_uint256(1));
+    BOOST_CHECK(arith_uint256("0xffffffffffffffff") = arith_uint256(0xffffffffffffffffULL));
+    BOOST_CHECK( (R1S & arith_uint160("0xffffffffffffffff")) == arith_uint160(R1LLow64));
+    BOOST_CHECK(ZeroS == arith_uint160(0));
+    BOOST_CHECK(OneS == arith_uint160(1));
+    BOOST_CHECK(arith_uint160("0xffffffffffffffff") = arith_uint160(0xffffffffffffffffULL));
+
+    // Assignment (from base_uint)
+    arith_uint256 tmpL = ~ZeroL; BOOST_CHECK(tmpL == ~ZeroL);
+    tmpL = ~OneL; BOOST_CHECK(tmpL == ~OneL);
+    tmpL = ~R1L; BOOST_CHECK(tmpL == ~R1L);
+    tmpL = ~R2L; BOOST_CHECK(tmpL == ~R2L);
+    tmpL = ~MaxL; BOOST_CHECK(tmpL == ~MaxL);
+    arith_uint160 tmpS = ~ZeroS; BOOST_CHECK(tmpS == ~ZeroS);
+    tmpS = ~OneS; BOOST_CHECK(tmpS == ~OneS);
+    tmpS = ~R1S; BOOST_CHECK(tmpS == ~R1S);
+    tmpS = ~R2S; BOOST_CHECK(tmpS == ~R2S);
+    tmpS = ~MaxS; BOOST_CHECK(tmpS == ~MaxS);
+
+    // Wrong length must throw exception.
+    BOOST_CHECK_THROW(arith_uint256(std::vector<unsigned char>(OneArray,OneArray+31)), uint_error);
+    BOOST_CHECK_THROW(arith_uint256(std::vector<unsigned char>(OneArray,OneArray+20)), uint_error);
+    BOOST_CHECK_THROW(arith_uint160(std::vector<unsigned char>(OneArray,OneArray+32)), uint_error);
+    BOOST_CHECK_THROW(arith_uint160(std::vector<unsigned char>(OneArray,OneArray+19)), uint_error);
+}
+
+void shiftArrayRight(unsigned char* to, const unsigned char* from, unsigned int arrayLength, unsigned int bitsToShift)
+{
+    for (unsigned int T=0; T < arrayLength; ++T)
+    {
+        unsigned int F = (T+bitsToShift/8);
+        if (F < arrayLength)
+            to[T]  = from[F] >> (bitsToShift%8);
+        else
+            to[T] = 0;
+        if (F + 1 < arrayLength)
+            to[T] |= from[(F+1)] << (8-bitsToShift%8);
+    }
+}
+
+void shiftArrayLeft(unsigned char* to, const unsigned char* from, unsigned int arrayLength, unsigned int bitsToShift)
+{
+    for (unsigned int T=0; T < arrayLength; ++T)
+    {
+        if (T >= bitsToShift/8)
+        {
+            unsigned int F = T-bitsToShift/8;
+            to[T]  = from[F] << (bitsToShift%8);
+            if (T >= bitsToShift/8+1)
+                to[T] |= from[F-1] >> (8-bitsToShift%8);
+        }
+        else {
+            to[T] = 0;
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE( shifts ) { // "<<"  ">>"  "<<="  ">>="
+    unsigned char TmpArray[32];
+    arith_uint256 TmpL;
+    for (unsigned int i = 0; i < 256; ++i)
+    {
+        shiftArrayLeft(TmpArray, OneArray, 32, i);
+        BOOST_CHECK(arith_uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (OneL << i));
+        TmpL = OneL; TmpL <<= i;
+        BOOST_CHECK(TmpL == (OneL << i));
+        BOOST_CHECK((HalfL >> (255-i)) == (OneL << i));
+        TmpL = HalfL; TmpL >>= (255-i);
+        BOOST_CHECK(TmpL == (OneL << i));
+
+        shiftArrayLeft(TmpArray, R1Array, 32, i);
+        BOOST_CHECK(arith_uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (R1L << i));
+        TmpL = R1L; TmpL <<= i;
+        BOOST_CHECK(TmpL == (R1L << i));
+
+        shiftArrayRight(TmpArray, R1Array, 32, i);
+        BOOST_CHECK(arith_uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (R1L >> i));
+        TmpL = R1L; TmpL >>= i;
+        BOOST_CHECK(TmpL == (R1L >> i));
+
+        shiftArrayLeft(TmpArray, MaxArray, 32, i);
+        BOOST_CHECK(arith_uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (MaxL << i));
+        TmpL = MaxL; TmpL <<= i;
+        BOOST_CHECK(TmpL == (MaxL << i));
+
+        shiftArrayRight(TmpArray, MaxArray, 32, i);
+        BOOST_CHECK(arith_uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (MaxL >> i));
+        TmpL = MaxL; TmpL >>= i;
+        BOOST_CHECK(TmpL == (MaxL >> i));
+    }
+    arith_uint256 c1L = arith_uint256(0x0123456789abcdefULL);
+    arith_uint256 c2L = c1L << 128;
+    for (unsigned int i = 0; i < 128; ++i) {
+        BOOST_CHECK((c1L << i) == (c2L >> (128-i)));
+    }
+    for (unsigned int i = 128; i < 256; ++i) {
+        BOOST_CHECK((c1L << i) == (c2L << (i-128)));
+    }
+
+    arith_uint160 TmpS;
+    for (unsigned int i = 0; i < 160; ++i)
+    {
+        shiftArrayLeft(TmpArray, OneArray, 20, i);
+        BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (OneS << i));
+        TmpS = OneS; TmpS <<= i;
+        BOOST_CHECK(TmpS == (OneS << i));
+        BOOST_CHECK((HalfS >> (159-i)) == (OneS << i));
+        TmpS = HalfS; TmpS >>= (159-i);
+        BOOST_CHECK(TmpS == (OneS << i));
+
+        shiftArrayLeft(TmpArray, R1Array, 20, i);
+        BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (R1S << i));
+        TmpS = R1S; TmpS <<= i;
+        BOOST_CHECK(TmpS == (R1S << i));
+
+        shiftArrayRight(TmpArray, R1Array, 20, i);
+        BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (R1S >> i));
+        TmpS = R1S; TmpS >>= i;
+        BOOST_CHECK(TmpS == (R1S >> i));
+
+        shiftArrayLeft(TmpArray, MaxArray, 20, i);
+        BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (MaxS << i));
+        TmpS = MaxS; TmpS <<= i;
+        BOOST_CHECK(TmpS == (MaxS << i));
+
+        shiftArrayRight(TmpArray, MaxArray, 20, i);
+        BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (MaxS >> i));
+        TmpS = MaxS; TmpS >>= i;
+        BOOST_CHECK(TmpS == (MaxS >> i));
+    }
+    arith_uint160 c1S = arith_uint160(0x0123456789abcdefULL);
+    arith_uint160 c2S = c1S << 80;
+    for (unsigned int i = 0; i < 80; ++i) {
+        BOOST_CHECK((c1S << i) == (c2S >> (80-i)));
+    }
+    for (unsigned int i = 80; i < 160; ++i) {
+        BOOST_CHECK((c1S << i) == (c2S << (i-80)));
+    }
+}
+
+BOOST_AUTO_TEST_CASE( unaryOperators ) // !    ~    -
+{
+    BOOST_CHECK(!ZeroL);  BOOST_CHECK(!ZeroS);
+    BOOST_CHECK(!(!OneL));BOOST_CHECK(!(!OneS));
+    for (unsigned int i = 0; i < 256; ++i)
+        BOOST_CHECK(!(!(OneL<<i)));
+    for (unsigned int i = 0; i < 160; ++i)
+        BOOST_CHECK(!(!(OneS<<i)));
+    BOOST_CHECK(!(!R1L));BOOST_CHECK(!(!R1S));
+    BOOST_CHECK(!(!R2S));BOOST_CHECK(!(!R2S));
+    BOOST_CHECK(!(!MaxL));BOOST_CHECK(!(!MaxS));
+
+    BOOST_CHECK(~ZeroL == MaxL); BOOST_CHECK(~ZeroS == MaxS);
+
+    unsigned char TmpArray[32];
+    for (unsigned int i = 0; i < 32; ++i) { TmpArray[i] = ~R1Array[i]; }
+    BOOST_CHECK(arith_uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (~R1L));
+    BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (~R1S));
+
+    BOOST_CHECK(-ZeroL == ZeroL); BOOST_CHECK(-ZeroS == ZeroS);
+    BOOST_CHECK(-R1L == (~R1L)+1);
+    BOOST_CHECK(-R1S == (~R1S)+1);
+    for (unsigned int i = 0; i < 256; ++i)
+        BOOST_CHECK(-(OneL<<i) == (MaxL << i));
+    for (unsigned int i = 0; i < 160; ++i)
+        BOOST_CHECK(-(OneS<<i) == (MaxS << i));
+}
+
+
+// Check if doing _A_ _OP_ _B_ results in the same as applying _OP_ onto each
+// element of Aarray and Barray, and then converting the result into a arith_uint256.
+#define CHECKBITWISEOPERATOR(_A_,_B_,_OP_)                              \
+    for (unsigned int i = 0; i < 32; ++i) { TmpArray[i] = _A_##Array[i] _OP_ _B_##Array[i]; } \
+    BOOST_CHECK(arith_uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (_A_##L _OP_ _B_##L)); \
+    for (unsigned int i = 0; i < 20; ++i) { TmpArray[i] = _A_##Array[i] _OP_ _B_##Array[i]; } \
+    BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (_A_##S _OP_ _B_##S));
+
+#define CHECKASSIGNMENTOPERATOR(_A_,_B_,_OP_)                           \
+    TmpL = _A_##L; TmpL _OP_##= _B_##L; BOOST_CHECK(TmpL == (_A_##L _OP_ _B_##L)); \
+    TmpS = _A_##S; TmpS _OP_##= _B_##S; BOOST_CHECK(TmpS == (_A_##S _OP_ _B_##S));
+
+BOOST_AUTO_TEST_CASE( bitwiseOperators )
+{
+    unsigned char TmpArray[32];
+
+    CHECKBITWISEOPERATOR(R1,R2,|)
+    CHECKBITWISEOPERATOR(R1,R2,^)
+    CHECKBITWISEOPERATOR(R1,R2,&)
+    CHECKBITWISEOPERATOR(R1,Zero,|)
+    CHECKBITWISEOPERATOR(R1,Zero,^)
+    CHECKBITWISEOPERATOR(R1,Zero,&)
+    CHECKBITWISEOPERATOR(R1,Max,|)
+    CHECKBITWISEOPERATOR(R1,Max,^)
+    CHECKBITWISEOPERATOR(R1,Max,&)
+    CHECKBITWISEOPERATOR(Zero,R1,|)
+    CHECKBITWISEOPERATOR(Zero,R1,^)
+    CHECKBITWISEOPERATOR(Zero,R1,&)
+    CHECKBITWISEOPERATOR(Max,R1,|)
+    CHECKBITWISEOPERATOR(Max,R1,^)
+    CHECKBITWISEOPERATOR(Max,R1,&)
+
+    arith_uint256 TmpL;
+    arith_uint160 TmpS;
+    CHECKASSIGNMENTOPERATOR(R1,R2,|)
+    CHECKASSIGNMENTOPERATOR(R1,R2,^)
+    CHECKASSIGNMENTOPERATOR(R1,R2,&)
+    CHECKASSIGNMENTOPERATOR(R1,Zero,|)
+    CHECKASSIGNMENTOPERATOR(R1,Zero,^)
+    CHECKASSIGNMENTOPERATOR(R1,Zero,&)
+    CHECKASSIGNMENTOPERATOR(R1,Max,|)
+    CHECKASSIGNMENTOPERATOR(R1,Max,^)
+    CHECKASSIGNMENTOPERATOR(R1,Max,&)
+    CHECKASSIGNMENTOPERATOR(Zero,R1,|)
+    CHECKASSIGNMENTOPERATOR(Zero,R1,^)
+    CHECKASSIGNMENTOPERATOR(Zero,R1,&)
+    CHECKASSIGNMENTOPERATOR(Max,R1,|)
+    CHECKASSIGNMENTOPERATOR(Max,R1,^)
+    CHECKASSIGNMENTOPERATOR(Max,R1,&)
+
+    uint64_t Tmp64 = 0xe1db685c9a0b47a2ULL;
+    TmpL = R1L; TmpL |= Tmp64;  BOOST_CHECK(TmpL == (R1L | arith_uint256(Tmp64)));
+    TmpS = R1S; TmpS |= Tmp64;  BOOST_CHECK(TmpS == (R1S | arith_uint160(Tmp64)));
+    TmpL = R1L; TmpL |= 0; BOOST_CHECK(TmpL == R1L);
+    TmpS = R1S; TmpS |= 0; BOOST_CHECK(TmpS == R1S);
+    TmpL ^= 0; BOOST_CHECK(TmpL == R1L);
+    TmpS ^= 0; BOOST_CHECK(TmpS == R1S);
+    TmpL ^= Tmp64;  BOOST_CHECK(TmpL == (R1L ^ arith_uint256(Tmp64)));
+    TmpS ^= Tmp64;  BOOST_CHECK(TmpS == (R1S ^ arith_uint160(Tmp64)));
+}
+
+BOOST_AUTO_TEST_CASE( comparison ) // <= >= < >
+{
+    arith_uint256 TmpL;
+    for (unsigned int i = 0; i < 256; ++i) {
+        TmpL= OneL<< i;
+        BOOST_CHECK( TmpL >= ZeroL && TmpL > ZeroL && ZeroL < TmpL && ZeroL <= TmpL);
+        BOOST_CHECK( TmpL >= 0 && TmpL > 0 && 0 < TmpL && 0 <= TmpL);
+        TmpL |= R1L;
+        BOOST_CHECK( TmpL >= R1L ); BOOST_CHECK( (TmpL == R1L) != (TmpL > R1L)); BOOST_CHECK( (TmpL == R1L) || !( TmpL <= R1L));
+        BOOST_CHECK( R1L <= TmpL ); BOOST_CHECK( (R1L == TmpL) != (R1L < TmpL)); BOOST_CHECK( (TmpL == R1L) || !( R1L >= TmpL));
+        BOOST_CHECK(! (TmpL < R1L)); BOOST_CHECK(! (R1L > TmpL));
+    }
+    arith_uint160 TmpS;
+    for (unsigned int i = 0; i < 160; ++i) {
+        TmpS= OneS<< i;
+        BOOST_CHECK( TmpS >= ZeroS && TmpS > ZeroS && ZeroS < TmpS && ZeroS <= TmpS);
+        BOOST_CHECK( TmpS >= 0 && TmpS > 0 && 0 < TmpS && 0 <= TmpS);
+        TmpS |= R1S;
+        BOOST_CHECK( TmpS >= R1S ); BOOST_CHECK( (TmpS == R1S) != (TmpS > R1S)); BOOST_CHECK( (TmpS == R1S) || !( TmpS <= R1S));
+        BOOST_CHECK( R1S <= TmpS ); BOOST_CHECK( (R1S == TmpS) != (R1S < TmpS)); BOOST_CHECK( (TmpS == R1S) || !( R1S >= TmpS));
+        BOOST_CHECK(! (TmpS < R1S)); BOOST_CHECK(! (R1S > TmpS));
+    }
+}
+
+BOOST_AUTO_TEST_CASE( plusMinus )
+{
+    arith_uint256 TmpL = 0;
+    BOOST_CHECK(R1L+R2L == arith_uint256(R1LplusR2L));
+    TmpL += R1L;
+    BOOST_CHECK(TmpL == R1L);
+    TmpL += R2L;
+    BOOST_CHECK(TmpL == R1L + R2L);
+    BOOST_CHECK(OneL+MaxL == ZeroL);
+    BOOST_CHECK(MaxL+OneL == ZeroL);
+    for (unsigned int i = 1; i < 256; ++i) {
+        BOOST_CHECK( (MaxL >> i) + OneL == (HalfL >> (i-1)) );
+        BOOST_CHECK( OneL + (MaxL >> i) == (HalfL >> (i-1)) );
+        TmpL = (MaxL>>i); TmpL += OneL;
+        BOOST_CHECK( TmpL == (HalfL >> (i-1)) );
+        TmpL = (MaxL>>i); TmpL += 1;
+        BOOST_CHECK( TmpL == (HalfL >> (i-1)) );
+        TmpL = (MaxL>>i);
+        BOOST_CHECK( TmpL++ == (MaxL>>i) );
+        BOOST_CHECK( TmpL == (HalfL >> (i-1)));
+    }
+    BOOST_CHECK(arith_uint256(0xbedc77e27940a7ULL) + 0xee8d836fce66fbULL == arith_uint256(0xbedc77e27940a7ULL + 0xee8d836fce66fbULL));
+    TmpL = arith_uint256(0xbedc77e27940a7ULL); TmpL += 0xee8d836fce66fbULL;
+    BOOST_CHECK(TmpL == arith_uint256(0xbedc77e27940a7ULL+0xee8d836fce66fbULL));
+    TmpL -= 0xee8d836fce66fbULL;  BOOST_CHECK(TmpL == 0xbedc77e27940a7ULL);
+    TmpL = R1L;
+    BOOST_CHECK(++TmpL == R1L+1);
+
+    BOOST_CHECK(R1L -(-R2L) == R1L+R2L);
+    BOOST_CHECK(R1L -(-OneL) == R1L+OneL);
+    BOOST_CHECK(R1L - OneL == R1L+(-OneL));
+    for (unsigned int i = 1; i < 256; ++i) {
+        BOOST_CHECK((MaxL>>i) - (-OneL)  == (HalfL >> (i-1)));
+        BOOST_CHECK((HalfL >> (i-1)) - OneL == (MaxL>>i));
+        TmpL = (HalfL >> (i-1));
+        BOOST_CHECK(TmpL-- == (HalfL >> (i-1)));
+        BOOST_CHECK(TmpL == (MaxL >> i));
+        TmpL = (HalfL >> (i-1));
+        BOOST_CHECK(--TmpL == (MaxL >> i));
+    }
+    TmpL = R1L;
+    BOOST_CHECK(--TmpL == R1L-1);
+
+    // 160-bit; copy-pasted
+    arith_uint160 TmpS = 0;
+    BOOST_CHECK(R1S+R2S == arith_uint160(R1LplusR2L));
+    TmpS += R1S;
+    BOOST_CHECK(TmpS == R1S);
+    TmpS += R2S;
+    BOOST_CHECK(TmpS == R1S + R2S);
+    BOOST_CHECK(OneS+MaxS == ZeroS);
+    BOOST_CHECK(MaxS+OneS == ZeroS);
+    for (unsigned int i = 1; i < 160; ++i) {
+        BOOST_CHECK( (MaxS >> i) + OneS == (HalfS >> (i-1)) );
+        BOOST_CHECK( OneS + (MaxS >> i) == (HalfS >> (i-1)) );
+        TmpS = (MaxS>>i); TmpS += OneS;
+        BOOST_CHECK( TmpS == (HalfS >> (i-1)) );
+        TmpS = (MaxS>>i); TmpS += 1;
+        BOOST_CHECK( TmpS == (HalfS >> (i-1)) );
+        TmpS = (MaxS>>i);
+        BOOST_CHECK( TmpS++ == (MaxS>>i) );
+        BOOST_CHECK( TmpS == (HalfS >> (i-1)));
+    }
+    BOOST_CHECK(arith_uint160(0xbedc77e27940a7ULL) + 0xee8d836fce66fbULL == arith_uint160(0xbedc77e27940a7ULL + 0xee8d836fce66fbULL));
+    TmpS = arith_uint160(0xbedc77e27940a7ULL); TmpS += 0xee8d836fce66fbULL;
+    BOOST_CHECK(TmpS == arith_uint160(0xbedc77e27940a7ULL+0xee8d836fce66fbULL));
+    TmpS -= 0xee8d836fce66fbULL;  BOOST_CHECK(TmpS == 0xbedc77e27940a7ULL);
+    TmpS = R1S;
+    BOOST_CHECK(++TmpS == R1S+1);
+
+    BOOST_CHECK(R1S -(-R2S) == R1S+R2S);
+    BOOST_CHECK(R1S -(-OneS) == R1S+OneS);
+    BOOST_CHECK(R1S - OneS == R1S+(-OneS));
+    for (unsigned int i = 1; i < 160; ++i) {
+        BOOST_CHECK((MaxS>>i) - (-OneS)  == (HalfS >> (i-1)));
+        BOOST_CHECK((HalfS >> (i-1)) - OneS == (MaxS>>i));
+        TmpS = (HalfS >> (i-1));
+        BOOST_CHECK(TmpS-- == (HalfS >> (i-1)));
+        BOOST_CHECK(TmpS == (MaxS >> i));
+        TmpS = (HalfS >> (i-1));
+        BOOST_CHECK(--TmpS == (MaxS >> i));
+    }
+    TmpS = R1S;
+    BOOST_CHECK(--TmpS == R1S-1);
+
+}
+
+BOOST_AUTO_TEST_CASE( multiply )
+{
+    BOOST_CHECK((R1L * R1L).ToString() == "62a38c0486f01e45879d7910a7761bf30d5237e9873f9bff3642a732c4d84f10");
+    BOOST_CHECK((R1L * R2L).ToString() == "de37805e9986996cfba76ff6ba51c008df851987d9dd323f0e5de07760529c40");
+    BOOST_CHECK((R1L * ZeroL) == ZeroL);
+    BOOST_CHECK((R1L * OneL) == R1L);
+    BOOST_CHECK((R1L * MaxL) == -R1L);
+    BOOST_CHECK((R2L * R1L) == (R1L * R2L));
+    BOOST_CHECK((R2L * R2L).ToString() == "ac8c010096767d3cae5005dec28bb2b45a1d85ab7996ccd3e102a650f74ff100");
+    BOOST_CHECK((R2L * ZeroL) == ZeroL);
+    BOOST_CHECK((R2L * OneL) == R2L);
+    BOOST_CHECK((R2L * MaxL) == -R2L);
+
+    BOOST_CHECK((R1S * R1S).ToString() == "a7761bf30d5237e9873f9bff3642a732c4d84f10");
+    BOOST_CHECK((R1S * R2S).ToString() == "ba51c008df851987d9dd323f0e5de07760529c40");
+    BOOST_CHECK((R1S * ZeroS) == ZeroS);
+    BOOST_CHECK((R1S * OneS) == R1S);
+    BOOST_CHECK((R1S * MaxS) == -R1S);
+    BOOST_CHECK((R2S * R1S) == (R1S * R2S));
+    BOOST_CHECK((R2S * R2S).ToString() == "c28bb2b45a1d85ab7996ccd3e102a650f74ff100");
+    BOOST_CHECK((R2S * ZeroS) == ZeroS);
+    BOOST_CHECK((R2S * OneS) == R2S);
+    BOOST_CHECK((R2S * MaxS) == -R2S);
+
+    BOOST_CHECK(MaxL * MaxL == OneL);
+    BOOST_CHECK(MaxS * MaxS == OneS);
+
+    BOOST_CHECK((R1L * 0) == 0);
+    BOOST_CHECK((R1L * 1) == R1L);
+    BOOST_CHECK((R1L * 3).ToString() == "7759b1c0ed14047f961ad09b20ff83687876a0181a367b813634046f91def7d4");
+    BOOST_CHECK((R2L * 0x87654321UL).ToString() == "23f7816e30c4ae2017257b7a0fa64d60402f5234d46e746b61c960d09a26d070");
+    BOOST_CHECK((R1S * 0) == 0);
+    BOOST_CHECK((R1S * 1) == R1S);
+    BOOST_CHECK((R1S * 7).ToString() == "f7a987f3c3bf758d927f202d7e795faeff084244");
+    BOOST_CHECK((R2S * 0xFFFFFFFFUL).ToString() == "1c6f6c930353e17f7d6127213bb18d2883e2cd90");
+}
+
+BOOST_AUTO_TEST_CASE( divide )
+{
+    arith_uint256 D1L("AD7133AC1977FA2B7");
+    arith_uint256 D2L("ECD751716");
+    BOOST_CHECK((R1L / D1L).ToString() == "00000000000000000b8ac01106981635d9ed112290f8895545a7654dde28fb3a");
+    BOOST_CHECK((R1L / D2L).ToString() == "000000000873ce8efec5b67150bad3aa8c5fcb70e947586153bf2cec7c37c57a");
+    BOOST_CHECK(R1L / OneL == R1L);
+    BOOST_CHECK(R1L / MaxL == ZeroL);
+    BOOST_CHECK(MaxL / R1L == 2);
+    BOOST_CHECK_THROW(R1L / ZeroL, uint_error);
+    BOOST_CHECK((R2L / D1L).ToString() == "000000000000000013e1665895a1cc981de6d93670105a6b3ec3b73141b3a3c5");
+    BOOST_CHECK((R2L / D2L).ToString() == "000000000e8f0abe753bb0afe2e9437ee85d280be60882cf0bd1aaf7fa3cc2c4");
+    BOOST_CHECK(R2L / OneL == R2L);
+    BOOST_CHECK(R2L / MaxL == ZeroL);
+    BOOST_CHECK(MaxL / R2L == 1);
+    BOOST_CHECK_THROW(R2L / ZeroL, uint_error);
+
+    arith_uint160 D1S("D3C5EDCDEA54EB92679F0A4B4");
+    arith_uint160 D2S("13037");
+    BOOST_CHECK((R1S / D1S).ToString() == "0000000000000000000000000db9af3beade6c02");
+    BOOST_CHECK((R1S / D2S).ToString() == "000098dfb6cc40ca592bf74366794f298ada205c");
+    BOOST_CHECK(R1S / OneS == R1S);
+    BOOST_CHECK(R1S / MaxS == ZeroS);
+    BOOST_CHECK(MaxS / R1S == 1);
+    BOOST_CHECK_THROW(R1S / ZeroS, uint_error);
+    BOOST_CHECK((R2S / D1S).ToString() == "0000000000000000000000000c5608e781182047");
+    BOOST_CHECK((R2S / D2S).ToString() == "00008966751b7187c3c67c1fda5cea7db2c1c069");
+    BOOST_CHECK(R2S / OneS == R2S);
+    BOOST_CHECK(R2S / MaxS == ZeroS);
+    BOOST_CHECK(MaxS / R2S == 1);
+    BOOST_CHECK_THROW(R2S / ZeroS, uint_error);
+}
+
+
+bool almostEqual(double d1, double d2)
+{
+    return fabs(d1-d2) <= 4*fabs(d1)*std::numeric_limits<double>::epsilon();
+}
+
+BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex begin() end() size() GetLow64 GetSerializeSize, Serialize, Unserialize
+{
+    BOOST_CHECK(R1L.GetHex() == R1L.ToString());
+    BOOST_CHECK(R2L.GetHex() == R2L.ToString());
+    BOOST_CHECK(OneL.GetHex() == OneL.ToString());
+    BOOST_CHECK(MaxL.GetHex() == MaxL.ToString());
+    arith_uint256 TmpL(R1L);
+    BOOST_CHECK(TmpL == R1L);
+    TmpL.SetHex(R2L.ToString());   BOOST_CHECK(TmpL == R2L);
+    TmpL.SetHex(ZeroL.ToString()); BOOST_CHECK(TmpL == 0);
+    TmpL.SetHex(HalfL.ToString()); BOOST_CHECK(TmpL == HalfL);
+
+    TmpL.SetHex(R1L.ToString());
+    BOOST_CHECK(memcmp(R1L.begin(), R1Array, 32)==0);
+    BOOST_CHECK(memcmp(TmpL.begin(), R1Array, 32)==0);
+    BOOST_CHECK(memcmp(R2L.begin(), R2Array, 32)==0);
+    BOOST_CHECK(memcmp(ZeroL.begin(), ZeroArray, 32)==0);
+    BOOST_CHECK(memcmp(OneL.begin(), OneArray, 32)==0);
+    BOOST_CHECK(R1L.size() == 32);
+    BOOST_CHECK(R2L.size() == 32);
+    BOOST_CHECK(ZeroL.size() == 32);
+    BOOST_CHECK(MaxL.size() == 32);
+    BOOST_CHECK(R1L.begin() + 32 == R1L.end());
+    BOOST_CHECK(R2L.begin() + 32 == R2L.end());
+    BOOST_CHECK(OneL.begin() + 32 == OneL.end());
+    BOOST_CHECK(MaxL.begin() + 32 == MaxL.end());
+    BOOST_CHECK(TmpL.begin() + 32 == TmpL.end());
+    BOOST_CHECK(R1L.GetLow64()  == R1LLow64);
+    BOOST_CHECK(HalfL.GetLow64() ==0x0000000000000000ULL);
+    BOOST_CHECK(OneL.GetLow64() ==0x0000000000000001ULL);
+    BOOST_CHECK(R1L.GetSerializeSize(0,PROTOCOL_VERSION) == 32);
+    BOOST_CHECK(ZeroL.GetSerializeSize(0,PROTOCOL_VERSION) == 32);
+
+    std::stringstream ss;
+    R1L.Serialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ss.str() == std::string(R1Array,R1Array+32));
+    TmpL.Unserialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(R1L == TmpL);
+    ss.str("");
+    ZeroL.Serialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ss.str() == std::string(ZeroArray,ZeroArray+32));
+    TmpL.Unserialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ZeroL == TmpL);
+    ss.str("");
+    MaxL.Serialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ss.str() == std::string(MaxArray,MaxArray+32));
+    TmpL.Unserialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(MaxL == TmpL);
+    ss.str("");
+
+    BOOST_CHECK(R1S.GetHex() == R1S.ToString());
+    BOOST_CHECK(R2S.GetHex() == R2S.ToString());
+    BOOST_CHECK(OneS.GetHex() == OneS.ToString());
+    BOOST_CHECK(MaxS.GetHex() == MaxS.ToString());
+    arith_uint160 TmpS(R1S);
+    BOOST_CHECK(TmpS == R1S);
+    TmpS.SetHex(R2S.ToString());   BOOST_CHECK(TmpS == R2S);
+    TmpS.SetHex(ZeroS.ToString()); BOOST_CHECK(TmpS == 0);
+    TmpS.SetHex(HalfS.ToString()); BOOST_CHECK(TmpS == HalfS);
+
+    TmpS.SetHex(R1S.ToString());
+    BOOST_CHECK(memcmp(R1S.begin(), R1Array, 20)==0);
+    BOOST_CHECK(memcmp(TmpS.begin(), R1Array, 20)==0);
+    BOOST_CHECK(memcmp(R2S.begin(), R2Array, 20)==0);
+    BOOST_CHECK(memcmp(ZeroS.begin(), ZeroArray, 20)==0);
+    BOOST_CHECK(memcmp(OneS.begin(), OneArray, 20)==0);
+    BOOST_CHECK(R1S.size() == 20);
+    BOOST_CHECK(R2S.size() == 20);
+    BOOST_CHECK(ZeroS.size() == 20);
+    BOOST_CHECK(MaxS.size() == 20);
+    BOOST_CHECK(R1S.begin() + 20 == R1S.end());
+    BOOST_CHECK(R2S.begin() + 20 == R2S.end());
+    BOOST_CHECK(OneS.begin() + 20 == OneS.end());
+    BOOST_CHECK(MaxS.begin() + 20 == MaxS.end());
+    BOOST_CHECK(TmpS.begin() + 20 == TmpS.end());
+    BOOST_CHECK(R1S.GetLow64()  == R1LLow64);
+    BOOST_CHECK(HalfS.GetLow64() ==0x0000000000000000ULL);
+    BOOST_CHECK(OneS.GetLow64() ==0x0000000000000001ULL);
+    BOOST_CHECK(R1S.GetSerializeSize(0,PROTOCOL_VERSION) == 20);
+    BOOST_CHECK(ZeroS.GetSerializeSize(0,PROTOCOL_VERSION) == 20);
+
+    R1S.Serialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ss.str() == std::string(R1Array,R1Array+20));
+    TmpS.Unserialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(R1S == TmpS);
+    ss.str("");
+    ZeroS.Serialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ss.str() == std::string(ZeroArray,ZeroArray+20));
+    TmpS.Unserialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ZeroS == TmpS);
+    ss.str("");
+    MaxS.Serialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ss.str() == std::string(MaxArray,MaxArray+20));
+    TmpS.Unserialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(MaxS == TmpS);
+    ss.str("");
+
+    for (unsigned int i = 0; i < 255; ++i)
+    {
+        BOOST_CHECK((OneL << i).getdouble() == ldexp(1.0,i));
+        if (i < 160) BOOST_CHECK((OneS << i).getdouble() == ldexp(1.0,i));
+    }
+    BOOST_CHECK(ZeroL.getdouble() == 0.0);
+    BOOST_CHECK(ZeroS.getdouble() == 0.0);
+    for (int i = 256; i > 53; --i)
+        BOOST_CHECK(almostEqual((R1L>>(256-i)).getdouble(), ldexp(R1Ldouble,i)));
+    for (int i = 160; i > 53; --i)
+        BOOST_CHECK(almostEqual((R1S>>(160-i)).getdouble(), ldexp(R1Sdouble,i)));
+    uint64_t R1L64part = (R1L>>192).GetLow64();
+    uint64_t R1S64part = (R1S>>96).GetLow64();
+    for (int i = 53; i > 0; --i) // doubles can store all integers in {0,...,2^54-1} exactly
+    {
+        BOOST_CHECK((R1L>>(256-i)).getdouble() == (double)(R1L64part >> (64-i)));
+        BOOST_CHECK((R1S>>(160-i)).getdouble() == (double)(R1S64part >> (64-i)));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(bignum_SetCompact)
+{
+    arith_uint256 num;
+    bool fNegative;
+    bool fOverflow;
+    num.SetCompact(0, &fNegative, &fOverflow);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
+    BOOST_CHECK_EQUAL(fNegative, false);
+    BOOST_CHECK_EQUAL(fOverflow, false);
+
+    num.SetCompact(0x00123456, &fNegative, &fOverflow);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
+    BOOST_CHECK_EQUAL(fNegative, false);
+    BOOST_CHECK_EQUAL(fOverflow, false);
+
+    num.SetCompact(0x01003456, &fNegative, &fOverflow);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
+    BOOST_CHECK_EQUAL(fNegative, false);
+    BOOST_CHECK_EQUAL(fOverflow, false);
+
+    num.SetCompact(0x02000056, &fNegative, &fOverflow);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
+    BOOST_CHECK_EQUAL(fNegative, false);
+    BOOST_CHECK_EQUAL(fOverflow, false);
+
+    num.SetCompact(0x03000000, &fNegative, &fOverflow);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
+    BOOST_CHECK_EQUAL(fNegative, false);
+    BOOST_CHECK_EQUAL(fOverflow, false);
+
+    num.SetCompact(0x04000000, &fNegative, &fOverflow);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
+    BOOST_CHECK_EQUAL(fNegative, false);
+    BOOST_CHECK_EQUAL(fOverflow, false);
+
+    num.SetCompact(0x00923456, &fNegative, &fOverflow);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
+    BOOST_CHECK_EQUAL(fNegative, false);
+    BOOST_CHECK_EQUAL(fOverflow, false);
+
+    num.SetCompact(0x01803456, &fNegative, &fOverflow);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
+    BOOST_CHECK_EQUAL(fNegative, false);
+    BOOST_CHECK_EQUAL(fOverflow, false);
+
+    num.SetCompact(0x02800056, &fNegative, &fOverflow);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
+    BOOST_CHECK_EQUAL(fNegative, false);
+    BOOST_CHECK_EQUAL(fOverflow, false);
+
+    num.SetCompact(0x03800000, &fNegative, &fOverflow);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
+    BOOST_CHECK_EQUAL(fNegative, false);
+    BOOST_CHECK_EQUAL(fOverflow, false);
+
+    num.SetCompact(0x04800000, &fNegative, &fOverflow);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000000");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0U);
+    BOOST_CHECK_EQUAL(fNegative, false);
+    BOOST_CHECK_EQUAL(fOverflow, false);
+
+    num.SetCompact(0x01123456, &fNegative, &fOverflow);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000000012");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0x01120000U);
+    BOOST_CHECK_EQUAL(fNegative, false);
+    BOOST_CHECK_EQUAL(fOverflow, false);
+
+    // Make sure that we don't generate compacts with the 0x00800000 bit set
+    num = 0x80;
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0x02008000U);
+
+    num.SetCompact(0x01fedcba, &fNegative, &fOverflow);
+    BOOST_CHECK_EQUAL(num.GetHex(), "000000000000000000000000000000000000000000000000000000000000007e");
+    BOOST_CHECK_EQUAL(num.GetCompact(true), 0x01fe0000U);
+    BOOST_CHECK_EQUAL(fNegative, true);
+    BOOST_CHECK_EQUAL(fOverflow, false);
+
+    num.SetCompact(0x02123456, &fNegative, &fOverflow);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000001234");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0x02123400U);
+    BOOST_CHECK_EQUAL(fNegative, false);
+    BOOST_CHECK_EQUAL(fOverflow, false);
+
+    num.SetCompact(0x03123456, &fNegative, &fOverflow);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000000123456");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0x03123456U);
+    BOOST_CHECK_EQUAL(fNegative, false);
+    BOOST_CHECK_EQUAL(fOverflow, false);
+
+    num.SetCompact(0x04123456, &fNegative, &fOverflow);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000012345600");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0x04123456U);
+    BOOST_CHECK_EQUAL(fNegative, false);
+    BOOST_CHECK_EQUAL(fOverflow, false);
+
+    num.SetCompact(0x04923456, &fNegative, &fOverflow);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000012345600");
+    BOOST_CHECK_EQUAL(num.GetCompact(true), 0x04923456U);
+    BOOST_CHECK_EQUAL(fNegative, true);
+    BOOST_CHECK_EQUAL(fOverflow, false);
+
+    num.SetCompact(0x05009234, &fNegative, &fOverflow);
+    BOOST_CHECK_EQUAL(num.GetHex(), "0000000000000000000000000000000000000000000000000000000092340000");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0x05009234U);
+    BOOST_CHECK_EQUAL(fNegative, false);
+    BOOST_CHECK_EQUAL(fOverflow, false);
+
+    num.SetCompact(0x20123456, &fNegative, &fOverflow);
+    BOOST_CHECK_EQUAL(num.GetHex(), "1234560000000000000000000000000000000000000000000000000000000000");
+    BOOST_CHECK_EQUAL(num.GetCompact(), 0x20123456U);
+    BOOST_CHECK_EQUAL(fNegative, false);
+    BOOST_CHECK_EQUAL(fOverflow, false);
+
+    num.SetCompact(0xff123456, &fNegative, &fOverflow);
+    BOOST_CHECK_EQUAL(fNegative, false);
+    BOOST_CHECK_EQUAL(fOverflow, true);
+}
+
+
+BOOST_AUTO_TEST_CASE( getmaxcoverage ) // some more tests just to get 100% coverage
+{
+    // ~R1L give a base_uint<256>
+    BOOST_CHECK((~~R1L >> 10) == (R1L >> 10)); BOOST_CHECK((~~R1S >> 10) == (R1S >> 10));
+    BOOST_CHECK((~~R1L << 10) == (R1L << 10)); BOOST_CHECK((~~R1S << 10) == (R1S << 10));
+    BOOST_CHECK(!(~~R1L < R1L)); BOOST_CHECK(!(~~R1S < R1S));
+    BOOST_CHECK(~~R1L <= R1L); BOOST_CHECK(~~R1S <= R1S);
+    BOOST_CHECK(!(~~R1L > R1L)); BOOST_CHECK(!(~~R1S > R1S));
+    BOOST_CHECK(~~R1L >= R1L); BOOST_CHECK(~~R1S >= R1S);
+    BOOST_CHECK(!(R1L < ~~R1L)); BOOST_CHECK(!(R1S < ~~R1S));
+    BOOST_CHECK(R1L <= ~~R1L); BOOST_CHECK(R1S <= ~~R1S);
+    BOOST_CHECK(!(R1L > ~~R1L)); BOOST_CHECK(!(R1S > ~~R1S));
+    BOOST_CHECK(R1L >= ~~R1L); BOOST_CHECK(R1S >= ~~R1S);
+
+    BOOST_CHECK(~~R1L + R2L == R1L + ~~R2L);
+    BOOST_CHECK(~~R1S + R2S == R1S + ~~R2S);
+    BOOST_CHECK(~~R1L - R2L == R1L - ~~R2L);
+    BOOST_CHECK(~~R1S - R2S == R1S - ~~R2S);
+    BOOST_CHECK(~R1L != R1L); BOOST_CHECK(R1L != ~R1L);
+    BOOST_CHECK(~R1S != R1S); BOOST_CHECK(R1S != ~R1S);
+    unsigned char TmpArray[32];
+    CHECKBITWISEOPERATOR(~R1,R2,|)
+    CHECKBITWISEOPERATOR(~R1,R2,^)
+    CHECKBITWISEOPERATOR(~R1,R2,&)
+    CHECKBITWISEOPERATOR(R1,~R2,|)
+    CHECKBITWISEOPERATOR(R1,~R2,^)
+    CHECKBITWISEOPERATOR(R1,~R2,&)
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(pmt_test1)
 
         // calculate actual merkle root and height
         uint256 merkleRoot1 = block.BuildMerkleTree();
-        std::vector<uint256> vTxid(nTx, 0);
+        std::vector<uint256> vTxid(nTx, UINT256_ZERO);
         for (unsigned int j=0; j<nTx; j++)
             vTxid[j] = block.vtx[j].GetHash();
         int nHeight = 1, nTx_ = nTx;
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(pmt_test1)
 
             // check that it has the same merkle root as the original, and a valid one
             BOOST_CHECK(merkleRoot1 == merkleRoot2);
-            BOOST_CHECK(merkleRoot2 != 0);
+            BOOST_CHECK(!merkleRoot2.IsNull());
 
             // check that it contains the matched transactions (in the same order!)
             BOOST_CHECK(vMatchTxid1 == vMatchTxid2);

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(set)
 BOOST_AUTO_TEST_CASE(is)
 {
     // Test CScript::IsPayToScriptHash()
-    uint160 dummy(0);
+    uint160 dummy;
     CScript p2sh;
     p2sh << OP_HASH160 << ToByteVector(dummy) << OP_EQUAL;
     BOOST_CHECK(p2sh.IsPayToScriptHash());

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -29,7 +29,7 @@ uint256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, un
     if (nIn >= txTo.vin.size())
     {
         printf("ERROR: SignatureHash() : nIn=%d out of range\n", nIn);
-        return 1;
+        return UINT256_ONE;
     }
     CMutableTransaction txTmp(txTo);
 
@@ -60,7 +60,7 @@ uint256 static SignatureHashOld(CScript scriptCode, const CTransaction& txTo, un
         if (nOut >= txTmp.vout.size())
         {
             printf("ERROR: SignatureHash() : nOut=%d out of range\n", nOut);
-            return 1;
+            return UINT256_ONE;
         }
         txTmp.vout.resize(nOut+1);
         for (unsigned int i = 0; i < nOut; i++)

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(GetSigOpCount)
     BOOST_CHECK_EQUAL(s1.GetSigOpCount(false), 0U);
     BOOST_CHECK_EQUAL(s1.GetSigOpCount(true), 0U);
 
-    uint160 dummy(0);
+    uint160 dummy;
     s1 << OP_1 << ToByteVector(dummy) << ToByteVector(dummy) << OP_2 << OP_CHECKMULTISIG;
     BOOST_CHECK_EQUAL(s1.GetSigOpCount(true), 2U);
     s1 << OP_IF << OP_CHECKSIG << OP_ENDIF;

--- a/src/test/test_random.h
+++ b/src/test/test_random.h
@@ -14,7 +14,7 @@ extern FastRandomContext insecure_rand_ctx;
 static inline void seed_insecure_rand(bool fDeterministic = false)
 {
     if (fDeterministic) {
-        insecure_rand_seed = uint256();
+        insecure_rand_seed = UINT256_ZERO;
     } else {
         insecure_rand_seed = GetRandHash();
     }

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
 
     // uint64_t constructor
     BOOST_CHECK( (R1L & uint256("0xffffffffffffffff")) == uint256(R1LLow64));
-    BOOST_CHECK(ZeroL == uint256(0));
+    BOOST_CHECK(ZeroL == UINT256_ZERO);
     BOOST_CHECK(OneL == uint256(1));
     BOOST_CHECK(uint256("0xffffffffffffffff") = uint256(0xffffffffffffffffULL));
     BOOST_CHECK( (R1S & uint160("0xffffffffffffffff")) == uint160(R1LLow64));

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
 
     // uint64_t constructor
     BOOST_CHECK( (R1L & uint256("0xffffffffffffffff")) == uint256(R1LLow64));
-    BOOST_CHECK(ZeroL == UINT256_ZERO);
+    BOOST_CHECK(ZeroL.IsNull());
     BOOST_CHECK(OneL == uint256(1));
     BOOST_CHECK(uint256("0xffffffffffffffff") = uint256(0xffffffffffffffffULL));
     BOOST_CHECK( (R1S & uint160("0xffffffffffffffff")) == uint160(R1LLow64));

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -46,7 +46,7 @@ uint256 CCoinsViewDB::GetBestBlock() const
 {
     uint256 hashBestChain;
     if (!db.Read(DB_BEST_BLOCK, hashBestChain))
-        return uint256(0);
+        return UINT256_ZERO;
     return hashBestChain;
 }
 
@@ -67,7 +67,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock)
         CCoinsMap::iterator itOld = it++;
         mapCoins.erase(itOld);
     }
-    if (hashBlock != uint256(0))
+    if (hashBlock != UINT256_ZERO)
         batch.Write(DB_BEST_BLOCK, hashBlock);
 
     LogPrint(BCLog::COINDB, "Committing %u changed transactions (out of %u) to coin database...\n", (unsigned int)changed, (unsigned int)count);
@@ -239,7 +239,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
 {
     boost::scoped_ptr<CDBIterator> pcursor(NewIterator());
 
-    pcursor->Seek(std::make_pair(DB_BLOCK_INDEX, uint256(0)));
+    pcursor->Seek(std::make_pair(DB_BLOCK_INDEX, UINT256_ZERO));
 
     // Load mapBlockIndex
     uint256 nPreviousCheckpoint;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -67,7 +67,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock)
         CCoinsMap::iterator itOld = it++;
         mapCoins.erase(itOld);
     }
-    if (hashBlock != UINT256_ZERO)
+    if (!hashBlock.IsNull())
         batch.Write(DB_BEST_BLOCK, hashBlock);
 
     LogPrint(BCLog::COINDB, "Committing %u changed transactions (out of %u) to coin database...\n", (unsigned int)changed, (unsigned int)count);

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -1,271 +1,13 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin developers
+// Copyright (c) 2017-2019 The PIVX developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "uint256.h"
+#include "crypto/common.h"
 
-#include "utilstrencodings.h"
-
-#include <stdio.h>
-#include <string.h>
-
-template <unsigned int BITS>
-base_uint<BITS>::base_uint(const std::string& str)
-{
-    SetHex(str);
-}
-
-template <unsigned int BITS>
-base_uint<BITS>::base_uint(const std::vector<unsigned char>& vch)
-{
-    if (vch.size() != sizeof(pn))
-        throw uint_error("Converting vector of wrong size to base_uint");
-    memcpy(pn, &vch[0], sizeof(pn));
-}
-
-template <unsigned int BITS>
-base_uint<BITS>& base_uint<BITS>::operator<<=(unsigned int shift)
-{
-    base_uint<BITS> a(*this);
-    for (int i = 0; i < WIDTH; i++)
-        pn[i] = 0;
-    int k = shift / 32;
-    shift = shift % 32;
-    for (int i = 0; i < WIDTH; i++) {
-        if (i + k + 1 < WIDTH && shift != 0)
-            pn[i + k + 1] |= (a.pn[i] >> (32 - shift));
-        if (i + k < WIDTH)
-            pn[i + k] |= (a.pn[i] << shift);
-    }
-    return *this;
-}
-
-template <unsigned int BITS>
-base_uint<BITS>& base_uint<BITS>::operator>>=(unsigned int shift)
-{
-    base_uint<BITS> a(*this);
-    for (int i = 0; i < WIDTH; i++)
-        pn[i] = 0;
-    int k = shift / 32;
-    shift = shift % 32;
-    for (int i = 0; i < WIDTH; i++) {
-        if (i - k - 1 >= 0 && shift != 0)
-            pn[i - k - 1] |= (a.pn[i] << (32 - shift));
-        if (i - k >= 0)
-            pn[i - k] |= (a.pn[i] >> shift);
-    }
-    return *this;
-}
-
-template <unsigned int BITS>
-base_uint<BITS>& base_uint<BITS>::operator*=(uint32_t b32)
-{
-    uint64_t carry = 0;
-    for (int i = 0; i < WIDTH; i++) {
-        uint64_t n = carry + (uint64_t)b32 * pn[i];
-        pn[i] = n & 0xffffffff;
-        carry = n >> 32;
-    }
-    return *this;
-}
-
-template <unsigned int BITS>
-base_uint<BITS>& base_uint<BITS>::operator*=(const base_uint& b)
-{
-    base_uint<BITS> a = *this;
-    *this = 0;
-    for (int j = 0; j < WIDTH; j++) {
-        uint64_t carry = 0;
-        for (int i = 0; i + j < WIDTH; i++) {
-            uint64_t n = carry + pn[i + j] + (uint64_t)a.pn[j] * b.pn[i];
-            pn[i + j] = n & 0xffffffff;
-            carry = n >> 32;
-        }
-    }
-    return *this;
-}
-
-template <unsigned int BITS>
-base_uint<BITS>& base_uint<BITS>::operator/=(const base_uint& b)
-{
-    base_uint<BITS> div = b;     // make a copy, so we can shift.
-    base_uint<BITS> num = *this; // make a copy, so we can subtract.
-    *this = 0;                   // the quotient.
-    int num_bits = num.bits();
-    int div_bits = div.bits();
-    if (div_bits == 0)
-        throw uint_error("Division by zero");
-    if (div_bits > num_bits) // the result is certainly 0.
-        return *this;
-    int shift = num_bits - div_bits;
-    div <<= shift; // shift so that div and nun align.
-    while (shift >= 0) {
-        if (num >= div) {
-            num -= div;
-            pn[shift / 32] |= (1 << (shift & 31)); // set a bit of the result.
-        }
-        div >>= 1; // shift back.
-        shift--;
-    }
-    // num now contains the remainder of the division.
-    return *this;
-}
-
-template <unsigned int BITS>
-int base_uint<BITS>::CompareTo(const base_uint<BITS>& b) const
-{
-    for (int i = WIDTH - 1; i >= 0; i--) {
-        if (pn[i] < b.pn[i])
-            return -1;
-        if (pn[i] > b.pn[i])
-            return 1;
-    }
-    return 0;
-}
-
-template <unsigned int BITS>
-bool base_uint<BITS>::EqualTo(uint64_t b) const
-{
-    for (int i = WIDTH - 1; i >= 2; i--) {
-        if (pn[i])
-            return false;
-    }
-    if (pn[1] != (b >> 32))
-        return false;
-    if (pn[0] != (b & 0xfffffffful))
-        return false;
-    return true;
-}
-
-template <unsigned int BITS>
-double base_uint<BITS>::getdouble() const
-{
-    double ret = 0.0;
-    double fact = 1.0;
-    for (int i = 0; i < WIDTH; i++) {
-        ret += fact * pn[i];
-        fact *= 4294967296.0;
-    }
-    return ret;
-}
-
-template <unsigned int BITS>
-std::string base_uint<BITS>::GetHex() const
-{
-    char psz[sizeof(pn) * 2 + 1];
-    for (unsigned int i = 0; i < sizeof(pn); i++)
-        sprintf(psz + i * 2, "%02x", ((unsigned char*)pn)[sizeof(pn) - i - 1]);
-    return std::string(psz, psz + sizeof(pn) * 2);
-}
-
-template <unsigned int BITS>
-void base_uint<BITS>::SetHex(const char* psz)
-{
-    memset(pn, 0, sizeof(pn));
-
-    // skip leading spaces
-    while (isspace(*psz))
-        psz++;
-
-    // skip 0x
-    if (psz[0] == '0' && tolower(psz[1]) == 'x')
-        psz += 2;
-
-    // hex string to uint
-    const char* pbegin = psz;
-    while (::HexDigit(*psz) != -1)
-        psz++;
-    psz--;
-    unsigned char* p1 = (unsigned char*)pn;
-    unsigned char* pend = p1 + WIDTH * 4;
-    while (psz >= pbegin && p1 < pend) {
-        *p1 = ::HexDigit(*psz--);
-        if (psz >= pbegin) {
-            *p1 |= ((unsigned char)::HexDigit(*psz--) << 4);
-            p1++;
-        }
-    }
-}
-
-template <unsigned int BITS>
-void base_uint<BITS>::SetHex(const std::string& str)
-{
-    SetHex(str.c_str());
-}
-
-template <unsigned int BITS>
-std::string base_uint<BITS>::ToString() const
-{
-    return (GetHex());
-}
-
-template <unsigned int BITS>
-std::string base_uint<BITS>::ToStringReverseEndian() const
-{
-    char psz[sizeof(pn) * 2 + 1];
-    for (unsigned int i = 0; i < sizeof(pn); i++)
-        sprintf(psz + i * 2, "%02x", ((unsigned char*)pn)[i]);
-    return std::string(psz, psz + sizeof(pn) * 2);
-}
-
-template <unsigned int BITS>
-unsigned int base_uint<BITS>::bits() const
-{
-    for (int pos = WIDTH - 1; pos >= 0; pos--) {
-        if (pn[pos]) {
-            for (int bits = 31; bits > 0; bits--) {
-                if (pn[pos] & 1 << bits)
-                    return 32 * pos + bits + 1;
-            }
-            return 32 * pos + 1;
-        }
-    }
-    return 0;
-}
-
-// Explicit instantiations for base_uint<160>
-template base_uint<160>::base_uint(const std::string&);
-template base_uint<160>::base_uint(const std::vector<unsigned char>&);
-template base_uint<160>& base_uint<160>::operator<<=(unsigned int);
-template base_uint<160>& base_uint<160>::operator>>=(unsigned int);
-template base_uint<160>& base_uint<160>::operator*=(uint32_t b32);
-template base_uint<160>& base_uint<160>::operator*=(const base_uint<160>& b);
-template base_uint<160>& base_uint<160>::operator/=(const base_uint<160>& b);
-template int base_uint<160>::CompareTo(const base_uint<160>&) const;
-template bool base_uint<160>::EqualTo(uint64_t) const;
-template double base_uint<160>::getdouble() const;
-template std::string base_uint<160>::GetHex() const;
-template std::string base_uint<160>::ToString() const;
-template void base_uint<160>::SetHex(const char*);
-template void base_uint<160>::SetHex(const std::string&);
-template unsigned int base_uint<160>::bits() const;
-
-// Explicit instantiations for base_uint<256>
-template base_uint<256>::base_uint(const std::string&);
-template base_uint<256>::base_uint(const std::vector<unsigned char>&);
-template base_uint<256>& base_uint<256>::operator<<=(unsigned int);
-template base_uint<256>& base_uint<256>::operator>>=(unsigned int);
-template base_uint<256>& base_uint<256>::operator*=(uint32_t b32);
-template base_uint<256>& base_uint<256>::operator*=(const base_uint<256>& b);
-template base_uint<256>& base_uint<256>::operator/=(const base_uint<256>& b);
-template int base_uint<256>::CompareTo(const base_uint<256>&) const;
-template bool base_uint<256>::EqualTo(uint64_t) const;
-template double base_uint<256>::getdouble() const;
-template std::string base_uint<256>::GetHex() const;
-template std::string base_uint<256>::ToString() const;
-template void base_uint<256>::SetHex(const char*);
-template void base_uint<256>::SetHex(const std::string&);
-template unsigned int base_uint<256>::bits() const;
-template std::string base_uint<256>::ToStringReverseEndian() const;
-
-// Explicit instantiations for base_uint<512>
-template base_uint<512>::base_uint(const std::string&);
-template base_uint<512>& base_uint<512>::operator<<=(unsigned int);
-template base_uint<512>& base_uint<512>::operator>>=(unsigned int);
-template std::string base_uint<512>::GetHex() const;
-template std::string base_uint<512>::ToString() const;
-template std::string base_uint<512>::ToStringReverseEndian() const;
+/** Old classes definitions **/
 
 // This implementation directly uses shifts instead of going
 // through an intermediate MPI representation.
@@ -284,8 +26,8 @@ uint256& uint256::SetCompact(uint32_t nCompact, bool* pfNegative, bool* pfOverfl
         *pfNegative = nWord != 0 && (nCompact & 0x00800000) != 0;
     if (pfOverflow)
         *pfOverflow = nWord != 0 && ((nSize > 34) ||
-                                        (nWord > 0xff && nSize > 33) ||
-                                        (nWord > 0xffff && nSize > 32));
+                                     (nWord > 0xff && nSize > 33) ||
+                                     (nWord > 0xffff && nSize > 32));
     return *this;
 }
 
@@ -372,4 +114,35 @@ uint64_t uint256::GetHash(const uint256& salt) const
     HashFinal(a, b, c);
 
     return ((((uint64_t)b) << 32) | c);
+}
+
+uint256 ArithToUint256(const arith_uint256 &a)
+{
+    uint256 b;
+    for(int x=0; x<a.WIDTH; ++x)
+        WriteLE32(b.begin() + x*4, a.pn[x]);
+    return b;
+}
+arith_uint256 UintToArith256(const uint256 &a)
+{
+    arith_uint256 b;
+    for(int x=0; x<b.WIDTH; ++x)
+        b.pn[x] = ReadLE32(a.begin() + x*4);
+    return b;
+}
+
+uint512 ArithToUint512(const arith_uint512 &a)
+{
+    uint512 b;
+    for(int x=0; x<a.WIDTH; ++x)
+        WriteLE32(b.begin() + x*4, a.pn[x]);
+    return b;
+}
+
+arith_uint512 UintToArith512(const uint512 &a)
+{
+    arith_uint512 b;
+    for(int x=0; x<b.WIDTH; ++x)
+        b.pn[x] = ReadLE32(a.begin() + x*4);
+    return b;
 }

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -6,9 +6,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_UINT256_H
-#define BITCOIN_UINT256_H
+#ifndef PRCY_UINT256_H
+#define PRCY_UINT256_H
 
+#include "arith_uint256.h"
 #include <assert.h>
 #include <cstring>
 #include <stdexcept>
@@ -16,312 +17,11 @@
 #include <string>
 #include <vector>
 
-class uint_error : public std::runtime_error
-{
-public:
-    explicit uint_error(const std::string& str) : std::runtime_error(str) {}
-};
-
-/** Template base class for unsigned big integers. */
-template <unsigned int BITS>
-class base_uint
-{
-protected:
-    enum { WIDTH = BITS / 32 };
-    uint32_t pn[WIDTH];
-
-public:
-    base_uint()
-    {
-        for (int i = 0; i < WIDTH; i++)
-            pn[i] = 0;
-    }
-
-    base_uint(const base_uint& b)
-    {
-        for (int i = 0; i < WIDTH; i++)
-            pn[i] = b.pn[i];
-    }
-
-
-    bool IsNull() const
-    {
-        for (int i = 0; i < WIDTH; i++)
-            if (pn[i] != 0)
-                return false;
-        return true;
-    }
-
-    void SetNull()
-    {
-        memset(pn, 0, sizeof(pn));
-    }
-
-
-    base_uint& operator=(const base_uint& b)
-    {
-        for (int i = 0; i < WIDTH; i++)
-            pn[i] = b.pn[i];
-        return *this;
-    }
-
-    base_uint(uint64_t b)
-    {
-        pn[0] = (unsigned int)b;
-        pn[1] = (unsigned int)(b >> 32);
-        for (int i = 2; i < WIDTH; i++)
-            pn[i] = 0;
-    }
-
-    explicit base_uint(const std::string& str);
-    explicit base_uint(const std::vector<unsigned char>& vch);
-
-    bool operator!() const
-    {
-        for (int i = 0; i < WIDTH; i++)
-            if (pn[i] != 0)
-                return false;
-        return true;
-    }
-
-    const base_uint operator~() const
-    {
-        base_uint ret;
-        for (int i = 0; i < WIDTH; i++)
-            ret.pn[i] = ~pn[i];
-        return ret;
-    }
-
-    const base_uint operator-() const
-    {
-        base_uint ret;
-        for (int i = 0; i < WIDTH; i++)
-            ret.pn[i] = ~pn[i];
-        ret++;
-        return ret;
-    }
-
-    double getdouble() const;
-
-    base_uint& operator=(uint64_t b)
-    {
-        pn[0] = (unsigned int)b;
-        pn[1] = (unsigned int)(b >> 32);
-        for (int i = 2; i < WIDTH; i++)
-            pn[i] = 0;
-        return *this;
-    }
-
-    base_uint& operator^=(const base_uint& b)
-    {
-        for (int i = 0; i < WIDTH; i++)
-            pn[i] ^= b.pn[i];
-        return *this;
-    }
-
-    base_uint& operator&=(const base_uint& b)
-    {
-        for (int i = 0; i < WIDTH; i++)
-            pn[i] &= b.pn[i];
-        return *this;
-    }
-
-    base_uint& operator|=(const base_uint& b)
-    {
-        for (int i = 0; i < WIDTH; i++)
-            pn[i] |= b.pn[i];
-        return *this;
-    }
-
-    base_uint& operator^=(uint64_t b)
-    {
-        pn[0] ^= (unsigned int)b;
-        pn[1] ^= (unsigned int)(b >> 32);
-        return *this;
-    }
-
-    base_uint& operator|=(uint64_t b)
-    {
-        pn[0] |= (unsigned int)b;
-        pn[1] |= (unsigned int)(b >> 32);
-        return *this;
-    }
-
-    base_uint& operator<<=(unsigned int shift);
-    base_uint& operator>>=(unsigned int shift);
-
-    base_uint& operator+=(const base_uint& b)
-    {
-        uint64_t carry = 0;
-        for (int i = 0; i < WIDTH; i++) {
-            uint64_t n = carry + pn[i] + b.pn[i];
-            pn[i] = n & 0xffffffff;
-            carry = n >> 32;
-        }
-        return *this;
-    }
-
-    base_uint& operator-=(const base_uint& b)
-    {
-        *this += -b;
-        return *this;
-    }
-
-    base_uint& operator+=(uint64_t b64)
-    {
-        base_uint b;
-        b = b64;
-        *this += b;
-        return *this;
-    }
-
-    base_uint& operator-=(uint64_t b64)
-    {
-        base_uint b;
-        b = b64;
-        *this += -b;
-        return *this;
-    }
-
-    base_uint& operator*=(uint32_t b32);
-    base_uint& operator*=(const base_uint& b);
-    base_uint& operator/=(const base_uint& b);
-
-    base_uint& operator++()
-    {
-        // prefix operator
-        int i = 0;
-        while (++pn[i] == 0 && i < WIDTH - 1)
-            i++;
-        return *this;
-    }
-
-    const base_uint operator++(int)
-    {
-        // postfix operator
-        const base_uint ret = *this;
-        ++(*this);
-        return ret;
-    }
-
-    base_uint& operator--()
-    {
-        // prefix operator
-        int i = 0;
-        while (--pn[i] == (uint32_t)-1 && i < WIDTH - 1)
-            i++;
-        return *this;
-    }
-
-    const base_uint operator--(int)
-    {
-        // postfix operator
-        const base_uint ret = *this;
-        --(*this);
-        return ret;
-    }
-
-    int CompareTo(const base_uint& b) const;
-    bool EqualTo(uint64_t b) const;
-
-    friend inline const base_uint operator+(const base_uint& a, const base_uint& b) { return base_uint(a) += b; }
-    friend inline const base_uint operator-(const base_uint& a, const base_uint& b) { return base_uint(a) -= b; }
-    friend inline const base_uint operator*(const base_uint& a, const base_uint& b) { return base_uint(a) *= b; }
-    friend inline const base_uint operator/(const base_uint& a, const base_uint& b) { return base_uint(a) /= b; }
-    friend inline const base_uint operator|(const base_uint& a, const base_uint& b) { return base_uint(a) |= b; }
-    friend inline const base_uint operator&(const base_uint& a, const base_uint& b) { return base_uint(a) &= b; }
-    friend inline const base_uint operator^(const base_uint& a, const base_uint& b) { return base_uint(a) ^= b; }
-    friend inline const base_uint operator>>(const base_uint& a, int shift) { return base_uint(a) >>= shift; }
-    friend inline const base_uint operator<<(const base_uint& a, int shift) { return base_uint(a) <<= shift; }
-    friend inline const base_uint operator*(const base_uint& a, uint32_t b) { return base_uint(a) *= b; }
-    friend inline bool operator==(const base_uint& a, const base_uint& b) { return memcmp(a.pn, b.pn, sizeof(a.pn)) == 0; }
-    friend inline bool operator!=(const base_uint& a, const base_uint& b) { return memcmp(a.pn, b.pn, sizeof(a.pn)) != 0; }
-    friend inline bool operator>(const base_uint& a, const base_uint& b) { return a.CompareTo(b) > 0; }
-    friend inline bool operator<(const base_uint& a, const base_uint& b) { return a.CompareTo(b) < 0; }
-    friend inline bool operator>=(const base_uint& a, const base_uint& b) { return a.CompareTo(b) >= 0; }
-    friend inline bool operator<=(const base_uint& a, const base_uint& b) { return a.CompareTo(b) <= 0; }
-    friend inline bool operator==(const base_uint& a, uint64_t b) { return a.EqualTo(b); }
-    friend inline bool operator!=(const base_uint& a, uint64_t b) { return !a.EqualTo(b); }
-
-    std::string GetHex() const;
-    void SetHex(const char* psz);
-    void SetHex(const std::string& str);
-    std::string ToString() const;
-    std::string ToStringReverseEndian() const;
-
-    unsigned char* begin()
-    {
-        return (unsigned char*)&pn[0];
-    }
-
-    unsigned char* end()
-    {
-        return (unsigned char*)&pn[WIDTH];
-    }
-
-    const unsigned char* begin() const
-    {
-        return (unsigned char*)&pn[0];
-    }
-
-    const unsigned char* end() const
-    {
-        return (unsigned char*)&pn[WIDTH];
-    }
-
-    unsigned int size() const
-    {
-        return sizeof(pn);
-    }
-
-    uint64_t Get64(int n = 0) const
-    {
-        return pn[2 * n] | (uint64_t)pn[2 * n + 1] << 32;
-    }
-
-    uint32_t Get32(int n = 0) const
-    {
-        return pn[2 * n];
-    }
-    /**
-     * Returns the position of the highest bit set plus one, or zero if the
-     * value is zero.
-     */
-    unsigned int bits() const;
-
-    uint64_t GetLow64() const
-    {
-        assert(WIDTH >= 2);
-        return pn[0] | (uint64_t)pn[1] << 32;
-    }
-
-    unsigned int GetSerializeSize(int nType, int nVersion) const
-    {
-        return sizeof(pn);
-    }
-
-    template <typename Stream>
-    void Serialize(Stream& s, int nType, int nVersion) const
-    {
-        s.write((char*)pn, sizeof(pn));
-    }
-
-    template <typename Stream>
-    void Unserialize(Stream& s, int nType, int nVersion)
-    {
-        s.read((char*)pn, sizeof(pn));
-    }
-
-    // Temporary for migration to opaque uint160/256
-    uint64_t GetCheapHash() const
-    {
-        return GetLow64();
-    }
-
-    friend class uint160;
-    friend class uint256;
-    friend class uint512;
-};
+//
+// This is a migration file class, as soon as we move every
+// uint256 field used, invalidly, as a number to the proper arith_uint256, this will be replaced
+// with the blob_uint256 file.
+//
 
 /** 160-bit unsigned big integer. */
 class uint160 : public base_uint<160>
@@ -353,20 +53,43 @@ public:
      * The lower 23 bits are the mantissa.
      * Bit number 24 (0x800000) represents the sign of N.
      * N = (-1^sign) * mantissa * 256^(exponent-3)
-     * 
+     *
      * Satoshi's original implementation used BN_bn2mpi() and BN_mpi2bn().
      * MPI uses the most significant bit of the first byte as sign.
      * Thus 0x1234560000 is compact (0x05123456)
      * and  0xc0de000000 is compact (0x0600c0de)
-     * 
+     *
      * Bitcoin only uses this "compact" format for encoding difficulty
      * targets, which are unsigned 256bit quantities.  Thus, all the
      * complexities of the sign bit and using base 256 are probably an
      * implementation accident.
      */
-    uint256& SetCompact(uint32_t nCompact, bool* pfNegative = NULL, bool* pfOverflow = NULL);
+    uint256& SetCompact(uint32_t nCompact, bool* pfNegative = nullptr, bool* pfOverflow = nullptr);
     uint32_t GetCompact(bool fNegative = false) const;
     uint64_t GetHash(const uint256& salt) const;
+};
+
+/** 512-bit unsigned big integer. */
+class uint512 : public base_uint<512>
+{
+public:
+    uint512() {}
+    uint512(const base_uint<512>& b) : base_uint<512>(b) {}
+    uint512(uint64_t b) : base_uint<512>(b) {}
+    explicit uint512(const std::string& str) : base_uint<512>(str) {}
+    explicit uint512(const std::vector<unsigned char>& vch) : base_uint<512>(vch) {}
+
+    uint256 trim256() const
+    {
+        uint256 ret;
+        for (unsigned int i = 0; i < uint256::WIDTH; i++) {
+            ret.pn[i] = pn[i];
+        }
+        return ret;
+    }
+
+    friend arith_uint512 UintToArith512(const uint512 &a);
+    friend uint512 ArithToUint512(const arith_uint512 &a);
 };
 
 /* uint256 from const char *.
@@ -390,26 +113,6 @@ inline uint256 uint256S(const std::string& str)
     return rv;
 }
 
-/** 512-bit unsigned big integer. */
-class uint512 : public base_uint<512>
-{
-public:
-    uint512() {}
-    uint512(const base_uint<512>& b) : base_uint<512>(b) {}
-    uint512(uint64_t b) : base_uint<512>(b) {}
-    explicit uint512(const std::string& str) : base_uint<512>(str) {}
-    explicit uint512(const std::vector<unsigned char>& vch) : base_uint<512>(vch) {}
-
-    uint256 trim256() const
-    {
-        uint256 ret;
-        for (unsigned int i = 0; i < uint256::WIDTH; i++) {
-            ret.pn[i] = pn[i];
-        }
-        return ret;
-    }
-};
-
 inline uint512 uint512S(const std::string& str)
 {
     uint512 rv;
@@ -417,8 +120,13 @@ inline uint512 uint512S(const std::string& str)
     return rv;
 }
 
+uint256 ArithToUint256(const arith_uint256 &);
+arith_uint256 UintToArith256(const uint256 &);
+uint512 ArithToUint512(const arith_uint512 &);
+arith_uint512 UintToArith512(const uint512 &);
+
 /** constant uint256 instances */
 const uint256 UINT256_ZERO = uint256();
 const uint256 UINT256_ONE = uint256("0000000000000000000000000000000000000000000000000000000000000001");
 
-#endif // BITCOIN_UINT256_H
+#endif // PRCY_UINT256_H

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -419,5 +419,6 @@ inline uint512 uint512S(const std::string& str)
 
 /** constant uint256 instances */
 const uint256 UINT256_ZERO = uint256();
+const uint256 UINT256_ONE = uint256("0000000000000000000000000000000000000000000000000000000000000001");
 
 #endif // BITCOIN_UINT256_H

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -312,6 +312,12 @@ public:
         s.read((char*)pn, sizeof(pn));
     }
 
+    // Temporary for migration to opaque uint160/256
+    uint64_t GetCheapHash() const
+    {
+        return GetLow64();
+    }
+
     friend class uint160;
     friend class uint256;
     friend class uint512;
@@ -365,7 +371,7 @@ public:
 
 /* uint256 from const char *.
  * This is a separate function because the constructor uint256(const char*) can result
- * in dangerously catching uint256(0).
+ * in dangerously catching UINT256_ZERO.
  */
 inline uint256 uint256S(const char* str)
 {
@@ -375,7 +381,7 @@ inline uint256 uint256S(const char* str)
 }
 /* uint256 from std::string.
  * This is a separate function because the constructor uint256(const std::string &str) can result
- * in dangerously catching uint256(0) via std::string(const char*).
+ * in dangerously catching UINT256_ZERO via std::string(const char*).
  */
 inline uint256 uint256S(const std::string& str)
 {
@@ -410,5 +416,8 @@ inline uint512 uint512S(const std::string& str)
     rv.SetHex(str);
     return rv;
 }
+
+/** constant uint256 instances */
+const uint256 UINT256_ZERO = uint256();
 
 #endif // BITCOIN_UINT256_H

--- a/src/uint512.h
+++ b/src/uint512.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2017-2018 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PRCY_UINT512_H
+#define PRCY_UINT512_H
+
+#include "arith_uint256.h"
+#include "blob_uint256.h"
+
+/** 512-bit unsigned big integer. */
+class blob_uint512 : public base_blob<512>
+{
+public:
+    blob_uint512() {}
+    blob_uint512(const base_blob<512>& b) : base_blob<512>(b) {}
+    explicit blob_uint512(const std::vector<unsigned char>& vch) : base_blob<512>(vch) {}
+
+    blob_uint256 trim256() const
+    {
+        std::vector<unsigned char> vch;
+        const unsigned char* p = this->begin();
+        for (unsigned int i = 0; i < 32; i++) {
+            vch.push_back(*p++);
+        }
+        return blob_uint256(vch);
+    }
+};
+
+
+/* uint256 from const char *.
+ * This is a separate function because the constructor uint256(const char*) can result
+ * in dangerously catching UINT256_ZERO.
+ */
+inline blob_uint512 blob_uint512S(const char* str)
+{
+    blob_uint512 rv;
+    rv.SetHex(str);
+    return rv;
+}
+
+#endif // PRCY_UINT512_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2057,7 +2057,7 @@ UniValue lockunspent(const UniValue& params, bool fHelp)
         if (nOutput < 0)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, vout must be positive");
 
-        COutPoint outpt(uint256(txid), nOutput);
+        COutPoint outpt(uint256S(txid), nOutput);
 
         if (fUnlock)
             pwalletMain->UnlockCoin(outpt);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1632,7 +1632,7 @@ UniValue listsinceblock(const UniValue& params, bool fHelp)
     isminefilter filter = ISMINE_SPENDABLE;
 
     if (params.size() > 0) {
-        uint256 blockId = 0;
+        uint256 blockId;
 
         blockId.SetHex(params[0].get_str());
         BlockMap::iterator it = mapBlockIndex.find(blockId);
@@ -1663,7 +1663,7 @@ UniValue listsinceblock(const UniValue& params, bool fHelp)
     }
 
     CBlockIndex* pblockLast = chainActive[chainActive.Height() + 1 - target_confirms];
-    uint256 lastblock = pblockLast ? pblockLast->GetBlockHash() : 0;
+    uint256 lastblock = pblockLast ? pblockLast->GetBlockHash() : UINT256_ZERO;
 
     UniValue ret(UniValue::VOBJ);
     ret.push_back(Pair("transactions", transactions));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -777,7 +777,7 @@ bool CWallet::IsSpent(const uint256& hash, unsigned int n)
 
     std::string outString = outpoint.hash.GetHex() + std::to_string(outpoint.n);
     CKeyImage ki = outpointToKeyImages[outString];
-    if (IsSpentKeyImage(ki.GetHex(), uint256())) {
+    if (IsSpentKeyImage(ki.GetHex(), UINT256_ZERO)) {
         return true;
     }
 
@@ -3962,7 +3962,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
                 // Read block header
                 CBlockHeader block = pindex->GetBlockHeader();
                 bool fKernelFound = false;
-                uint256 hashProofOfStake = 0;
+                uint256 hashProofOfStake;
                 COutPoint prevoutStake = COutPoint(pcoin.first->GetHash(), pcoin.second);
                 nTxNewTime = GetAdjustedTime();
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4840,7 +4840,7 @@ void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t>& mapKeyBirth) const
 unsigned int CWallet::ComputeTimeSmart(const CWalletTx& wtx) const
 {
     unsigned int nTimeSmart = wtx.nTimeReceived;
-    if (wtx.hashBlock != 0) {
+    if (!wtx.hashBlock.IsNull()) {
         if (mapBlockIndex.count(wtx.hashBlock)) {
             int64_t latestNow = wtx.nTimeReceived;
             int64_t latestEntry = 0;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -734,7 +734,7 @@ public:
 
     void Init()
     {
-        hashBlock = 0;
+        hashBlock = UINT256_ZERO;
         nIndex = -1;
         fMerkleVerified = false;
     }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -602,7 +602,7 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
             }
             CKey key;
             CPrivKey pkey;
-            uint256 hash = 0;
+            uint256 hash;
 
             if (strType == "key") {
                 wss.nKeys++;
@@ -625,7 +625,7 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
 
             bool fSkipCheck = false;
 
-            if (hash != 0) {
+            if (!hash.IsNull()) {
                 // hash pubkey/privkey to accelerate wallet load
                 std::vector<unsigned char> vchKey;
                 vchKey.reserve(vchPubKey.size() + pkey.size());


### PR DESCRIPTION
> This is part of the large effort of making the uint256 file an opaque blob object and not treat every uint256 as an arith_uint256 anymore (same for the uint160 and uint512). Work coded on top of #1395, this is the second step.
> 
> As we cannot do it all at once, i opted to do the migration in steps. The amount of changes needed is really extensive and the risk of damage the synchronization process -and other areas as well- is high, this will need changes on the MNs, budget and zerocoin library sources which are using the uint256 object purely as a number.
> 
> This step is doing the following changes:
> 
> 1. Creating blob_uint256 files (opaque blob version of the uint256 files -- this is the future uint256 files that will be refactored once all of the fields that are using it as a number in our sources get migrated to use the new arith_uint256 classes).
> 2. Creating arith_uint256 files.
> 3. Cleaning shared code between the uint256 file and the arith_uint256 classes and only leaving in uint256 the old classes that needs to be checked and migrated -- if them are using the uint256 as a number and not as an opaque blob object -- (following the explanation in point 1).
> 4. Updating, cleaning and connecting the arith_uint256 unit test (including arith_uint160 and arith_uint256 checks and validations).

from https://github.com/PIVX-Project/PIVX/pull/1414

We leave out the CMake commit as we currently do not have CMake builds