### PR TITLE
[Qt] Use Stealth Address instead of URI for Request Payment QR Code by lyricidal

### DIFF
--- a/src/qt/receiverequestdialog.cpp
+++ b/src/qt/receiverequestdialog.cpp
@@ -154,7 +154,7 @@ void ReceiveRequestDialog::update()
         if (uri.length() > MAX_URI_LENGTH) {
             ui->lblQRCode->setText(tr("Resulting URI too long, try to reduce the text for label / message."));
         } else {
-            QRcode* code = QRcode_encodeString(uri.toUtf8().constData(), 0, QR_ECLEVEL_L, QR_MODE_8, 1);
+            QRcode* code = QRcode_encodeString(info.address.toUtf8().constData(), 0, QR_ECLEVEL_L, QR_MODE_8, 1); // don't use uri, better mobile scanning
             if (!code) {
                 ui->lblQRCode->setText(tr("Error encoding URI into QR Code."));
                 return;


### PR DESCRIPTION
Fixing an old issue / request

When trying to scan QR codes from the Mobile Wallet/Web Wallet, it wouldn't work correctly as the URI was prepended to it. Remove this to allow easier scanning. Could potentially be an option/setting.