### PR TITLE
[Fix] Send All - Incorrect Transaction ID

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2848,11 +2848,10 @@ UniValue sendalltostealthaddress(const UniValue& params, bool fHelp)
     // Stealth Address
     std::string stealthAddr = params[0].get_str();
 
-
     // Wallet comments
     CWalletTx wtx;
 
-    if (!pwalletMain->SendAll(stealthAddr)) {
+    if (!pwalletMain->SendAll(stealthAddr, wtx)) {
         throw JSONRPCError(RPC_WALLET_ERROR,
                            "Cannot create transaction.");
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4905,7 +4905,7 @@ bool CWallet::LoadDestData(const CTxDestination& dest, const std::string& key, c
     return true;
 }
 
-bool CWallet::SendAll(std::string des)
+bool CWallet::SendAll(std::string des, CWalletTx& wtxNew)
 {
     if (this->IsLocked()) {
         throw std::runtime_error("Wallet is locked! Please unlock it to make transactions.");
@@ -4981,7 +4981,6 @@ bool CWallet::SendAll(std::string des)
 
             if (ret) {
                 // Generate transaction public key
-                CWalletTx wtxNew;
                 CKey secret;
                 secret.MakeNewKey(true);
                 SetMinVersion(FEATURE_COMPRPUBKEY);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -315,7 +315,7 @@ public:
     CAmount nAutoCombineThreshold;
     CAmount nAutoCombineTarget;
     bool CreateSweepingTransaction(CAmount target, CAmount threshold, uint32_t nTimeBefore);
-    bool SendAll(std::string des);
+    bool SendAll(std::string des, CWalletTx& wtxNew);
 
     CWallet();
     CWallet(std::string strWalletFileIn);


### PR DESCRIPTION
When using Send All (sendalltostealthaddress), it would give an incorrect TXID. This should fix that.