### PR TITLE
[Trivial] Remove DUST variable

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -18,7 +18,6 @@ typedef int64_t CAmount;
 
 static const CAmount COIN = 100000000;
 static const CAmount CENT = 1000000;
-static const CAmount DUST = COIN / 100000;
 static const CAmount MIN_FEE = COIN / 10000;
 static const CAmount MAX_FEE = COIN / 100;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2021,8 +2021,6 @@ bool CWallet::AvailableCoins(const uint256 wtxid, const CWalletTx* pcoin, std::v
             }
             if (!found) continue;
 
-            if (value <= DUST) continue; //dust
-
             isminetype mine = IsMine(pcoin->vout[i]);
             if (mine == ISMINE_NO)
                 continue;
@@ -2252,7 +2250,6 @@ StakingStatusError CWallet::StakingCoinStatus(CAmount& minFee, CAmount& maxFee)
                                 continue;
                             }
                         }
-                        if (value <= DUST) continue; //dust
 
                         isminetype mine = IsMine(pcoin->vout[i]);
                         if (mine == ISMINE_NO)


### PR DESCRIPTION
Remove `DUST = COIN / 100000` and the 2 checks that use it as they aren't required.