### PR TITLE
[Testnet] Add Testnet specific changes

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -129,6 +129,7 @@ public:
         nPoAPadding = 10; // Current PoA Padding
         nHardForkBlock = 375000; // Add hard fork block for Consensus/PoA Padding
         nHardForkBlockRingSize = 750000; // Add hard fork block for Ring Size bump
+        nHardForkBlockRingSize2 = nHardForkBlockRingSize; // For testnet & compile purposes
 
         /**
          * Build the genesis block. Note that the output of the genesis coinbase cannot
@@ -282,7 +283,8 @@ public:
         nPoAPaddingBlock = 0;
         nPoAPadding = 5; // Current PoA Padding
         nHardForkBlock = 700; // Add hard fork block for Consensus/PoA Padding
-        nHardForkBlockRingSize = 16000; // Add hard fork block for Ring Size bump
+        nHardForkBlockRingSize = 16000; // Add hard fork block for Ring Size bump to 25-30
+        nHardForkBlockRingSize2 = 126000; // Add hard fork block for Ring Size bump to 30-32
 
         //! Modify the testnet genesis block so the timestamp is valid for a later start.
         genesis.nTime = 1608422400;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -116,6 +116,7 @@ public:
     int BIP65ActivationHeight() const { return nBIP65ActivationHeight; }
     int HardFork() const { return nHardForkBlock;}
     int HardForkRingSize() const { return nHardForkBlockRingSize;}
+    int HardForkRingSize2() const { return nHardForkBlockRingSize2;}
 
     //For PoA block time
     int POA_BLOCK_TIME() const { return nPoABlockTime; }
@@ -144,6 +145,7 @@ protected:
     int nSoftForkBlock;
     int nHardForkBlock;
     int nHardForkBlockRingSize;
+    int nHardForkBlockRingSize2;
     int nPoANewDiff;
     int nPoAFixTime;
     int nPoAPaddingBlock;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2305,12 +2305,28 @@ void SetRingSize(int nHeight)
     if (nHeight == 0) {
         nHeight = chainActive.Tip()->nHeight;
     }
+
+    // Original Ring Sizes on all networks
     MIN_RING_SIZE = 11;
     MAX_RING_SIZE = 15;
 
+    // Ring Sizes after the Hard Fork block
+    // Add any Ring Size increases as the last check
     if (nHeight >= Params().HardForkRingSize()) {
         MIN_RING_SIZE = 27;
         MAX_RING_SIZE = 32;
+    }
+
+    // Testnet Hard Forks were different
+    if (Params().NetworkID() == CBaseChainParams::TESTNET) {
+        if (nHeight >= Params().HardForkRingSize()) {
+            MIN_RING_SIZE = 25;
+            MAX_RING_SIZE = 30;
+        }
+        if (nHeight >= Params().HardForkRingSize2()) {
+            MIN_RING_SIZE = 30;
+            MAX_RING_SIZE = 32;
+        }
     }
 
     LogPrint(BCLog::SELECTCOINS, "%s: height %d: min ring size %d, max ring size: %d\n", __func__, nHeight, MIN_RING_SIZE, MAX_RING_SIZE);


### PR DESCRIPTION
Testnet had different Hard Forks/Ring Sizes than Mainnet - add a specific check for them

This aligns the builds to be usable on each network, as they had slightly deviated from each other due to above