### PR TITLE
[Upstream] [Wallet] Close DB on error

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -106,8 +106,10 @@ bool CDBEnv::Open(const fs::path& pathIn)
             DB_RECOVER |
             nEnvFlags,
         S_IRUSR | S_IWUSR);
-    if (ret != 0)
+    if (ret != 0) {
+        dbenv->close(0);
         return error("CDBEnv::Open : Error %d opening database environment: %s\n", ret, DbEnv::strerror(ret));
+    }
 
     fDbEnvInit = true;
     fMockDb = false;
@@ -396,8 +398,10 @@ bool CDB::Rewrite(const std::string& strFile, const char* pszSkip)
                         bitdb.CloseDb(strFile);
                         if (pdbCopy->close(0))
                             fSuccess = false;
-                        delete pdbCopy;
+                    } else {
+                        pdbCopy->close(0);
                     }
+                    delete pdbCopy;
                 }
                 if (fSuccess) {
                     Db dbA(bitdb.dbenv, 0);


### PR DESCRIPTION
> Coming from [bitcoin#11017](https://github.com/bitcoin/bitcoin/pull/11017)
> 
> > This PR intends to plug some leaks. It specifically implements adherence to the requirement in BDB to close a handle which failed to open (https://docs.oracle.com/cd/E17276_01/html/api_reference/C/dbopen.html):
> > > The DB->open() method returns a non-zero error value on failure and 0 on success. If DB->open() fails, the DB->close() method
> > > must be called to discard the DB handle.

simple backport from https://github.com/PIVX-Project/PIVX/pull/2197
