### PR TITLE
[Consensus] Increase MAX_STANDARD_TX_SIZE

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -66,7 +66,7 @@ static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;
 /** The maximum size for transactions we're willing to relay/mine */
-static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
+static const unsigned int MAX_STANDARD_TX_SIZE = 150000;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */
 static const unsigned int MAX_P2SH_SIGOPS = 15;
 /** Default for -maxorphantx, maximum number of orphan transactions kept in memory */


### PR DESCRIPTION
Increase the MAX_STANDARD_TX_SIZE to match the size that Zerocoin used to be.
This is safe because currently no transactions can currently reach this size until after the Hard Fork