### PR TITLE
[Consensus] PoA fix for after hard fork

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -371,7 +371,7 @@ bool VerifyRingSignatureWithTxFee(const CTransaction& tx, CBlockIndex* pindex)
     if (tx.nTxFee < 0) return false;
     if (IsInitialBlockDownload()) return true;
     const size_t MAX_VIN = MAX_TX_INPUTS;
-    SetRingSize();
+    SetRingSize(pindex->nHeight);
     const size_t MAX_DECOYS = MAX_RING_SIZE; //padding 1 for safety reasons
     const size_t MAX_VOUT = 5;
 
@@ -2299,12 +2299,15 @@ int64_t GetMasternodePayment(int nHeight, int64_t blockValue, int nMasternodeCou
     return ret;
 }
 
-void SetRingSize()
+void SetRingSize(int nHeight)
 {
+    if (chainActive.Tip() == NULL) return;
+    if (nHeight == 0) {
+        nHeight = chainActive.Tip()->nHeight;
+    }
     MIN_RING_SIZE = 11;
     MAX_RING_SIZE = 15;
-    if (chainActive.Tip() == NULL) return;
-    int nHeight = chainActive.Tip()->nHeight;
+
     if (nHeight >= Params().HardForkRingSize()) {
         MIN_RING_SIZE = 27;
         MAX_RING_SIZE = 32;

--- a/src/main.h
+++ b/src/main.h
@@ -240,7 +240,7 @@ bool ActivateBestChain(CValidationState& state, CBlock* pblock = NULL, bool fAlr
 CAmount GetBlockValue(int nHeight);
 
 void RemoveInvalidTransactionsFromMempool();
-void SetRingSize();
+void SetRingSize(int nHeight);
 
 /** Create a new block index entry for a given block hash */
 CBlockIndex* InsertBlockIndex(uint256 hash);

--- a/src/qt/optionspage.cpp
+++ b/src/qt/optionspage.cpp
@@ -485,7 +485,7 @@ void OptionsPage::on_EnableStaking(ToggleButton* widget)
             } else if (stt == UNSTAKABLE_BALANCE_RESERVE_TOO_HIGH) {
                 errorMessage = "Your stakeable balance is under the threshold of 2500 PRCY. This is due to your reserve balance being too high. Please deposit more PRCY into your account or reduce your reserved amount in order to enable staking.";
             } else {
-                SetRingSize();
+                SetRingSize(0);
                 CAmount totalFee = maxFee + pwalletMain->ComputeFee(1, 2, MAX_RING_SIZE);
                 errorMessage = "Your stakeable balance is under the threshold of 2500 PRCY. This is due to your reserve balance of " + FormatMoney(nReserveBalance) + " PRCY being too high. The wallet software has tried to consolidate your funds with the reserve balance but without success because of a consolidation fee of " + FormatMoney(totalFee) + " PRCY. Please wait around 10 minutes for the wallet to resolve the reserve to enable staking.";
             }

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -206,7 +206,7 @@ void SendCoinsDialog::on_sendButton_clicked(){
     recipientElement.append("<br/><span class='h3'>"+tr("Destination")+": <br/><b>"+recipient.address+"</b></span><br/>");
 
     formatted.append(recipientElement);
-    SetRingSize();
+    SetRingSize(0);
     QString strFee = BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), (pwalletMain->ComputeFee(1, 1, MAX_RING_SIZE)));
     QString questionString = "<br/><span class='h2'><center><b>"+tr("Are you sure you want to send?")+"</b></center></span>";
     questionString.append("%1");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2202,7 +2202,7 @@ StakingStatusError CWallet::StakingCoinStatus(CAmount& minFee, CAmount& maxFee)
 {
     minFee = 0;
     maxFee = 0;
-    SetRingSize();
+    SetRingSize(0);
     CAmount nBalance = GetBalance();
     if (pwalletMain->IsMasternodeController()) {
         nBalance = GetSpendableBalance();
@@ -2691,7 +2691,7 @@ int CWallet::ComputeTxSize(size_t numIn, size_t numOut, size_t ringSize)
 
 //compute the amount that let users send reserve balance
 CAmount CWallet::ComputeReserveUTXOAmount() {
-    SetRingSize();
+    SetRingSize(0);
     CAmount fee = ComputeFee(1, 2, MAX_RING_SIZE);
     return nReserveBalance + fee;
 }
@@ -2731,7 +2731,7 @@ bool CWallet::IsAutoConsolidateOn()
 bool CWallet::CreateTransactionBulletProof(const CKey& txPrivDes, const CPubKey& recipientViewKey, const std::vector<std::pair<CScript, CAmount> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl* coinControl, AvailableCoinsType coin_type, bool useIX, CAmount nFeePay, int ringSize, bool tomyself)
 {
     if (useIX && nFeePay < CENT) nFeePay = CENT;
-    SetRingSize();
+    SetRingSize(0);
 
     //randomize ring size
     unsigned char rand_seed[16];
@@ -3177,7 +3177,7 @@ bool CWallet::makeRingCT(CTransaction& wtxNew, int ringSize, std::string& strFai
         }
     }
 
-    SetRingSize();
+    SetRingSize(0);
     const size_t MAX_VIN = MAX_TX_INPUTS;
     const size_t MAX_DECOYS = MAX_RING_SIZE; //padding 1 for safety reasons
     const size_t MAX_VOUT = 5;
@@ -4911,7 +4911,7 @@ bool CWallet::SendAll(std::string des)
         throw std::runtime_error("Wallet is locked! Please unlock it to make transactions.");
     }
 
-    SetRingSize();
+    SetRingSize(0);
     int estimateTxSize = ComputeTxSize(1, 1, MIN_RING_SIZE);
     CAmount nFeeNeeded = GetMinimumFee(estimateTxSize, nTxConfirmTarget, mempool);
     if (GetSpendableBalance() <= nFeeNeeded) {
@@ -5219,7 +5219,7 @@ bool CWallet::CreateSweepingTransaction(CAmount target, CAmount threshold, uint3
                     }
                 }
             }
-            SetRingSize();
+            SetRingSize(0);
             int ringSize = MIN_RING_SIZE + secp256k1_rand32() % (MAX_RING_SIZE - MIN_RING_SIZE + 1);
             if (vCoins.size() <= 1) return false;
             CAmount estimatedFee = ComputeFee(vCoins.size(), 1, ringSize);


### PR DESCRIPTION
This fix is related to the Hard Fork/Ring Size bump - the ReVerifyPoS function would cause issue because it was expecting a certain amount of decoys/rings for that block. When the rings change this causes an issue with PoA mining expecting the previous amount of Rings. Fix this by adding 0 as a simple identifier to say that the height should be the current active tip, otherwise use the height passed in.