### PR TITLE
[Trivial] Add missed updates of fsbridge for fopen and freopen

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -92,7 +92,7 @@ bool CDBEnv::Open(const fs::path& pathIn)
     dbenv->set_lg_max(1048576);
     dbenv->set_lk_max_locks(40000);
     dbenv->set_lk_max_objects(40000);
-    dbenv->set_errfile(fopen(pathErrorFile.string().c_str(), "a")); /// debug
+    dbenv->set_errfile(fsbridge::fopen(pathErrorFile, "a")); /// debug
     dbenv->set_flags(DB_AUTO_COMMIT, 1);
     dbenv->set_flags(DB_TXN_WRITE_NOSYNC, 1);
     dbenv->log_set_config(DB_LOG_AUTO_REMOVE, 1);


### PR DESCRIPTION
A few missed changes for usage of fsbridge for fopen and freopen as we did not have logging.cpp at the time

> Abstracts away how a path is opened to a `FILE*`.

> Reduces the number of places where path is converted to a string
> for anything else but printing.

> backports https://github.com/bitcoin/bitcoin/commit/2a5f574762614b74dee738392057200dd28c64fb