### PR TITLE
[GitHub Actions] Update Ubuntu to 20.04 as 18.04 will be deprecated

### DIFF
--- a/.github/workflows/prcy-build-factory-debug.yml
+++ b/.github/workflows/prcy-build-factory-debug.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   create-source-distribution:
     name: Create Source Distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: "contains(github.event.head_commit.message, '[debug]')"
     env:
       ARTIFACT_DIR: source
@@ -59,7 +59,7 @@ jobs:
   build-x86_64-linux:
     name: Build for x86 Linux 64bit
     needs: create-source-distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACT_DIR: prcycoin-x86_64-linux-debug
       TEST_LOG_ARTIFACT_DIR: test-logs
@@ -105,7 +105,7 @@ jobs:
   build-win64:
     name: Build for Win64
     needs: create-source-distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACT_DIR: prcycoin-win64-debug
     steps:
@@ -154,7 +154,7 @@ jobs:
   build-osx64:
     name: Build for MacOSX
     needs: create-source-distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACT_DIR: prcycoin-macosx-debug
       SDK_URL: https://bitcoincore.org/depends-sources/sdks
@@ -217,7 +217,7 @@ jobs:
   build-aarch64-linux:
     name: Build for ARM Linux 64bit
     needs: create-source-distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACT_DIR: prcycoin-aarch64-linux-debug
     steps:
@@ -261,7 +261,7 @@ jobs:
   build-arm-linux-gnueabihf:
     name: Build for ARM Linux 32bit
     needs: create-source-distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACT_DIR: prcycoin-arm32-debug
     steps:
@@ -305,7 +305,7 @@ jobs:
   build-riscv64-linux-gnu:
     name: Build for RISC-V 64-bit
     needs: create-source-distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACT_DIR: prcycoin-riscv64-debug
     steps:

--- a/.github/workflows/prcy-build-factory.yml
+++ b/.github/workflows/prcy-build-factory.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   create-source-distribution:
     name: Create Source Distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACT_DIR: source
     steps:
@@ -106,7 +106,7 @@ jobs:
   build-x86_64-linux:
     name: Build for x86 Linux 64bit
     needs: create-source-distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACT_DIR: prcycoin-x86_64-linux
       TEST_LOG_ARTIFACT_DIR: test-logs
@@ -158,7 +158,7 @@ jobs:
   build-win64:
     name: Build for Win64
     needs: create-source-distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACT_DIR: prcycoin-win64
     steps:
@@ -213,7 +213,7 @@ jobs:
   build-osx64:
     name: Build for MacOSX
     needs: create-source-distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACT_DIR: prcycoin-macosx
       SDK_URL: https://bitcoincore.org/depends-sources/sdks
@@ -282,7 +282,7 @@ jobs:
   build-aarch64-linux:
     name: Build for ARM Linux 64bit
     needs: create-source-distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACT_DIR: prcycoin-aarch64-linux
     steps:
@@ -332,7 +332,7 @@ jobs:
   build-arm-linux-gnueabihf:
     name: Build for ARM Linux 32bit
     needs: create-source-distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACT_DIR: prcycoin-arm32
     steps:
@@ -382,7 +382,7 @@ jobs:
   build-riscv64-linux-gnu:
     name: Build for RISC-V 64-bit
     needs: create-source-distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       ARTIFACT_DIR: prcycoin-riscv64
     steps:


### PR DESCRIPTION
As per https://github.com/actions/runner-images/issues/6002:

> Deprecation will begin on 8/8/2022 and the image will be fully unsupported by 12/1/2022

Build for Linux remains behind for compatibility as it does not use the `depends` folder - we don't distribute this one anyways.