### PR TITLE
[Qt] Add Alternative Currency Value

### DIFF
--- a/src/qt/forms/optionspage.ui
+++ b/src/qt/forms/optionspage.ui
@@ -647,6 +647,80 @@
          </layout>
         </widget>
        </item>
+       <item>
+        <widget class="QGroupBox" name="currencyValuegroupBox">
+         <property name="title">
+          <string>Alternative Currency Value</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_9">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_7">
+            <item>
+             <widget class="QCheckBox" name="displayCurrencyValue">
+              <property name="text">
+               <string>Display alternative currency value of wallet on Overview</string>
+              </property>
+             </widget>
+            </item>
+            <item alignment="Qt::AlignRight">
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>Default Currency:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="defaultCurrency">
+              <property name="layoutDirection">
+               <enum>Qt::LeftToRight</enum>
+              </property>
+              <item>
+               <property name="text">
+                <string>USD</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>CAD</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>EUR</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>GBP</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>BTC</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>ETH</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>XAU</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>XAG</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
       </layout>
      </widget>
     </widget>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -247,9 +247,12 @@
           </widget>
          </item>
          <item>
-          <widget class="QLabel" name="label_9">
+          <widget class="QLabel" name="labelCurrencyValue">
            <property name="text">
             <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignHCenter|Qt::AlignTop</set>
            </property>
           </widget>
          </item>

--- a/src/qt/optionspage.cpp
+++ b/src/qt/optionspage.cpp
@@ -157,6 +157,8 @@ OptionsPage::OptionsPage(QWidget* parent) : QDialog(parent, Qt::WindowSystemMenu
     ui->alwaysRequest2FA->setChecked(settings.value("fAlwaysRequest2FA", false).toBool());
     ui->hideBalanceStaking->setChecked(settings.value("fHideBalance", false).toBool());
     ui->lockSendStaking->setChecked(settings.value("fLockSendStaking", false).toBool());
+    ui->displayCurrencyValue->setChecked(settings.value("fDisplayCurrencyValue", false).toBool());
+    ui->defaultCurrency->setCurrentText(settings.value("strDefaultCurrency").toString());
     connect(ui->addNewFunds, SIGNAL(stateChanged(int)), this, SLOT(setAutoConsolidate(int)));
     connect(ui->mapPortUpnp, SIGNAL(stateChanged(int)), this, SLOT(mapPortUpnp_clicked(int)));
     connect(ui->minimizeToTray, SIGNAL(stateChanged(int)), this, SLOT(minimizeToTray_clicked(int)));
@@ -164,6 +166,8 @@ OptionsPage::OptionsPage(QWidget* parent) : QDialog(parent, Qt::WindowSystemMenu
     connect(ui->alwaysRequest2FA, SIGNAL(stateChanged(int)), this, SLOT(alwaysRequest2FA_clicked(int)));
     connect(ui->hideBalanceStaking, SIGNAL(stateChanged(int)), this, SLOT(hideBalanceStaking_clicked(int)));
     connect(ui->lockSendStaking, SIGNAL(stateChanged(int)), this, SLOT(lockSendStaking_clicked(int)));
+    connect(ui->displayCurrencyValue, SIGNAL(stateChanged(int)), this, SLOT(displayCurrencyValue_clicked(int)));
+    connect(ui->defaultCurrency, SIGNAL(currentIndexChanged(int)), this, SLOT(setDefaultCurrency(int)));
 }
 
 void OptionsPage::setStakingToggle()
@@ -1062,6 +1066,26 @@ void OptionsPage::lockSendStaking_clicked(int state) {
             return;
         }
     }
+}
+
+
+void OptionsPage::displayCurrencyValue_clicked(int)
+{
+    checkForUnlock();
+    if (ui->displayCurrencyValue->isChecked()) {
+        settings.setValue("fDisplayCurrencyValue", true);
+        // Only set default USD if one doesn't already exist
+        if (!settings.contains("strDefaultCurrency"))
+            settings.setValue("strDefaultCurrency", "USD");
+    } else {
+        settings.setValue("fDisplayCurrencyValue", false);
+    }
+}
+
+void OptionsPage::setDefaultCurrency(int)
+{
+    checkForUnlock();
+    settings.setValue("strDefaultCurrency", ui->defaultCurrency->currentText());
 }
 
 void OptionsPage::checkForUnlock()

--- a/src/qt/optionspage.h
+++ b/src/qt/optionspage.h
@@ -105,6 +105,8 @@ private Q_SLOTS:
     void hideBalanceStaking_clicked(int);
     void lockSendStaking_clicked(int);
     void checkForUnlock();
+    void displayCurrencyValue_clicked(int);
+    void setDefaultCurrency(int);
 };
 
 #endif // BITCOIN_QT_OPTIONSPAGE_H

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -13,6 +13,7 @@
 #include <QDialog>
 #include <QSizeGrip>
 #include <QSettings>
+#include <QNetworkReply>
 
 class ClientModel;
 class TransactionFilterProxy;
@@ -63,6 +64,7 @@ Q_SIGNALS:
 private:
     QTimer* timer;
     QTimer* pingNetworkInterval;
+    QTimer* checkCurrencyValueInterval;
     Ui::OverviewPage* ui;
     ClientModel* clientModel;
     WalletModel* walletModel;
@@ -86,6 +88,7 @@ private:
     QWidget* balanceAnimSyncCircle;
     bool isSyncingBalance=true;
     QSettings settings;
+    bool isRuninngQuery=false;
 
     void initSyncCircle(float percentOfParent);
     void moveSyncCircle(QWidget* anchor, QWidget* animated, int deltaRadius, float degreesPerSecond, float angleOffset=0);
@@ -98,6 +101,8 @@ private Q_SLOTS:
     void updateWatchOnlyLabels(bool showWatchOnly);
     void on_lockUnlock();
     void updateLockStatus(int status);
+    void checkCurrencyValue();
+    void checkCurrencyValueserviceRequestFinished(QNetworkReply* reply);
 };
 
 #endif // BITCOIN_QT_OVERVIEWPAGE_H


### PR DESCRIPTION
Preliminary implementation - adding the` isRuninngQuery` boolean to avoid overexerting CoinGecko's free API. Set to false initially.
Allows for selection of multiple currencies, including:
USD
CAD
EUR
GBP
BTC
ETH
XAU
XAG

Thanks to CoinGecko
https://www.coingecko.com/en/api