### PR TITLE
[Upstream] [Core] Big endian support

### DIFF
--- a/src/compat/byteswap.h
+++ b/src/compat/byteswap.h
@@ -6,7 +6,7 @@
 #define BITCOIN_COMPAT_BYTESWAP_H
 
 #if defined(HAVE_CONFIG_H)
-#include <config/bitcoin-config.h>
+#include <config/prcycoin-config.h>
 #endif
 
 #include <stdint.h>

--- a/src/compat/endian.h
+++ b/src/compat/endian.h
@@ -6,7 +6,7 @@
 #define BITCOIN_COMPAT_ENDIAN_H
 
 #if defined(HAVE_CONFIG_H)
-#include <config/bitcoin-config.h>
+#include <config/prcycoin-config.h>
 #endif
 
 #include <compat/byteswap.h>

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -1,127 +1,93 @@
-// Copyright (c) 2014 The Bitcoin developers
+// Copyright (c) 2014-2018 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef BITCOIN_CRYPTO_COMMON_H
 #define BITCOIN_CRYPTO_COMMON_H
 
-#include <stdint.h>
-
-#if defined(HAVE_ENDIAN_H)
-#include <endian.h>
+#if defined(HAVE_CONFIG_H)
+#include <config/prcycoin-config.h>
 #endif
+
+#include <stdint.h>
+#include <string.h>
+
+#include <compat/endian.h>
+
+uint16_t static inline ReadLE16(const unsigned char* ptr)
+{
+    uint16_t x;
+    memcpy((char*)&x, ptr, 2);
+    return le16toh(x);
+}
 
 uint32_t static inline ReadLE32(const unsigned char* ptr)
 {
-#if HAVE_DECL_LE32TOH == 1
-    return le32toh(*((uint32_t*)ptr));
-#elif !defined(WORDS_BIGENDIAN)
-    return *((uint32_t*)ptr);
-#else
-    return ((uint32_t)ptr[3] << 24 | (uint32_t)ptr[2] << 16 | (uint32_t)ptr[1] << 8 | (uint32_t)ptr[0]);
-#endif
+    uint32_t x;
+    memcpy((char*)&x, ptr, 4);
+    return le32toh(x);
 }
 
 uint64_t static inline ReadLE64(const unsigned char* ptr)
 {
-#if HAVE_DECL_LE64TOH == 1
-    return le64toh(*((uint64_t*)ptr));
-#elif !defined(WORDS_BIGENDIAN)
-    return *((uint64_t*)ptr);
-#else
-    return ((uint64_t)ptr[7] << 56 | (uint64_t)ptr[6] << 48 | (uint64_t)ptr[5] << 40 | (uint64_t)ptr[4] << 32 |
-            (uint64_t)ptr[3] << 24 | (uint64_t)ptr[2] << 16 | (uint64_t)ptr[1] << 8 | (uint64_t)ptr[0]);
-#endif
+    uint64_t x;
+    memcpy((char*)&x, ptr, 8);
+    return le64toh(x);
+}
+
+void static inline WriteLE16(unsigned char* ptr, uint16_t x)
+{
+    uint16_t v = htole16(x);
+    memcpy(ptr, (char*)&v, 2);
 }
 
 void static inline WriteLE32(unsigned char* ptr, uint32_t x)
 {
-#if HAVE_DECL_HTOLE32 == 1
-    *((uint32_t*)ptr) = htole32(x);
-#elif !defined(WORDS_BIGENDIAN)
-    *((uint32_t*)ptr) = x;
-#else
-    ptr[3] = x >> 24;
-    ptr[2] = x >> 16;
-    ptr[1] = x >> 8;
-    ptr[0] = x;
-#endif
+    uint32_t v = htole32(x);
+    memcpy(ptr, (char*)&v, 4);
 }
 
 void static inline WriteLE64(unsigned char* ptr, uint64_t x)
 {
-#if HAVE_DECL_HTOLE64 == 1
-    *((uint64_t*)ptr) = htole64(x);
-#elif !defined(WORDS_BIGENDIAN)
-    *((uint64_t*)ptr) = x;
-#else
-    ptr[7] = x >> 56;
-    ptr[6] = x >> 48;
-    ptr[5] = x >> 40;
-    ptr[4] = x >> 32;
-    ptr[3] = x >> 24;
-    ptr[2] = x >> 16;
-    ptr[1] = x >> 8;
-    ptr[0] = x;
-#endif
+    uint64_t v = htole64(x);
+    memcpy(ptr, (char*)&v, 8);
 }
 
 uint32_t static inline ReadBE32(const unsigned char* ptr)
 {
-#if HAVE_DECL_BE32TOH == 1
-    return be32toh(*((uint32_t*)ptr));
-#else
-    return ((uint32_t)ptr[0] << 24 | (uint32_t)ptr[1] << 16 | (uint32_t)ptr[2] << 8 | (uint32_t)ptr[3]);
-#endif
+    uint32_t x;
+    memcpy((char*)&x, ptr, 4);
+    return be32toh(x);
 }
 
 uint64_t static inline ReadBE64(const unsigned char* ptr)
 {
-#if HAVE_DECL_BE64TOH == 1
-    return be64toh(*((uint64_t*)ptr));
-#else
-    return ((uint64_t)ptr[0] << 56 | (uint64_t)ptr[1] << 48 | (uint64_t)ptr[2] << 40 | (uint64_t)ptr[3] << 32 |
-            (uint64_t)ptr[4] << 24 | (uint64_t)ptr[5] << 16 | (uint64_t)ptr[6] << 8 | (uint64_t)ptr[7]);
-#endif
+    uint64_t x;
+    memcpy((char*)&x, ptr, 8);
+    return be64toh(x);
 }
 
 void static inline WriteBE32(unsigned char* ptr, uint32_t x)
 {
-#if HAVE_DECL_HTOBE32 == 1
-    *((uint32_t*)ptr) = htobe32(x);
-#else
-    ptr[0] = x >> 24;
-    ptr[1] = x >> 16;
-    ptr[2] = x >> 8;
-    ptr[3] = x;
-#endif
+    uint32_t v = htobe32(x);
+    memcpy(ptr, (char*)&v, 4);
 }
 
 void static inline WriteBE64(unsigned char* ptr, uint64_t x)
 {
-#if HAVE_DECL_HTOBE64 == 1
-    *((uint64_t*)ptr) = htobe64(x);
-#else
-    ptr[0] = x >> 56;
-    ptr[1] = x >> 48;
-    ptr[2] = x >> 40;
-    ptr[3] = x >> 32;
-    ptr[4] = x >> 24;
-    ptr[5] = x >> 16;
-    ptr[6] = x >> 8;
-    ptr[7] = x;
-#endif
+    uint64_t v = htobe64(x);
+    memcpy(ptr, (char*)&v, 8);
 }
 
 /** Return the smallest number n such that (x >> n) == 0 (or 64 if the highest bit in x is set. */
 uint64_t static inline CountBits(uint64_t x)
 {
-#ifdef HAVE_DECL___BUILTIN_CLZL
+#if HAVE_DECL___BUILTIN_CLZL
     if (sizeof(unsigned long) >= sizeof(uint64_t)) {
         return x ? 8 * sizeof(unsigned long) - __builtin_clzl(x) : 0;
     }
 #endif
-#ifdef HAVE_DECL___BUILTIN_CLZLL
+#if HAVE_DECL___BUILTIN_CLZLL
     if (sizeof(unsigned long long) >= sizeof(uint64_t)) {
         return x ? 8 * sizeof(unsigned long long) - __builtin_clzll(x) : 0;
     }

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "hash.h"
+#include "crypto/common.h"
 #include "crypto/hmac_sha512.h"
 #include "crypto/scrypt.h"
 
@@ -23,10 +24,10 @@ unsigned int MurmurHash3(unsigned int nHashSeed, const std::vector<unsigned char
 
         //----------
         // body
-        const uint32_t* blocks = (const uint32_t*)(&vDataToHash[0] + nblocks * 4);
+        const uint8_t* blocks = &vDataToHash[0] + nblocks * 4;
 
         for (int i = -nblocks; i; i++) {
-            uint32_t k1 = blocks[i];
+            uint32_t k1 = ReadLE32(blocks + i*4);
 
             k1 *= c1;
             k1 = ROTL32(k1, 15);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6789,8 +6789,7 @@ bool ProcessMessages(CNode* pfrom)
         // Checksum
         CDataStream& vRecv = msg.vRecv;
         uint256 hash = Hash(vRecv.begin(), vRecv.begin() + nMessageSize);
-        unsigned int nChecksum = 0;
-        memcpy(&nChecksum, &hash, sizeof(nChecksum));
+        unsigned int nChecksum = ReadLE32((unsigned char*)&hash);
         if (nChecksum != hdr.nChecksum) {
             LogPrintf("ProcessMessages(%s, %u bytes): CHECKSUM ERROR nChecksum=%08x hdr.nChecksum=%08x\n",
                 SanitizeString(strCommand), nMessageSize, nChecksum, hdr.nChecksum);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -15,6 +15,7 @@
 #include "addrman.h"
 #include "chainparams.h"
 #include "clientversion.h"
+#include "crypto/common.h"
 #include "guiinterface.h"
 #include "main.h"
 #include "primitives/transaction.h"
@@ -2164,7 +2165,7 @@ void CNode::EndMessage() UNLOCK_FUNCTION(cs_vSend) {
 
     // Set the size
     unsigned int nSize = ssSend.size() - CMessageHeader::HEADER_SIZE;
-    memcpy((char *) &ssSend[CMessageHeader::MESSAGE_SIZE_OFFSET], &nSize, sizeof(nSize));
+    WriteLE32((uint8_t*)&ssSend[CMessageHeader::MESSAGE_SIZE_OFFSET], nSize);
 
     // Set the checksum
     uint256 hash = Hash(ssSend.begin() + CMessageHeader::HEADER_SIZE, ssSend.end());

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -80,11 +80,30 @@ uint256 CBlockHeader::ComputeMinedHash() const
 
 uint256 CBlockHeader::GetHash() const
 {
-#if defined(WORDS_BIGENDIAN)
     if (IsPoABlockByVersion()) {
+#if defined(WORDS_BIGENDIAN)
         // TODO: Big Endian PoA hashing
+#else // Can take shortcut for little endian
+        return Hash(BEGIN(hashPrevBlock), END(hashPrevBlock),
+            BEGIN(minedHash), END(minedHash));
+#endif
+    }
+    if (nVersion >= 5)  {
+#if defined(WORDS_BIGENDIAN)
+        uint8_t data[80];
+        WriteLE32(&data[0], nVersion);
+        memcpy(&data[4], hashPrevBlock.begin(), hashPrevBlock.size());
+        memcpy(&data[36], hashMerkleRoot.begin(), hashMerkleRoot.size());
+        WriteLE32(&data[68], nTime);
+        WriteLE32(&data[72], nBits);
+        WriteLE32(&data[76], nAccumulatorCheckpoint);
+        return Hash(data, data + 80);
+#else // Can take shortcut for little endian
+        return Hash(BEGIN(nVersion), END(nAccumulatorCheckpoint));
+#endif
     }
     if (nVersion < 4)  {
+#if defined(WORDS_BIGENDIAN)
         uint8_t data[80];
         WriteLE32(&data[0], nVersion);
         memcpy(&data[4], hashPrevBlock.begin(), hashPrevBlock.size());
@@ -93,40 +112,12 @@ uint256 CBlockHeader::GetHash() const
         WriteLE32(&data[72], nBits);
         WriteLE32(&data[76], nNonce);
         return HashQuark(data, data + 80);
-    } else if (nVersion < 7) {
-        uint8_t data[112];
-        WriteLE32(&data[0], nVersion);
-        memcpy(&data[4], hashPrevBlock.begin(), hashPrevBlock.size());
-        memcpy(&data[36], hashMerkleRoot.begin(), hashMerkleRoot.size());
-        WriteLE32(&data[68], nTime);
-        WriteLE32(&data[72], nBits);
-        WriteLE32(&data[76], nNonce);
-        memcpy(&data[80], hashMerkleRoot.begin(), hashMerkleRoot.size());
-        return Hash(data, data + 80);
-    } else {
-        uint8_t data[80];
-        WriteLE32(&data[0], nVersion);
-        memcpy(&data[4], hashPrevBlock.begin(), hashPrevBlock.size());
-        memcpy(&data[36], hashMerkleRoot.begin(), hashMerkleRoot.size());
-        WriteLE32(&data[68], nTime);
-        WriteLE32(&data[72], nBits);
-        WriteLE32(&data[76], nNonce);
-        return Hash(data, data + 80);
-    }
-
 #else // Can take shortcut for little endian
-    if (IsPoABlockByVersion()) {
-        //Only hash necessary fields for PoA block header
-        //Dont add nAccumulatorCheckpoint to the hash
-        return Hash(BEGIN(hashPrevBlock), END(hashPrevBlock),
-            BEGIN(minedHash), END(minedHash));
-    }
-    if(nVersion < 4) {
         return HashQuark(BEGIN(nVersion), END(nNonce));
-    }
-
-    return Hash(BEGIN(nVersion), END(nAccumulatorCheckpoint));
 #endif
+    }
+    // version >= 6
+    return SerializeHash(*this);
 }
 
 uint256 CBlock::BuildMerkleTree(bool* fMutated) const

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -46,7 +46,8 @@ public:
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        READWRITE(FLATDATA(*this));
+        READWRITE(hash);
+        READWRITE(n);
     }
 
     void SetNull() { hash.SetNull(); n = (uint32_t) -1; }

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -16,6 +16,8 @@
 #include <string>
 #include <vector>
 
+#include "crypto/common.h"
+
 typedef std::vector<unsigned char> valtype;
 
 static const unsigned int MAX_SCRIPT_ELEMENT_SIZE = 520; // bytes
@@ -424,14 +426,16 @@ public:
         else if (b.size() <= 0xffff)
         {
             insert(end(), OP_PUSHDATA2);
-            unsigned short nSize = b.size();
-            insert(end(), (unsigned char*)&nSize, (unsigned char*)&nSize + sizeof(nSize));
+            uint8_t data[2];
+            WriteLE16(data, b.size());
+            insert(end(), data, data + sizeof(data));
         }
         else
         {
             insert(end(), OP_PUSHDATA4);
-            unsigned int nSize = b.size();
-            insert(end(), (unsigned char*)&nSize, (unsigned char*)&nSize + sizeof(nSize));
+            uint8_t data[4];
+            WriteLE32(data, b.size());
+            insert(end(), data, data + sizeof(data));
         }
         insert(end(), b.begin(), b.end());
         return *this;
@@ -510,15 +514,14 @@ public:
             {
                 if (end() - pc < 2)
                     return false;
-                nSize = 0;
-                memcpy(&nSize, &pc[0], 2);
+                nSize = ReadLE16(&pc[0]);
                 pc += 2;
             }
             else if (opcode == OP_PUSHDATA4)
             {
                 if (end() - pc < 4)
                     return false;
-                memcpy(&nSize, &pc[0], 4);
+                nSize = ReadLE32(&pc[0]);
                 pc += 4;
             }
             if (end() - pc < 0 || (unsigned int)(end() - pc) < nSize)

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -20,6 +20,8 @@
 #include <utility>
 #include <vector>
 
+#include "compat/endian.h"
+
 class CScript;
 
 static const unsigned int MAX_SIZE = 0x02000000;
@@ -43,6 +45,80 @@ inline T* NCONST_PTR(const T* val)
 {
     return const_cast<T*>(val);
 }
+
+
+/*
+ * Lowest-level serialization and conversion.
+ * @note Sizes of these types are verified in the tests
+ */
+template<typename Stream> inline void ser_writedata8(Stream &s, uint8_t obj)
+{
+    s.write((char*)&obj, 1);
+}
+template<typename Stream> inline void ser_writedata16(Stream &s, uint16_t obj)
+{
+    obj = htole16(obj);
+    s.write((char*)&obj, 2);
+}
+template<typename Stream> inline void ser_writedata32(Stream &s, uint32_t obj)
+{
+    obj = htole32(obj);
+    s.write((char*)&obj, 4);
+}
+template<typename Stream> inline void ser_writedata64(Stream &s, uint64_t obj)
+{
+    obj = htole64(obj);
+    s.write((char*)&obj, 8);
+}
+template<typename Stream> inline uint8_t ser_readdata8(Stream &s)
+{
+    uint8_t obj;
+    s.read((char*)&obj, 1);
+    return obj;
+}
+template<typename Stream> inline uint16_t ser_readdata16(Stream &s)
+{
+    uint16_t obj;
+    s.read((char*)&obj, 2);
+    return le16toh(obj);
+}
+template<typename Stream> inline uint32_t ser_readdata32(Stream &s)
+{
+    uint32_t obj;
+    s.read((char*)&obj, 4);
+    return le32toh(obj);
+}
+template<typename Stream> inline uint64_t ser_readdata64(Stream &s)
+{
+    uint64_t obj;
+    s.read((char*)&obj, 8);
+    return le64toh(obj);
+}
+inline uint64_t ser_double_to_uint64(double x)
+{
+    union { double x; uint64_t y; } tmp;
+    tmp.x = x;
+    return tmp.y;
+}
+inline uint32_t ser_float_to_uint32(float x)
+{
+    union { float x; uint32_t y; } tmp;
+    tmp.x = x;
+    return tmp.y;
+}
+inline double ser_uint64_to_double(uint64_t y)
+{
+    union { double x; uint64_t y; } tmp;
+    tmp.y = y;
+    return tmp.x;
+}
+inline float ser_uint32_to_float(uint32_t y)
+{
+    union { float x; uint32_t y; } tmp;
+    tmp.y = y;
+    return tmp.x;
+}
+
 
 /////////////////////////////////////////////////////////////////
 //
@@ -87,174 +163,46 @@ enum {
 /*
  * Basic Types
  */
-#define WRITEDATA(s, obj) s.write((char*)&(obj), sizeof(obj))
-#define READDATA(s, obj) s.read((char*)&(obj), sizeof(obj))
+inline unsigned int GetSerializeSize(char a,      int, int=0) { return 1; }
+inline unsigned int GetSerializeSize(int8_t a,    int, int=0) { return 1; }
+inline unsigned int GetSerializeSize(uint8_t a,   int, int=0) { return 1; }
+inline unsigned int GetSerializeSize(int16_t a,   int, int=0) { return 2; }
+inline unsigned int GetSerializeSize(uint16_t a,  int, int=0) { return 2; }
+inline unsigned int GetSerializeSize(int32_t a,   int, int=0) { return 4; }
+inline unsigned int GetSerializeSize(uint32_t a,  int, int=0) { return 4; }
+inline unsigned int GetSerializeSize(int64_t a,   int, int=0) { return 8; }
+inline unsigned int GetSerializeSize(uint64_t a,  int, int=0) { return 8; }
+inline unsigned int GetSerializeSize(float a,     int, int=0) { return 4; }
+inline unsigned int GetSerializeSize(double a,    int, int=0) { return 8; }
 
-inline unsigned int GetSerializeSize(char a, int, int = 0)
-{
-    return sizeof(a);
-}
-inline unsigned int GetSerializeSize(signed char a, int, int = 0) { return sizeof(a); }
-inline unsigned int GetSerializeSize(unsigned char a, int, int = 0) { return sizeof(a); }
-inline unsigned int GetSerializeSize(signed short a, int, int = 0) { return sizeof(a); }
-inline unsigned int GetSerializeSize(unsigned short a, int, int = 0) { return sizeof(a); }
-inline unsigned int GetSerializeSize(signed int a, int, int = 0) { return sizeof(a); }
-inline unsigned int GetSerializeSize(unsigned int a, int, int = 0) { return sizeof(a); }
-inline unsigned int GetSerializeSize(signed long a, int, int = 0) { return sizeof(a); }
-inline unsigned int GetSerializeSize(unsigned long a, int, int = 0) { return sizeof(a); }
-inline unsigned int GetSerializeSize(signed long long a, int, int = 0) { return sizeof(a); }
-inline unsigned int GetSerializeSize(unsigned long long a, int, int = 0) { return sizeof(a); }
-inline unsigned int GetSerializeSize(float a, int, int = 0) { return sizeof(a); }
-inline unsigned int GetSerializeSize(double a, int, int = 0) { return sizeof(a); }
+template<typename Stream> inline void Serialize(Stream& s, char a,         int, int=0) { ser_writedata8(s, a); } // TODO Get rid of bare char
+template<typename Stream> inline void Serialize(Stream& s, int8_t a,       int, int=0) { ser_writedata8(s, a); }
+template<typename Stream> inline void Serialize(Stream& s, uint8_t a,      int, int=0) { ser_writedata8(s, a); }
+template<typename Stream> inline void Serialize(Stream& s, int16_t a,      int, int=0) { ser_writedata16(s, a); }
+template<typename Stream> inline void Serialize(Stream& s, uint16_t a,     int, int=0) { ser_writedata16(s, a); }
+template<typename Stream> inline void Serialize(Stream& s, int32_t a,      int, int=0) { ser_writedata32(s, a); }
+template<typename Stream> inline void Serialize(Stream& s, uint32_t a,     int, int=0) { ser_writedata32(s, a); }
+template<typename Stream> inline void Serialize(Stream& s, int64_t a,      int, int=0) { ser_writedata64(s, a); }
+template<typename Stream> inline void Serialize(Stream& s, uint64_t a,     int, int=0) { ser_writedata64(s, a); }
+template<typename Stream> inline void Serialize(Stream& s, float a,        int, int=0) { ser_writedata32(s, ser_float_to_uint32(a)); }
+template<typename Stream> inline void Serialize(Stream& s, double a,       int, int=0) { ser_writedata64(s, ser_double_to_uint64(a)); }
 
-template <typename Stream>
-inline void Serialize(Stream& s, char a, int, int = 0)
-{
-    WRITEDATA(s, a);
-}
-template <typename Stream>
-inline void Serialize(Stream& s, signed char a, int, int = 0)
-{
-    WRITEDATA(s, a);
-}
-template <typename Stream>
-inline void Serialize(Stream& s, unsigned char a, int, int = 0)
-{
-    WRITEDATA(s, a);
-}
-template <typename Stream>
-inline void Serialize(Stream& s, signed short a, int, int = 0)
-{
-    WRITEDATA(s, a);
-}
-template <typename Stream>
-inline void Serialize(Stream& s, unsigned short a, int, int = 0)
-{
-    WRITEDATA(s, a);
-}
-template <typename Stream>
-inline void Serialize(Stream& s, signed int a, int, int = 0)
-{
-    WRITEDATA(s, a);
-}
-template <typename Stream>
-inline void Serialize(Stream& s, unsigned int a, int, int = 0)
-{
-    WRITEDATA(s, a);
-}
-template <typename Stream>
-inline void Serialize(Stream& s, signed long a, int, int = 0)
-{
-    WRITEDATA(s, a);
-}
-template <typename Stream>
-inline void Serialize(Stream& s, unsigned long a, int, int = 0)
-{
-    WRITEDATA(s, a);
-}
-template <typename Stream>
-inline void Serialize(Stream& s, signed long long a, int, int = 0)
-{
-    WRITEDATA(s, a);
-}
-template <typename Stream>
-inline void Serialize(Stream& s, unsigned long long a, int, int = 0)
-{
-    WRITEDATA(s, a);
-}
-template <typename Stream>
-inline void Serialize(Stream& s, float a, int, int = 0)
-{
-    WRITEDATA(s, a);
-}
-template <typename Stream>
-inline void Serialize(Stream& s, double a, int, int = 0)
-{
-    WRITEDATA(s, a);
-}
-
-template <typename Stream>
-inline void Unserialize(Stream& s, char& a, int, int = 0)
-{
-    READDATA(s, a);
-}
-template <typename Stream>
-inline void Unserialize(Stream& s, signed char& a, int, int = 0)
-{
-    READDATA(s, a);
-}
-template <typename Stream>
-inline void Unserialize(Stream& s, unsigned char& a, int, int = 0)
-{
-    READDATA(s, a);
-}
-template <typename Stream>
-inline void Unserialize(Stream& s, signed short& a, int, int = 0)
-{
-    READDATA(s, a);
-}
-template <typename Stream>
-inline void Unserialize(Stream& s, unsigned short& a, int, int = 0)
-{
-    READDATA(s, a);
-}
-template <typename Stream>
-inline void Unserialize(Stream& s, signed int& a, int, int = 0)
-{
-    READDATA(s, a);
-}
-template <typename Stream>
-inline void Unserialize(Stream& s, unsigned int& a, int, int = 0)
-{
-    READDATA(s, a);
-}
-template <typename Stream>
-inline void Unserialize(Stream& s, signed long& a, int, int = 0)
-{
-    READDATA(s, a);
-}
-template <typename Stream>
-inline void Unserialize(Stream& s, unsigned long& a, int, int = 0)
-{
-    READDATA(s, a);
-}
-template <typename Stream>
-inline void Unserialize(Stream& s, signed long long& a, int, int = 0)
-{
-    READDATA(s, a);
-}
-template <typename Stream>
-inline void Unserialize(Stream& s, unsigned long long& a, int, int = 0)
-{
-    READDATA(s, a);
-}
-template <typename Stream>
-inline void Unserialize(Stream& s, float& a, int, int = 0)
-{
-    READDATA(s, a);
-}
-template <typename Stream>
-inline void Unserialize(Stream& s, double& a, int, int = 0)
-{
-    READDATA(s, a);
-}
+template<typename Stream> inline void Unserialize(Stream& s, char& a,      int, int=0) { a = ser_readdata8(s); } // TODO Get rid of bare char
+template<typename Stream> inline void Unserialize(Stream& s, int8_t& a,    int, int=0) { a = ser_readdata8(s); }
+template<typename Stream> inline void Unserialize(Stream& s, uint8_t& a,   int, int=0) { a = ser_readdata8(s); }
+template<typename Stream> inline void Unserialize(Stream& s, int16_t& a,   int, int=0) { a = ser_readdata16(s); }
+template<typename Stream> inline void Unserialize(Stream& s, uint16_t& a,  int, int=0) { a = ser_readdata16(s); }
+template<typename Stream> inline void Unserialize(Stream& s, int32_t& a,   int, int=0) { a = ser_readdata32(s); }
+template<typename Stream> inline void Unserialize(Stream& s, uint32_t& a,  int, int=0) { a = ser_readdata32(s); }
+template<typename Stream> inline void Unserialize(Stream& s, int64_t& a,   int, int=0) { a = ser_readdata64(s); }
+template<typename Stream> inline void Unserialize(Stream& s, uint64_t& a,  int, int=0) { a = ser_readdata64(s); }
+template<typename Stream> inline void Unserialize(Stream& s, float& a,     int, int=0) { a = ser_uint32_to_float(ser_readdata32(s)); }
+template<typename Stream> inline void Unserialize(Stream& s, double& a,    int, int=0) { a = ser_uint64_to_double(ser_readdata64(s)); }
 
 inline unsigned int GetSerializeSize(bool a, int, int = 0) { return sizeof(char); }
-template <typename Stream>
-inline void Serialize(Stream& s, bool a, int, int = 0)
-{
-    char f = a;
-    WRITEDATA(s, f);
-}
+template<typename Stream> inline void Serialize(Stream& s, bool a, int, int=0)    { char f=a; ser_writedata8(s, f); }
+template<typename Stream> inline void Unserialize(Stream& s, bool& a, int, int=0) { char f=ser_readdata8(s); a=f; }
 
-
-template <typename Stream>
-inline void Unserialize(Stream& s, bool& a, int, int = 0)
-{
-    char f;
-    READDATA(s, f);
-    a = f;
-}
 
 /**
  * Compact Size
@@ -279,23 +227,16 @@ template <typename Stream>
 void WriteCompactSize(Stream& os, uint64_t nSize)
 {
     if (nSize < 253) {
-        unsigned char chSize = nSize;
-        WRITEDATA(os, chSize);
+        ser_writedata8(os, nSize);
     } else if (nSize <= std::numeric_limits<unsigned short>::max()) {
-        unsigned char chSize = 253;
-        unsigned short xSize = nSize;
-        WRITEDATA(os, chSize);
-        WRITEDATA(os, xSize);
+        ser_writedata8(os, 253);
+        ser_writedata16(os, nSize);
     } else if (nSize <= std::numeric_limits<unsigned int>::max()) {
-        unsigned char chSize = 254;
-        unsigned int xSize = nSize;
-        WRITEDATA(os, chSize);
-        WRITEDATA(os, xSize);
+        ser_writedata8(os, 254);
+        ser_writedata32(os, nSize);
     } else {
-        unsigned char chSize = 255;
-        uint64_t xSize = nSize;
-        WRITEDATA(os, chSize);
-        WRITEDATA(os, xSize);
+        ser_writedata8(os, 255);
+        ser_writedata64(os, nSize);
     }
     return;
 }
@@ -303,27 +244,20 @@ void WriteCompactSize(Stream& os, uint64_t nSize)
 template <typename Stream>
 uint64_t ReadCompactSize(Stream& is)
 {
-    unsigned char chSize;
-    READDATA(is, chSize);
+    uint8_t chSize = ser_readdata8(is);
     uint64_t nSizeRet = 0;
     if (chSize < 253) {
         nSizeRet = chSize;
     } else if (chSize == 253) {
-        unsigned short xSize;
-        READDATA(is, xSize);
-        nSizeRet = xSize;
+        nSizeRet = ser_readdata16(is);
         if (nSizeRet < 253)
             throw std::ios_base::failure("non-canonical ReadCompactSize()");
     } else if (chSize == 254) {
-        unsigned int xSize;
-        READDATA(is, xSize);
-        nSizeRet = xSize;
+        nSizeRet = ser_readdata32(is);
         if (nSizeRet < 0x10000u)
             throw std::ios_base::failure("non-canonical ReadCompactSize()");
     } else {
-        uint64_t xSize;
-        READDATA(is, xSize);
-        nSizeRet = xSize;
+        nSizeRet = ser_readdata64(is);
         if (nSizeRet < 0x100000000ULL)
             throw std::ios_base::failure("non-canonical ReadCompactSize()");
     }
@@ -382,7 +316,7 @@ void WriteVarInt(Stream& os, I n)
         len++;
     }
     do {
-        WRITEDATA(os, tmp[len]);
+        ser_writedata8(os, tmp[len]);
     } while (len--);
 }
 
@@ -391,8 +325,7 @@ I ReadVarInt(Stream& is)
 {
     I n = 0;
     while (true) {
-        unsigned char chData;
-        READDATA(is, chData);
+        unsigned char chData = ser_readdata8(is);
         n = (n << 7) | (chData & 0x7F);
         if (chData & 0x80)
             n++;

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -31,12 +31,100 @@ BOOST_AUTO_TEST_CASE(sizes)
 
     // Bool is serialized as char
     BOOST_CHECK_EQUAL(sizeof(char), GetSerializeSize(bool(0), 0));
+
+    // Sanity-check GetSerializeSize and c++ type matching
+    BOOST_CHECK_EQUAL(GetSerializeSize(char(0), 0), 1);
+    BOOST_CHECK_EQUAL(GetSerializeSize(int8_t(0), 0), 1);
+    BOOST_CHECK_EQUAL(GetSerializeSize(uint8_t(0), 0), 1);
+    BOOST_CHECK_EQUAL(GetSerializeSize(int16_t(0), 0), 2);
+    BOOST_CHECK_EQUAL(GetSerializeSize(uint16_t(0), 0), 2);
+    BOOST_CHECK_EQUAL(GetSerializeSize(int32_t(0), 0), 4);
+    BOOST_CHECK_EQUAL(GetSerializeSize(uint32_t(0), 0), 4);
+    BOOST_CHECK_EQUAL(GetSerializeSize(int64_t(0), 0), 8);
+    BOOST_CHECK_EQUAL(GetSerializeSize(uint64_t(0), 0), 8);
+    BOOST_CHECK_EQUAL(GetSerializeSize(float(0), 0), 4);
+    BOOST_CHECK_EQUAL(GetSerializeSize(double(0), 0), 8);
+    BOOST_CHECK_EQUAL(GetSerializeSize(bool(0), 0), 1);
 }
 
+BOOST_AUTO_TEST_CASE(floats_conversion)
+{
+    // Choose values that map unambigiously to binary floating point to avoid
+    // rounding issues at the compiler side.
+    BOOST_CHECK_EQUAL(ser_uint32_to_float(0x00000000), 0.0F);
+    BOOST_CHECK_EQUAL(ser_uint32_to_float(0x3f000000), 0.5F);
+    BOOST_CHECK_EQUAL(ser_uint32_to_float(0x3f800000), 1.0F);
+    BOOST_CHECK_EQUAL(ser_uint32_to_float(0x40000000), 2.0F);
+    BOOST_CHECK_EQUAL(ser_uint32_to_float(0x40800000), 4.0F);
+    BOOST_CHECK_EQUAL(ser_uint32_to_float(0x44444444), 785.066650390625F);
+
+    BOOST_CHECK_EQUAL(ser_float_to_uint32(0.0F), 0x00000000);
+    BOOST_CHECK_EQUAL(ser_float_to_uint32(0.5F), 0x3f000000);
+    BOOST_CHECK_EQUAL(ser_float_to_uint32(1.0F), 0x3f800000);
+    BOOST_CHECK_EQUAL(ser_float_to_uint32(2.0F), 0x40000000);
+    BOOST_CHECK_EQUAL(ser_float_to_uint32(4.0F), 0x40800000);
+    BOOST_CHECK_EQUAL(ser_float_to_uint32(785.066650390625F), 0x44444444);
+}
+
+BOOST_AUTO_TEST_CASE(doubles_conversion)
+{
+    // Choose values that map unambigiously to binary floating point to avoid
+    // rounding issues at the compiler side.
+    BOOST_CHECK_EQUAL(ser_uint64_to_double(0x0000000000000000ULL), 0.0);
+    BOOST_CHECK_EQUAL(ser_uint64_to_double(0x3fe0000000000000ULL), 0.5);
+    BOOST_CHECK_EQUAL(ser_uint64_to_double(0x3ff0000000000000ULL), 1.0);
+    BOOST_CHECK_EQUAL(ser_uint64_to_double(0x4000000000000000ULL), 2.0);
+    BOOST_CHECK_EQUAL(ser_uint64_to_double(0x4010000000000000ULL), 4.0);
+    BOOST_CHECK_EQUAL(ser_uint64_to_double(0x4088888880000000ULL), 785.066650390625);
+
+    BOOST_CHECK_EQUAL(ser_double_to_uint64(0.0), 0x0000000000000000ULL);
+    BOOST_CHECK_EQUAL(ser_double_to_uint64(0.5), 0x3fe0000000000000ULL);
+    BOOST_CHECK_EQUAL(ser_double_to_uint64(1.0), 0x3ff0000000000000ULL);
+    BOOST_CHECK_EQUAL(ser_double_to_uint64(2.0), 0x4000000000000000ULL);
+    BOOST_CHECK_EQUAL(ser_double_to_uint64(4.0), 0x4010000000000000ULL);
+    BOOST_CHECK_EQUAL(ser_double_to_uint64(785.066650390625), 0x4088888880000000ULL);
+}
+/*
+Python code to generate the below hashes:
+    def reversed_hex(x):
+        return binascii.hexlify(''.join(reversed(x)))
+    def dsha256(x):
+        return hashlib.sha256(hashlib.sha256(x).digest()).digest()
+    reversed_hex(dsha256(''.join(struct.pack('<f', x) for x in range(0,1000)))) == '8e8b4cf3e4df8b332057e3e23af42ebc663b61e0495d5e7e32d85099d7f3fe0c'
+    reversed_hex(dsha256(''.join(struct.pack('<d', x) for x in range(0,1000)))) == '43d0c82591953c4eafe114590d392676a01585d25b25d433557f0d7878b23f96'
+*/
 BOOST_AUTO_TEST_CASE(floats)
 {
-    // TODO ser_uint32_to_float, ser_uint64_to_double
-    // TODO ser_float_to_uint32, ser_double_to_uint64
+    CDataStream ss(SER_DISK, 0);
+    // encode
+    for (int i = 0; i < 1000; i++) {
+        ss << float(i);
+    }
+    BOOST_CHECK(Hash(ss.begin(), ss.end()) == uint256S("8e8b4cf3e4df8b332057e3e23af42ebc663b61e0495d5e7e32d85099d7f3fe0c"));
+
+    // decode
+    for (int i = 0; i < 1000; i++) {
+        float j;
+        ss >> j;
+        BOOST_CHECK_MESSAGE(i == j, "decoded:" << j << " expected:" << i);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(doubles)
+{
+    CDataStream ss(SER_DISK, 0);
+    // encode
+    for (int i = 0; i < 1000; i++) {
+        ss << double(i);
+    }
+    BOOST_CHECK(Hash(ss.begin(), ss.end()) == uint256S("43d0c82591953c4eafe114590d392676a01585d25b25d433557f0d7878b23f96"));
+
+    // decode
+    for (int i = 0; i < 1000; i++) {
+        double j;
+        ss >> j;
+        BOOST_CHECK_MESSAGE(i == j, "decoded:" << j << " expected:" << i);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(varints)

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2012-2013 The Bitcoin Core developers
+// Copyright (c) 2019 The PIVX developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -12,8 +13,31 @@
 #include <boost/test/unit_test.hpp>
 
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(serialize_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(sizes)
+{
+    BOOST_CHECK_EQUAL(sizeof(char), GetSerializeSize(char(0), 0));
+    BOOST_CHECK_EQUAL(sizeof(int8_t), GetSerializeSize(int8_t(0), 0));
+    BOOST_CHECK_EQUAL(sizeof(uint8_t), GetSerializeSize(uint8_t(0), 0));
+    BOOST_CHECK_EQUAL(sizeof(int16_t), GetSerializeSize(int16_t(0), 0));
+    BOOST_CHECK_EQUAL(sizeof(uint16_t), GetSerializeSize(uint16_t(0), 0));
+    BOOST_CHECK_EQUAL(sizeof(int32_t), GetSerializeSize(int32_t(0), 0));
+    BOOST_CHECK_EQUAL(sizeof(uint32_t), GetSerializeSize(uint32_t(0), 0));
+    BOOST_CHECK_EQUAL(sizeof(int64_t), GetSerializeSize(int64_t(0), 0));
+    BOOST_CHECK_EQUAL(sizeof(uint64_t), GetSerializeSize(uint64_t(0), 0));
+    BOOST_CHECK_EQUAL(sizeof(float), GetSerializeSize(float(0), 0));
+    BOOST_CHECK_EQUAL(sizeof(double), GetSerializeSize(double(0), 0));
+
+    // Bool is serialized as char
+    BOOST_CHECK_EQUAL(sizeof(char), GetSerializeSize(bool(0), 0));
+}
+
+BOOST_AUTO_TEST_CASE(floats)
+{
+    // TODO ser_uint32_to_float, ser_uint64_to_double
+    // TODO ser_float_to_uint32, ser_double_to_uint64
+}
 
 BOOST_AUTO_TEST_CASE(varints)
 {
@@ -50,7 +74,7 @@ BOOST_AUTO_TEST_CASE(varints)
 BOOST_AUTO_TEST_CASE(compactsize)
 {
     CDataStream ss(SER_DISK, 0);
-    vector<char>::size_type i, j;
+    std::vector<char>::size_type i, j;
 
     for (i = 1; i <= MAX_SIZE; i *= 2)
     {
@@ -83,7 +107,7 @@ BOOST_AUTO_TEST_CASE(noncanonical)
     // Write some non-canonical CompactSize encodings, and
     // make sure an exception is thrown when read back.
     CDataStream ss(SER_DISK, 0);
-    vector<char>::size_type n;
+    std::vector<char>::size_type n;
 
     // zero encoded with three bytes:
     ss.write("\xfd\x00\x00", 3);
@@ -164,4 +188,3 @@ BOOST_AUTO_TEST_CASE(insert_delete)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -320,7 +320,7 @@ public:
     void Write(CAutoFile& fileout) const
     {
         fileout << nBestSeenHeight;
-        fileout << history.size();
+        fileout << (uint32_t)history.size();
         for (const CBlockAverage& entry : history) {
             entry.Write(fileout);
         }
@@ -330,7 +330,7 @@ public:
     {
         int nFileBestSeenHeight;
         filein >> nFileBestSeenHeight;
-        size_t numEntries;
+        uint32_t numEntries;
         filein >> numEntries;
         if (numEntries <= 0 || numEntries > 10000)
             throw std::runtime_error("Corrupt estimates file. Must have between 1 and 10k entries.");


### PR DESCRIPTION
> First step in getting our serialization code up to par with upstream. Backports [bitcoin#5510](https://github.com/bitcoin/bitcoin/pull/5510) with only minor adjustments.
> 
> > Fix issue [bitcoin#888](https://github.com/bitcoin/bitcoin/issues/888).
> > This has been structured so that each compatibility change is one commit that touches only one file. After the initial build change, they are independent.
> > Most extensive changes are in 'src/serialize.h: base serialization level endianness neutrality'. I had to replace READDATA and WRITEDATA with functions that take sized integer types to make use of the proper endian.h functions. I'm confident that the end result is the same, although this may require more tests.
> > I've tested this on mipsbe32.
> > All tests pass
> > Testnet syncs correctly
> > Node can successfully function on P2P mainnet
> > Checked that data directory can be copied between endians with no adverse results (only peers.dat required special attention here)
> > Known issues (to be fixed before merge):
> > DNS seeding always comes with 0 results on BE (confirmed as working by @paveljanik on real hardware, must have been issue with my qemu-user setup)

from https://github.com/PIVX-Project/PIVX/pull/1554

additional info:
 - required a cherry picked commit to update our `crypto/common.h` - in https://github.com/PRCYCoin/PRCYCoin/commit/20973da723887e9c73b408996bcfd37dcef208ba
 - Big Endian hashing for PoA is currently just commented out -> we can add it in an additional PR if required, but we do not have any Big Endian users right now anyway
 - Code adapted for use with our current block version (5) - TODO: update this code for when we bump block versions