### PR TITLE
[Qt] Fix address copying on small screens

### DIFF
--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -240,7 +240,15 @@ void ReceiveCoinsDialog::keyPressEvent(QKeyEvent* event)
 
 void ReceiveCoinsDialog::copyAddress(){
     QClipboard *clipboard = QApplication::clipboard();
-    clipboard->setText(ui->lineEditAddress->text());
+    if (ui->lineEditAddress->text().contains(".")) {
+        // It's a smaller screen, don't copy the line text as it is truncated
+        QString addr;
+        std::string address;
+        pwalletMain->ComputeStealthPublicAddress("masteraccount", address);
+        clipboard->setText(QString(address.c_str()));
+    } else {
+        clipboard->setText(ui->lineEditAddress->text());
+    }
 }
 
 void ReceiveCoinsDialog::generateAddress()


### PR DESCRIPTION
Fixing a minor bug introduced by my own code changes without compensating for the adjustments for the smaller screens that display a truncated version of the address. In this case, we change from copying the LineEdit to the actual Master Account, Integrated addresses are not truncated.