### PR TITLE
[Qt] Add warning to Overview when wallet is larger than 10k transactions

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -550,6 +550,12 @@
        <property name="text">
         <string>It is advised not to send or receive coins until your current sync is complete.</string>
        </property>
+       <property name="openExternalLinks">
+        <bool>true</bool>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::TextBrowserInteraction</set>
+       </property>
       </widget>
      </item>
      <item alignment="Qt::AlignRight">

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -397,7 +397,7 @@ void OverviewPage::onAnimTick()
     } else {
         blockSyncCircle->setStyleSheet("image:url(':/images/syncb')");
         blockAnimSyncCircle->setVisible(false);
-        ui->lblHelp->setVisible(false);
+        ui->lblHelp->setText(ui->lblHelp->text().remove("It is advised not to send or receive coins until your current sync is complete."));
     }
     if (isSyncingBalance){
         moveSyncCircle(balanceSyncCircle, balanceAnimSyncCircle, 3, -100, 130);
@@ -513,6 +513,15 @@ void OverviewPage::updateRecentTransactions() {
 
                     if (i % 2 == 0) {
                         entry->setObjectName("secondaryTxEntry");
+                    }
+                }
+                if (latestTxes.size() >= 10000) {
+                    QString txWarning = "Your wallet has more than 10,000 Transactions. It may run slowly. It's recommended to send your funds to a new wallet.";
+                    QString kbURL = "https://prcycoin.com/knowledge-base/wallets/sluggish-large-wallet-dat-solution/";
+                    QString kbTitle = "Need Help?";
+                    txWarning.append(" <a href=\"" + kbURL + "\">" + kbTitle + "</a>");
+                    if (!ui->lblHelp->text().contains(txWarning)) {
+                        ui->lblHelp->setText(ui->lblHelp->text() + "\n" + txWarning);
                     }
                 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2319897/175159602-6f4bf4af-27bb-49f3-9edd-940f715bd644.png)

Need Help? links to https://prcycoin.com/knowledge-base/wallets/sluggish-large-wallet-dat-solution/