### PR TITLE
[Upstream] [Core] Prevector

### DIFF
--- a/contrib/prcycoin-qt.pro
+++ b/contrib/prcycoin-qt.pro
@@ -115,6 +115,7 @@ HEADERS += src/activemasternode.h \
            src/netbase.h \
            src/noui.h \
            src/poa.h \
+           src/prevector.h \
            src/protocol.h \
            src/pubkey.h \
            src/random.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -147,6 +147,7 @@ BITCOIN_CORE_H = \
   netbase.h \
   noui.h \
   poa.h \
+  prevector.h \
   protocol.h \
   pubkey.h \
   random.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -49,6 +49,7 @@ BITCOIN_TESTS =\
   test/mruset_tests.cpp \
   test/netbase_tests.cpp \
   test/pmt_tests.cpp \
+  test/prevector_tests.cpp \
   test/reverselock_tests.cpp \
   test/rpc_tests.cpp \
   test/sanity_tests.cpp \

--- a/src/coins.h
+++ b/src/coins.h
@@ -290,8 +290,7 @@ public:
     size_t DynamicMemoryUsage() const {
         size_t ret = memusage::DynamicUsage(vout);
         for(const CTxOut &out : vout) {
-            const std::vector<unsigned char> *script = &out.scriptPubKey;
-            ret += memusage::DynamicUsage(*script);
+            ret += memusage::DynamicUsage(*static_cast<const CScriptBase*>(&out.scriptPubKey));
         }
         return ret;
     }

--- a/src/hash.h
+++ b/src/hash.h
@@ -11,6 +11,7 @@
 
 #include "crypto/ripemd160.h"
 #include "crypto/sha256.h"
+#include "prevector.h"
 #include "serialize.h"
 #include "uint256.h"
 #include "version.h"
@@ -243,6 +244,13 @@ inline uint160 Hash160(const T1 pbegin, const T1 pend)
 
 /** Compute the 160-bit hash of a vector. */
 inline uint160 Hash160(const std::vector<unsigned char>& vch)
+{
+    return Hash160(vch.begin(), vch.end());
+}
+
+/** Compute the 160-bit hash of a vector. */
+template<unsigned int N>
+inline uint160 Hash160(const prevector<N, unsigned char>& vch)
 {
     return Hash160(vch.begin(), vch.end());
 }

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -293,7 +293,7 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
     {
-        READWRITE(payee);
+        READWRITE(*(CScriptBase*)(&payee));
         READWRITE(nAmount);
         READWRITE(nProposalHash);
     }
@@ -522,7 +522,7 @@ public:
         ss << nBlockStart;
         ss << nBlockEnd;
         ss << nAmount;
-        ss << address;
+        ss << std::vector<unsigned char>(address.begin(), address.end());
         uint256 h1 = ss.GetHash();
 
         return h1;
@@ -540,7 +540,7 @@ public:
         READWRITE(nBlockStart);
         READWRITE(nBlockEnd);
         READWRITE(nAmount);
-        READWRITE(address);
+        READWRITE(*(CScriptBase*)(&address));
         READWRITE(nTime);
         READWRITE(nFeeTXHash);
 
@@ -597,7 +597,7 @@ public:
         READWRITE(nBlockStart);
         READWRITE(nBlockEnd);
         READWRITE(nAmount);
-        READWRITE(address);
+        READWRITE(*(CScriptBase*)(&address));
         READWRITE(nFeeTXHash);
     }
 };

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -37,7 +37,9 @@ template<typename X> static size_t DynamicUsage(const X& x);
 static inline size_t MallocUsage(size_t alloc)
 {
     // Measured on libc6 2.19 on Linux.
-    if (sizeof(void*) == 8) {
+    if (alloc == 0) {
+        return 0;
+    } else if (sizeof(void*) == 8) {
         return ((alloc + 31) >> 4) << 4;
     } else if (sizeof(void*) == 4) {
         return ((alloc + 15) >> 3) << 3;
@@ -63,6 +65,12 @@ template<typename X>
 static inline size_t DynamicUsage(const std::vector<X>& v)
 {
     return MallocUsage(v.capacity() * sizeof(X));
+}
+
+template<unsigned int N, typename X, typename S, typename D>
+static inline size_t DynamicUsage(const prevector<N, X, S, D>& v)
+{
+    return MallocUsage(v.allocated_memory());
 }
 
 template<typename X>

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -248,6 +248,10 @@ public:
         }
     }
 
+    prevector(prevector<N, T, Size, Diff>&& other) : _size(0) {
+        swap(other);
+    }
+
     prevector& operator=(const prevector<N, T, Size, Diff>& other) {
         if (&other == this) {
             return *this;
@@ -260,6 +264,11 @@ public:
             new(static_cast<void*>(item_ptr(size() - 1))) T(*it);
             ++it;
         }
+        return *this;
+    }
+
+    prevector& operator=(prevector<N, T, Size, Diff>&& other) {
+        swap(other);
         return *this;
     }
 

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -1,0 +1,486 @@
+#ifndef _BITCOIN_PREVECTOR_H_
+#define _BITCOIN_PREVECTOR_H_
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <iterator>
+
+#pragma pack(push, 1)
+/** Implements a drop-in replacement for std::vector<T> which stores up to N
+ *  elements directly (without heap allocation). The types Size and Diff are
+ *  used to store element counts, and can be any unsigned + signed type.
+ *
+ *  Storage layout is either:
+ *  - Direct allocation:
+ *    - Size _size: the number of used elements (between 0 and N)
+ *    - T direct[N]: an array of N elements of type T
+ *      (only the first _size are initialized).
+ *  - Indirect allocation:
+ *    - Size _size: the number of used elements plus N + 1
+ *    - Size capacity: the number of allocated elements
+ *    - T* indirect: a pointer to an array of capacity elements of type T
+ *      (only the first _size are initialized).
+ *
+ *  The data type T must be movable by memmove/realloc(). Once we switch to C++,
+ *  move constructors can be used instead.
+ */
+template<unsigned int N, typename T, typename Size = uint32_t, typename Diff = int32_t>
+class prevector {
+public:
+    typedef Size size_type;
+    typedef Diff difference_type;
+    typedef T value_type;
+    typedef value_type& reference;
+    typedef const value_type& const_reference;
+    typedef value_type* pointer;
+    typedef const value_type* const_pointer;
+
+    class iterator {
+        T* ptr;
+    public:
+        typedef Diff difference_type;
+        typedef T value_type;
+        typedef T* pointer;
+        typedef T& reference;
+        typedef std::random_access_iterator_tag iterator_category;
+        iterator(T* ptr_) : ptr(ptr_) {}
+        T& operator*() const { return *ptr; }
+        T* operator->() const { return ptr; }
+        T& operator[](size_type pos) { return ptr[pos]; }
+        const T& operator[](size_type pos) const { return ptr[pos]; }
+        iterator& operator++() { ptr++; return *this; }
+        iterator& operator--() { ptr--; return *this; }
+        iterator operator++(int) { iterator copy(*this); ++(*this); return copy; }
+        iterator operator--(int) { iterator copy(*this); --(*this); return copy; }
+        difference_type friend operator-(iterator a, iterator b) { return (&(*a) - &(*b)); }
+        iterator operator+(size_type n) { return iterator(ptr + n); }
+        iterator& operator+=(size_type n) { ptr += n; return *this; }
+        iterator operator-(size_type n) { return iterator(ptr - n); }
+        iterator& operator-=(size_type n) { ptr -= n; return *this; }
+        bool operator==(iterator x) const { return ptr == x.ptr; }
+        bool operator!=(iterator x) const { return ptr != x.ptr; }
+        bool operator>=(iterator x) const { return ptr >= x.ptr; }
+        bool operator<=(iterator x) const { return ptr <= x.ptr; }
+        bool operator>(iterator x) const { return ptr > x.ptr; }
+        bool operator<(iterator x) const { return ptr < x.ptr; }
+    };
+
+    class reverse_iterator {
+        T* ptr;
+    public:
+        typedef Diff difference_type;
+        typedef T value_type;
+        typedef T* pointer;
+        typedef T& reference;
+        typedef std::bidirectional_iterator_tag iterator_category;
+        reverse_iterator(T* ptr_) : ptr(ptr_) {}
+        T& operator*() { return *ptr; }
+        const T& operator*() const { return *ptr; }
+        T* operator->() { return ptr; }
+        const T* operator->() const { return ptr; }
+        reverse_iterator& operator--() { ptr++; return *this; }
+        reverse_iterator& operator++() { ptr--; return *this; }
+        reverse_iterator operator++(int) { reverse_iterator copy(*this); ++(*this); return copy; }
+        reverse_iterator operator--(int) { reverse_iterator copy(*this); --(*this); return copy; }
+        bool operator==(reverse_iterator x) const { return ptr == x.ptr; }
+        bool operator!=(reverse_iterator x) const { return ptr != x.ptr; }
+    };
+
+    class const_iterator {
+        const T* ptr;
+    public:
+        typedef Diff difference_type;
+        typedef const T value_type;
+        typedef const T* pointer;
+        typedef const T& reference;
+        typedef std::random_access_iterator_tag iterator_category;
+        const_iterator(const T* ptr_) : ptr(ptr_) {}
+        const_iterator(iterator x) : ptr(&(*x)) {}
+        const T& operator*() const { return *ptr; }
+        const T* operator->() const { return ptr; }
+        const T& operator[](size_type pos) const { return ptr[pos]; }
+        const_iterator& operator++() { ptr++; return *this; }
+        const_iterator& operator--() { ptr--; return *this; }
+        const_iterator operator++(int) { const_iterator copy(*this); ++(*this); return copy; }
+        const_iterator operator--(int) { const_iterator copy(*this); --(*this); return copy; }
+        difference_type friend operator-(const_iterator a, const_iterator b) { return (&(*a) - &(*b)); }
+        const_iterator operator+(size_type n) { return const_iterator(ptr + n); }
+        const_iterator& operator+=(size_type n) { ptr += n; return *this; }
+        const_iterator operator-(size_type n) { return const_iterator(ptr - n); }
+        const_iterator& operator-=(size_type n) { ptr -= n; return *this; }
+        bool operator==(const_iterator x) const { return ptr == x.ptr; }
+        bool operator!=(const_iterator x) const { return ptr != x.ptr; }
+        bool operator>=(const_iterator x) const { return ptr >= x.ptr; }
+        bool operator<=(const_iterator x) const { return ptr <= x.ptr; }
+        bool operator>(const_iterator x) const { return ptr > x.ptr; }
+        bool operator<(const_iterator x) const { return ptr < x.ptr; }
+    };
+
+    class const_reverse_iterator {
+        const T* ptr;
+    public:
+        typedef Diff difference_type;
+        typedef const T value_type;
+        typedef const T* pointer;
+        typedef const T& reference;
+        typedef std::bidirectional_iterator_tag iterator_category;
+        const_reverse_iterator(T* ptr_) : ptr(ptr_) {}
+        const_reverse_iterator(reverse_iterator x) : ptr(&(*x)) {}
+        const T& operator*() const { return *ptr; }
+        const T* operator->() const { return ptr; }
+        const_reverse_iterator& operator--() { ptr++; return *this; }
+        const_reverse_iterator& operator++() { ptr--; return *this; }
+        const_reverse_iterator operator++(int) { const_reverse_iterator copy(*this); ++(*this); return copy; }
+        const_reverse_iterator operator--(int) { const_reverse_iterator copy(*this); --(*this); return copy; }
+        bool operator==(const_reverse_iterator x) const { return ptr == x.ptr; }
+        bool operator!=(const_reverse_iterator x) const { return ptr != x.ptr; }
+    };
+
+private:
+    size_type _size;
+    union {
+        char direct[sizeof(T) * N];
+        struct {
+            size_type capacity;
+            char* indirect;
+        };
+    } _union;
+
+    T* direct_ptr(difference_type pos) { return reinterpret_cast<T*>(_union.direct) + pos; }
+    const T* direct_ptr(difference_type pos) const { return reinterpret_cast<const T*>(_union.direct) + pos; }
+    T* indirect_ptr(difference_type pos) { return reinterpret_cast<T*>(_union.indirect) + pos; }
+    const T* indirect_ptr(difference_type pos) const { return reinterpret_cast<const T*>(_union.indirect) + pos; }
+    bool is_direct() const { return _size <= N; }
+
+    void change_capacity(size_type new_capacity) {
+        if (new_capacity <= N) {
+            if (!is_direct()) {
+                T* indirect = indirect_ptr(0);
+                T* src = indirect;
+                T* dst = direct_ptr(0);
+                memcpy(dst, src, size() * sizeof(T));
+                free(indirect);
+                _size -= N + 1;
+            }
+        } else {
+            if (!is_direct()) {
+                _union.indirect = static_cast<char*>(realloc(_union.indirect, ((size_t)sizeof(T)) * new_capacity));
+                _union.capacity = new_capacity;
+            } else {
+                char* new_indirect = static_cast<char*>(malloc(((size_t)sizeof(T)) * new_capacity));
+                T* src = direct_ptr(0);
+                T* dst = reinterpret_cast<T*>(new_indirect);
+                memcpy(dst, src, size() * sizeof(T));
+                _union.indirect = new_indirect;
+                _union.capacity = new_capacity;
+                _size += N + 1;
+            }
+        }
+    }
+
+    T* item_ptr(difference_type pos) { return is_direct() ? direct_ptr(pos) : indirect_ptr(pos); }
+    const T* item_ptr(difference_type pos) const { return is_direct() ? direct_ptr(pos) : indirect_ptr(pos); }
+
+public:
+    void assign(size_type n, const T& val) {
+        clear();
+        if (capacity() < n) {
+            change_capacity(n);
+        }
+        while (size() < n) {
+            _size++;
+            new(static_cast<void*>(item_ptr(size() - 1))) T(val);
+        }
+    }
+
+    template<typename InputIterator>
+    void assign(InputIterator first, InputIterator last) {
+        size_type n = last - first;
+        clear();
+        if (capacity() < n) {
+            change_capacity(n);
+        }
+        while (first != last) {
+            _size++;
+            new(static_cast<void*>(item_ptr(size() - 1))) T(*first);
+            ++first;
+        }
+    }
+
+    prevector() : _size(0) {}
+
+    explicit prevector(size_type n) : _size(0) {
+        resize(n);
+    }
+
+    explicit prevector(size_type n, const T& val = T()) : _size(0) {
+        change_capacity(n);
+        while (size() < n) {
+            _size++;
+            new(static_cast<void*>(item_ptr(size() - 1))) T(val);
+        }
+    }
+
+    template<typename InputIterator>
+    prevector(InputIterator first, InputIterator last) : _size(0) {
+        size_type n = last - first;
+        change_capacity(n);
+        while (first != last) {
+            _size++;
+            new(static_cast<void*>(item_ptr(size() - 1))) T(*first);
+            ++first;
+        }
+    }
+
+    prevector(const prevector<N, T, Size, Diff>& other) : _size(0) {
+        change_capacity(other.size());
+        const_iterator it = other.begin();
+        while (it != other.end()) {
+            _size++;
+            new(static_cast<void*>(item_ptr(size() - 1))) T(*it);
+            ++it;
+        }
+    }
+
+    prevector& operator=(const prevector<N, T, Size, Diff>& other) {
+        if (&other == this) {
+            return *this;
+        }
+        resize(0);
+        change_capacity(other.size());
+        const_iterator it = other.begin();
+        while (it != other.end()) {
+            _size++;
+            new(static_cast<void*>(item_ptr(size() - 1))) T(*it);
+            ++it;
+        }
+        return *this;
+    }
+
+    size_type size() const {
+        return is_direct() ? _size : _size - N - 1;
+    }
+
+    bool empty() const {
+        return size() == 0;
+    }
+
+    iterator begin() { return iterator(item_ptr(0)); }
+    const_iterator begin() const { return const_iterator(item_ptr(0)); }
+    iterator end() { return iterator(item_ptr(size())); }
+    const_iterator end() const { return const_iterator(item_ptr(size())); }
+
+    reverse_iterator rbegin() { return reverse_iterator(item_ptr(size() - 1)); }
+    const_reverse_iterator rbegin() const { return const_reverse_iterator(item_ptr(size() - 1)); }
+    reverse_iterator rend() { return reverse_iterator(item_ptr(-1)); }
+    const_reverse_iterator rend() const { return const_reverse_iterator(item_ptr(-1)); }
+
+    size_t capacity() const {
+        if (is_direct()) {
+            return N;
+        } else {
+            return _union.capacity;
+        }
+    }
+
+    T& operator[](size_type pos) {
+        return *item_ptr(pos);
+    }
+
+    const T& operator[](size_type pos) const {
+        return *item_ptr(pos);
+    }
+
+    void resize(size_type new_size) {
+        while (size() > new_size) {
+            item_ptr(size() - 1)->~T();
+            _size--;
+        }
+        if (new_size > capacity()) {
+            change_capacity(new_size);
+        }
+        while (size() < new_size) {
+            _size++;
+            new(static_cast<void*>(item_ptr(size() - 1))) T();
+        }
+    }
+
+    void reserve(size_type new_capacity) {
+        if (new_capacity > capacity()) {
+            change_capacity(new_capacity);
+        }
+    }
+
+    void shrink_to_fit() {
+        change_capacity(size());
+    }
+
+    void clear() {
+        resize(0);
+    }
+
+    iterator insert(iterator pos, const T& value) {
+        size_type p = pos - begin();
+        size_type new_size = size() + 1;
+        if (capacity() < new_size) {
+            change_capacity(new_size + (new_size >> 1));
+        }
+        memmove(item_ptr(p + 1), item_ptr(p), (size() - p) * sizeof(T));
+        _size++;
+        new(static_cast<void*>(item_ptr(p))) T(value);
+        return iterator(item_ptr(p));
+    }
+
+    void insert(iterator pos, size_type count, const T& value) {
+        size_type p = pos - begin();
+        size_type new_size = size() + count;
+        if (capacity() < new_size) {
+            change_capacity(new_size + (new_size >> 1));
+        }
+        memmove(item_ptr(p + count), item_ptr(p), (size() - p) * sizeof(T));
+        _size += count;
+        for (size_type i = 0; i < count; i++) {
+            new(static_cast<void*>(item_ptr(p + i))) T(value);
+        }
+    }
+
+    template<typename InputIterator>
+    void insert(iterator pos, InputIterator first, InputIterator last) {
+        size_type p = pos - begin();
+        difference_type count = last - first;
+        size_type new_size = size() + count;
+        if (capacity() < new_size) {
+            change_capacity(new_size + (new_size >> 1));
+        }
+        memmove(item_ptr(p + count), item_ptr(p), (size() - p) * sizeof(T));
+        _size += count;
+        while (first != last) {
+            new(static_cast<void*>(item_ptr(p))) T(*first);
+            ++p;
+            ++first;
+        }
+    }
+
+    iterator erase(iterator pos) {
+        (*pos).~T();
+        memmove(&(*pos), &(*pos) + 1, ((char*)&(*end())) - ((char*)(1 + &(*pos))));
+        _size--;
+        return pos;
+    }
+
+    iterator erase(iterator first, iterator last) {
+        iterator p = first;
+        char* endp = (char*)&(*end());
+        while (p != last) {
+            (*p).~T();
+            _size--;
+            ++p;
+        }
+        memmove(&(*first), &(*last), endp - ((char*)(&(*last))));
+        return first;
+    }
+
+    void push_back(const T& value) {
+        size_type new_size = size() + 1;
+        if (capacity() < new_size) {
+            change_capacity(new_size + (new_size >> 1));
+        }
+        new(item_ptr(size())) T(value);
+        _size++;
+    }
+
+    void pop_back() {
+        _size--;
+    }
+
+    T& front() {
+        return *item_ptr(0);
+    }
+
+    const T& front() const {
+        return *item_ptr(0);
+    }
+
+    T& back() {
+        return *item_ptr(size() - 1);
+    }
+
+    const T& back() const {
+        return *item_ptr(size() - 1);
+    }
+
+    void swap(prevector<N, T, Size, Diff>& other) {
+        if (_size & other._size & 1) {
+            std::swap(_union.capacity, other._union.capacity);
+            std::swap(_union.indirect, other._union.indirect);
+        } else {
+            std::swap(_union, other._union);
+        }
+        std::swap(_size, other._size);
+    }
+
+    ~prevector() {
+        clear();
+        if (!is_direct()) {
+            free(_union.indirect);
+            _union.indirect = NULL;
+        }
+    }
+
+    bool operator==(const prevector<N, T, Size, Diff>& other) const {
+        if (other.size() != size()) {
+            return false;
+        }
+        const_iterator b1 = begin();
+        const_iterator b2 = other.begin();
+        const_iterator e1 = end();
+        while (b1 != e1) {
+            if ((*b1) != (*b2)) {
+                return false;
+            }
+            ++b1;
+            ++b2;
+        }
+        return true;
+    }
+
+    bool operator!=(const prevector<N, T, Size, Diff>& other) const {
+        return !(*this == other);
+    }
+
+    bool operator<(const prevector<N, T, Size, Diff>& other) const {
+        if (size() < other.size()) {
+            return true;
+        }
+        if (size() > other.size()) {
+            return false;
+        }
+        const_iterator b1 = begin();
+        const_iterator b2 = other.begin();
+        const_iterator e1 = end();
+        while (b1 != e1) {
+            if ((*b1) < (*b2)) {
+                return true;
+            }
+            if ((*b2) < (*b1)) {
+                return false;
+            }
+            ++b1;
+            ++b2;
+        }
+        return false;
+    }
+
+    size_t allocated_memory() const {
+        if (is_direct()) {
+            return 0;
+        } else {
+            return ((size_t)(sizeof(T))) * _union.capacity;
+        }
+    }
+};
+#pragma pack(pop)
+
+#endif

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -387,6 +387,12 @@ public:
     }
 
     iterator erase(iterator first, iterator last) {
+        // Erase is not allowed to the change the object's capacity. That means
+        // that when starting with an indirectly allocated prevector with
+        // size and capacity > N, the result may be a still indirectly allocated
+        // prevector with size <= N and capacity > N. A shrink_to_fit() call is
+        // necessary to switch to the (more efficient) directly allocated
+        // representation (with capacity N and size <= N).
         iterator p = first;
         char* endp = (char*)&(*end());
         if (!std::is_trivially_destructible<T>::value) {

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -412,12 +412,7 @@ public:
     }
 
     void swap(prevector<N, T, Size, Diff>& other) {
-        if (_size & other._size & 1) {
-            std::swap(_union.capacity, other._union.capacity);
-            std::swap(_union.indirect, other._union.indirect);
-        } else {
-            std::swap(_union, other._union);
-        }
+        std::swap(_union, other._union);
         std::swap(_size, other._size);
     }
 

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include <iterator>
+#include <type_traits>
 
 #pragma pack(push, 1)
 /** Implements a drop-in replacement for std::vector<T> which stores up to N
@@ -382,10 +383,14 @@ public:
     iterator erase(iterator first, iterator last) {
         iterator p = first;
         char* endp = (char*)&(*end());
-        while (p != last) {
-            (*p).~T();
-            _size--;
-            ++p;
+        if (!std::is_trivially_destructible<T>::value) {
+            while (p != last) {
+                (*p).~T();
+                _size--;
+                ++p;
+            }
+        } else {
+            _size -= last - p;
         }
         memmove(&(*first), &(*last), endp - ((char*)(&(*last))));
         return first;
@@ -426,7 +431,9 @@ public:
     }
 
     ~prevector() {
-        clear();
+        if (!std::is_trivially_destructible<T>::value) {
+            clear();
+        }
         if (!is_direct()) {
             free(_union.indirect);
             _union.indirect = NULL;

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -476,7 +476,7 @@ public:
         }
     }
 
-    value_type* data() noexcept {
+    value_type* data() {
         return item_ptr(0);
     }
 

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -475,6 +475,14 @@ public:
             return ((size_t)(sizeof(T))) * _union.capacity;
         }
     }
+
+    value_type* data() noexcept {
+        return item_ptr(0);
+    }
+
+    const value_type* data() const {
+        return item_ptr(0);
+    }
 };
 #pragma pack(pop)
 

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -220,13 +220,13 @@ public:
         }
     }
 
-    prevector() : _size(0) {}
+    prevector() : _size(0), _union{{}} {}
 
-    explicit prevector(size_type n) : _size(0) {
+    explicit prevector(size_type n) : prevector() {
         resize(n);
     }
 
-    explicit prevector(size_type n, const T& val = T()) : _size(0) {
+    explicit prevector(size_type n, const T& val = T()) : prevector() {
         change_capacity(n);
         while (size() < n) {
             _size++;
@@ -235,7 +235,7 @@ public:
     }
 
     template<typename InputIterator>
-    prevector(InputIterator first, InputIterator last) : _size(0) {
+    prevector(InputIterator first, InputIterator last) : prevector() {
         size_type n = last - first;
         change_capacity(n);
         while (first != last) {
@@ -245,7 +245,7 @@ public:
         }
     }
 
-    prevector(const prevector<N, T, Size, Diff>& other) : _size(0) {
+    prevector(const prevector<N, T, Size, Diff>& other) : prevector() {
         change_capacity(other.size());
         const_iterator it = other.begin();
         while (it != other.end()) {
@@ -255,7 +255,7 @@ public:
         }
     }
 
-    prevector(prevector<N, T, Size, Diff>&& other) : _size(0) {
+    prevector(prevector<N, T, Size, Diff>&& other) : prevector() {
         swap(other);
     }
 

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -5,6 +5,7 @@
 #ifndef _BITCOIN_PREVECTOR_H_
 #define _BITCOIN_PREVECTOR_H_
 
+#include <assert.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
@@ -171,10 +172,15 @@ private:
             }
         } else {
             if (!is_direct()) {
+                /* FIXME: Because malloc/realloc here won't call new_handler if allocation fails, assert
+                    success. These should instead use an allocator or new/delete so that handlers
+                    are called as necessary, but performance would be slightly degraded by doing so. */
                 _union.indirect = static_cast<char*>(realloc(_union.indirect, ((size_t)sizeof(T)) * new_capacity));
+                assert(_union.indirect);
                 _union.capacity = new_capacity;
             } else {
                 char* new_indirect = static_cast<char*>(malloc(((size_t)sizeof(T)) * new_capacity));
+                assert(new_indirect);
                 T* src = direct_ptr(0);
                 T* dst = reinterpret_cast<T*>(new_indirect);
                 memcpy(dst, src, size() * sizeof(T));

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef _BITCOIN_PREVECTOR_H_
 #define _BITCOIN_PREVECTOR_H_
 
@@ -294,9 +298,8 @@ public:
     }
 
     void resize(size_type new_size) {
-        while (size() > new_size) {
-            item_ptr(size() - 1)->~T();
-            _size--;
+        if (size() > new_size) {
+            erase(item_ptr(new_size), end());
         }
         if (new_size > capacity()) {
             change_capacity(new_size);
@@ -364,10 +367,7 @@ public:
     }
 
     iterator erase(iterator pos) {
-        (*pos).~T();
-        memmove(&(*pos), &(*pos) + 1, ((char*)&(*end())) - ((char*)(1 + &(*pos))));
-        _size--;
-        return pos;
+        return erase(pos, pos + 1);
     }
 
     iterator erase(iterator first, iterator last) {
@@ -392,7 +392,7 @@ public:
     }
 
     void pop_back() {
-        _size--;
+        erase(end() - 1, end());
     }
 
     T& front() {

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -111,7 +111,7 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(prevout);
-        READWRITE(scriptSig);
+        READWRITE(*(CScriptBase*)(&scriptSig));
         READWRITE(nSequence);
         READWRITE(encryptionKey);
         READWRITE(keyImage);
@@ -189,7 +189,7 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(nValue);
-        READWRITE(scriptPubKey);
+        READWRITE(*(CScriptBase*)(&scriptPubKey));
         READWRITE(txPriv);
         READWRITE(txPub);
         READWRITE(maskValue.amount);
@@ -516,7 +516,7 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(prevout);
-        READWRITE(scriptSig);
+        READWRITE(*(CScriptBase*)(&scriptSig));
         READWRITE(nSequence);
         READWRITE(encryptionKey);
         READWRITE(keyImage);

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -6,6 +6,7 @@
 #define BITCOIN_QT_TRANSACTIONRECORD_H
 
 #include "amount.h"
+#include "script/script.h"
 #include "uint256.h"
 
 #include <QList>

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -330,7 +330,7 @@ UniValue masternodedebug (const UniValue& params, bool fHelp)
         return activeMasternode.GetStatus();
 
     CTxIn vin = CTxIn();
-    CPubKey pubkey = CScript();
+    CPubKey pubkey;
     CKey key;
     if (!activeMasternode.GetMasterNodeVin(vin, pubkey, key))
         throw std::runtime_error("Missing masternode input, please look at the documentation for instructions on masternode creation\n");

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1031,7 +1031,7 @@ public:
         // Serialize the script
         if (nInput != nIn)
             // Blank out other inputs' signatures
-            ::Serialize(s, CScript(), nType, nVersion);
+            ::Serialize(s, CScriptBase(), nType, nVersion);
         else
             SerializeScriptCode(s, nType, nVersion);
         // Serialize the nSequence

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -236,9 +236,9 @@ bool CScript::IsPayToScriptHash() const
 {
     // Extra-fast test for pay-to-script-hash CScripts:
     return (this->size() == 23 &&
-            this->at(0) == OP_HASH160 &&
-            this->at(1) == 0x14 &&
-            this->at(22) == OP_EQUAL);
+            (*this)[0] == OP_HASH160 &&
+            (*this)[1] == 0x14 &&
+            (*this)[22] == OP_EQUAL);
 }
 
 bool CScript::IsPushOnly(const_iterator pc) const

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "crypto/common.h"
+#include "prevector.h"
 
 typedef std::vector<unsigned char> valtype;
 
@@ -350,8 +351,10 @@ private:
     int64_t m_value;
 };
 
+typedef prevector<28, unsigned char> CScriptBase;
+
 /** Serialized script, used inside transaction inputs and outputs */
-class CScript : public std::vector<unsigned char>
+class CScript : public CScriptBase
 {
 protected:
     CScript& push_int64(int64_t n)
@@ -372,9 +375,10 @@ protected:
     }
 public:
     CScript() { }
-    CScript(const CScript& b) : std::vector<unsigned char>(b.begin(), b.end()) { }
-    CScript(const_iterator pbegin, const_iterator pend) : std::vector<unsigned char>(pbegin, pend) { }
-    CScript(const unsigned char* pbegin, const unsigned char* pend) : std::vector<unsigned char>(pbegin, pend) { }
+    CScript(const CScript& b) : CScriptBase(b.begin(), b.end()) { }
+    CScript(const_iterator pbegin, const_iterator pend) : CScriptBase(pbegin, pend) { }
+    CScript(std::vector<unsigned char>::const_iterator pbegin, std::vector<unsigned char>::const_iterator pend) : CScriptBase(pbegin, pend) { }
+    CScript(const unsigned char* pbegin, const unsigned char* pend) : CScriptBase(pbegin, pend) { }
 
     CScript& operator+=(const CScript& b)
     {
@@ -625,7 +629,7 @@ public:
     void clear()
     {
         // The default std::vector::clear() does not release memory.
-        std::vector<unsigned char>().swap(*this);
+        CScriptBase().swap(*this);
     }
 };
 

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -627,8 +627,9 @@ public:
     std::string ToString() const;
     void clear()
     {
-        // The default std::vector::clear() does not release memory.
-        CScriptBase().swap(*this);
+        // The default prevector::clear() does not release memory
+        CScriptBase::clear();
+        shrink_to_fit();
     }
 };
 

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -351,6 +351,12 @@ private:
     int64_t m_value;
 };
 
+/**
+ * We use a prevector for the script to reduce the considerable memory overhead
+ * of vectors in cases where they normally contain a small number of small elements.
+ * Tests in October 2015 (bitcoin) showed use of this reduced dbcache memory usage by 23%
+ *  and made an initial sync 13% faster.
+ */
 typedef prevector<28, unsigned char> CScriptBase;
 
 /** Serialized script, used inside transaction inputs and outputs */

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -375,7 +375,6 @@ protected:
     }
 public:
     CScript() { }
-    CScript(const CScript& b) : CScriptBase(b.begin(), b.end()) { }
     CScript(const_iterator pbegin, const_iterator pend) : CScriptBase(pbegin, pend) { }
     CScript(std::vector<unsigned char>::const_iterator pbegin, std::vector<unsigned char>::const_iterator pend) : CScriptBase(pbegin, pend) { }
     CScript(const unsigned char* pbegin, const unsigned char* pend) : CScriptBase(pbegin, pend) { }

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -119,7 +119,7 @@ bool SignSignature(const CKeyStore &keystore, const CScript &fromPubKey, CMutabl
         bool fSolved =
                 Solver(keystore, subscript, hash2, nHashType, txin.scriptSig, subType) && subType != TX_SCRIPTHASH;
         // Append serialized subscript whether or not it is completely signed:
-        txin.scriptSig << static_cast<valtype>(subscript);
+        txin.scriptSig << valtype(subscript.begin(), subscript.end());
         if (!fSolved) return false;
     }
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -47,32 +47,31 @@ inline T* NCONST_PTR(const T* val)
 }
 
 /**
- * Get begin pointer of vector (non-const version).
- * @note These functions avoid the undefined case of indexing into an empty
- * vector, as well as that of indexing after the end of the vector.
+ * Important: Do not use the following functions in new code, but use v.data()
+ * and v.data() + v.size() respectively directly. They were once introduced to
+ * have a compatible, safe way to get the begin and end pointer of a vector.
+ * However with C++11 the language has built-in functionality for this and it's
+ * more readable to just use that.
  */
 template <typename V>
 inline typename V::value_type* begin_ptr(V& v)
 {
-    return v.empty() ? nullptr : &v[0];
+    return v.data();
 }
-/** Get begin pointer of vector (const version) */
 template <typename V>
 inline const typename V::value_type* begin_ptr(const V& v)
 {
-    return v.empty() ? nullptr : &v[0];
+    return v.data();
 }
-/** Get end pointer of vector (non-const version) */
 template <typename V>
 inline typename V::value_type* end_ptr(V& v)
 {
-    return v.empty() ? nullptr : (&v[0] + v.size());
+    return v.data() + v.size();
 }
-/** Get end pointer of vector (const version) */
 template <typename V>
 inline const typename V::value_type* end_ptr(const V& v)
 {
-    return v.empty() ? nullptr : (&v[0] + v.size());
+    return v.data() + v.size();
 }
 
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -21,8 +21,8 @@
 #include <vector>
 
 #include "compat/endian.h"
+#include "prevector.h"
 
-class CScript;
 
 static const unsigned int MAX_SIZE = 0x02000000;
 
@@ -44,6 +44,35 @@ template <typename T>
 inline T* NCONST_PTR(const T* val)
 {
     return const_cast<T*>(val);
+}
+
+/**
+ * Get begin pointer of vector (non-const version).
+ * @note These functions avoid the undefined case of indexing into an empty
+ * vector, as well as that of indexing after the end of the vector.
+ */
+template <typename V>
+inline typename V::value_type* begin_ptr(V& v)
+{
+    return v.empty() ? nullptr : &v[0];
+}
+/** Get begin pointer of vector (const version) */
+template <typename V>
+inline const typename V::value_type* begin_ptr(const V& v)
+{
+    return v.empty() ? nullptr : &v[0];
+}
+/** Get end pointer of vector (non-const version) */
+template <typename V>
+inline typename V::value_type* end_ptr(V& v)
+{
+    return v.empty() ? nullptr : (&v[0] + v.size());
+}
+/** Get end pointer of vector (const version) */
+template <typename V>
+inline const typename V::value_type* end_ptr(const V& v)
+{
+    return v.empty() ? nullptr : (&v[0] + v.size());
 }
 
 
@@ -355,6 +384,12 @@ public:
         pbegin = (char*)v.data();
         pend = (char*)(v.data() + v.size());
     }
+    template <unsigned int N, typename T, typename S, typename D>
+    explicit CFlatData(prevector<N, T, S, D> &v)
+    {
+        pbegin = (char*)begin_ptr(v);
+        pend = (char*)end_ptr(v);
+    }
     char* begin() { return pbegin; }
     const char* begin() const { return pbegin; }
     char* end() { return pend; }
@@ -461,6 +496,20 @@ template <typename Stream, typename C>
 void Unserialize(Stream& is, std::basic_string<C>& str, int, int = 0);
 
 /**
+ * prevector
+ * prevectors of unsigned char are a special case and are intended to be serialized as a single opaque blob.
+ */
+template<unsigned int N, typename T> unsigned int GetSerializeSize_impl(const prevector<N, T>& v, int nType, int nVersion, const unsigned char&);
+template<unsigned int N, typename T, typename V> unsigned int GetSerializeSize_impl(const prevector<N, T>& v, int nType, int nVersion, const V&);
+template<unsigned int N, typename T> inline unsigned int GetSerializeSize(const prevector<N, T>& v, int nType, int nVersion);
+template<typename Stream, unsigned int N, typename T> void Serialize_impl(Stream& os, const prevector<N, T>& v, int nType, int nVersion, const unsigned char&);
+template<typename Stream, unsigned int N, typename T, typename V> void Serialize_impl(Stream& os, const prevector<N, T>& v, int nType, int nVersion, const V&);
+template<typename Stream, unsigned int N, typename T> inline void Serialize(Stream& os, const prevector<N, T>& v, int nType, int nVersion);
+template<typename Stream, unsigned int N, typename T> void Unserialize_impl(Stream& is, prevector<N, T>& v, int nType, int nVersion, const unsigned char&);
+template<typename Stream, unsigned int N, typename T, typename V> void Unserialize_impl(Stream& is, prevector<N, T>& v, int nType, int nVersion, const V&);
+template<typename Stream, unsigned int N, typename T> inline void Unserialize(Stream& is, prevector<N, T>& v, int nType, int nVersion);
+
+/**
  * vector
  * vectors of unsigned char are a special case and are intended to be serialized as a single opaque blob.
  */
@@ -482,15 +531,6 @@ template <typename Stream, typename T, typename A, typename V>
 void Unserialize_impl(Stream& is, std::vector<T, A>& v, int nType, int nVersion, const V&);
 template <typename Stream, typename T, typename A>
 inline void Unserialize(Stream& is, std::vector<T, A>& v, int nType, int nVersion);
-
-/**
- * others derived from vector
- */
-extern inline unsigned int GetSerializeSize(const CScript& v, int nType, int nVersion);
-template <typename Stream>
-void Serialize(Stream& os, const CScript& v, int nType, int nVersion);
-template <typename Stream>
-void Unserialize(Stream& is, CScript& v, int nType, int nVersion);
 
 /**
  * pair
@@ -573,6 +613,97 @@ void Unserialize(Stream& is, std::basic_string<C>& str, int, int)
     if (nSize != 0)
         is.read((char*)&str[0], nSize * sizeof(str[0]));
 }
+
+
+
+/**
+ * prevector
+ */
+template<unsigned int N, typename T>
+unsigned int GetSerializeSize_impl(const prevector<N, T>& v, int nType, int nVersion, const unsigned char&)
+{
+    return (GetSizeOfCompactSize(v.size()) + v.size() * sizeof(T));
+}
+
+template<unsigned int N, typename T, typename V>
+unsigned int GetSerializeSize_impl(const prevector<N, T>& v, int nType, int nVersion, const V&)
+{
+    unsigned int nSize = GetSizeOfCompactSize(v.size());
+    for (typename prevector<N, T>::const_iterator vi = v.begin(); vi != v.end(); ++vi)
+        nSize += GetSerializeSize((*vi), nType, nVersion);
+    return nSize;
+}
+
+template<unsigned int N, typename T>
+inline unsigned int GetSerializeSize(const prevector<N, T>& v, int nType, int nVersion)
+{
+    return GetSerializeSize_impl(v, nType, nVersion, T());
+}
+
+
+template<typename Stream, unsigned int N, typename T>
+void Serialize_impl(Stream& os, const prevector<N, T>& v, int nType, int nVersion, const unsigned char&)
+{
+    WriteCompactSize(os, v.size());
+    if (!v.empty())
+        os.write((char*)&v[0], v.size() * sizeof(T));
+}
+
+template<typename Stream, unsigned int N, typename T, typename V>
+void Serialize_impl(Stream& os, const prevector<N, T>& v, int nType, int nVersion, const V&)
+{
+    WriteCompactSize(os, v.size());
+    for (typename prevector<N, T>::const_iterator vi = v.begin(); vi != v.end(); ++vi)
+        ::Serialize(os, (*vi), nType, nVersion);
+}
+
+template<typename Stream, unsigned int N, typename T>
+inline void Serialize(Stream& os, const prevector<N, T>& v, int nType, int nVersion)
+{
+    Serialize_impl(os, v, nType, nVersion, T());
+}
+
+
+template<typename Stream, unsigned int N, typename T>
+void Unserialize_impl(Stream& is, prevector<N, T>& v, int nType, int nVersion, const unsigned char&)
+{
+    // Limit size per read so bogus size value won't cause out of memory
+    v.clear();
+    unsigned int nSize = ReadCompactSize(is);
+    unsigned int i = 0;
+    while (i < nSize)
+    {
+        unsigned int blk = std::min(nSize - i, (unsigned int)(1 + 4999999 / sizeof(T)));
+        v.resize(i + blk);
+        is.read((char*)&v[i], blk * sizeof(T));
+        i += blk;
+    }
+}
+
+template<typename Stream, unsigned int N, typename T, typename V>
+void Unserialize_impl(Stream& is, prevector<N, T>& v, int nType, int nVersion, const V&)
+{
+    v.clear();
+    unsigned int nSize = ReadCompactSize(is);
+    unsigned int i = 0;
+    unsigned int nMid = 0;
+    while (nMid < nSize)
+    {
+        nMid += 5000000 / sizeof(T);
+        if (nMid > nSize)
+            nMid = nSize;
+        v.resize(nMid);
+        for (; i < nMid; i++)
+            Unserialize(is, v[i], nType, nVersion);
+    }
+}
+
+template<typename Stream, unsigned int N, typename T>
+inline void Unserialize(Stream& is, prevector<N, T>& v, int nType, int nVersion)
+{
+    Unserialize_impl(is, v, nType, nVersion, T());
+}
+
 
 
 /**
@@ -661,26 +792,6 @@ inline void Unserialize(Stream& is, std::vector<T, A>& v, int nType, int nVersio
     Unserialize_impl(is, v, nType, nVersion, T());
 }
 
-
-/**
- * others derived from vector
- */
-inline unsigned int GetSerializeSize(const CScript& v, int nType, int nVersion)
-{
-    return GetSerializeSize((const std::vector<unsigned char>&)v, nType, nVersion);
-}
-
-template <typename Stream>
-void Serialize(Stream& os, const CScript& v, int nType, int nVersion)
-{
-    Serialize(os, (const std::vector<unsigned char>&)v, nType, nVersion);
-}
-
-template <typename Stream>
-void Unserialize(Stream& is, CScript& v, int nType, int nVersion)
-{
-    Unserialize(is, (std::vector<unsigned char>&)v, nType, nVersion);
-}
 
 
 /**

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     hash = tx.GetHash();
     mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11));
     tx.vin[0].prevout.hash = hash;
-    tx.vin[0].scriptSig = CScript() << (std::vector<unsigned char>)script;
+    tx.vin[0].scriptSig = CScript() << std::vector<unsigned char>(script.begin(), script.end());
     tx.vout[0].nValue -= 1000000;
     hash = tx.GetHash();
     mempool.addUnchecked(hash, CTxMemPoolEntry(tx, 11, GetTime(), 111.0, 11));

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -1,0 +1,213 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <vector>
+#include "prevector.h"
+#include "random.h"
+
+#include "serialize.h"
+#include "streams.h"
+
+#include "test/test_pivx.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(PrevectorTests, TestingSetup)
+
+template<unsigned int N, typename T>
+class prevector_tester {
+    typedef std::vector<T> realtype;
+    realtype real_vector;
+
+    typedef prevector<N, T> pretype;
+    pretype pre_vector;
+
+    typedef typename pretype::size_type Size;
+
+    void test() {
+        const pretype& const_pre_vector = pre_vector;
+        BOOST_CHECK_EQUAL(real_vector.size(), pre_vector.size());
+        BOOST_CHECK_EQUAL(real_vector.empty(), pre_vector.empty());
+        for (Size s = 0; s < real_vector.size(); s++) {
+             BOOST_CHECK(real_vector[s] == pre_vector[s]);
+             BOOST_CHECK(&(pre_vector[s]) == &(pre_vector.begin()[s]));
+             BOOST_CHECK(&(pre_vector[s]) == &*(pre_vector.begin() + s));
+             BOOST_CHECK(&(pre_vector[s]) == &*((pre_vector.end() + s) - real_vector.size()));
+        }
+        // BOOST_CHECK(realtype(pre_vector) == real_vector);
+        BOOST_CHECK(pretype(real_vector.begin(), real_vector.end()) == pre_vector);
+        BOOST_CHECK(pretype(pre_vector.begin(), pre_vector.end()) == pre_vector);
+        size_t pos = 0;
+        for (const T& v  : pre_vector) {
+             BOOST_CHECK(v == real_vector[pos++]);
+        }
+        pos = 0;
+        for (const T& v : const_pre_vector) {
+             BOOST_CHECK(v == real_vector[pos++]);
+        }
+
+        CDataStream ss1(SER_DISK, 0);
+        CDataStream ss2(SER_DISK, 0);
+        ss1 << real_vector;
+        ss2 << pre_vector;
+        BOOST_CHECK_EQUAL(ss1.size(), ss2.size());
+        for (Size s = 0; s < ss1.size(); s++) {
+            BOOST_CHECK_EQUAL(ss1[s], ss2[s]);
+        }
+    }
+
+public:
+    void resize(Size s) {
+        real_vector.resize(s);
+        BOOST_CHECK_EQUAL(real_vector.size(), s);
+        pre_vector.resize(s);
+        BOOST_CHECK_EQUAL(pre_vector.size(), s);
+        test();
+    }
+
+    void reserve(Size s) {
+        real_vector.reserve(s);
+        BOOST_CHECK(real_vector.capacity() >= s);
+        pre_vector.reserve(s);
+        BOOST_CHECK(pre_vector.capacity() >= s);
+        test();
+    }
+
+    void insert(Size position, const T& value) {
+        real_vector.insert(real_vector.begin() + position, value);
+        pre_vector.insert(pre_vector.begin() + position, value);
+        test();
+    }
+
+    void insert(Size position, Size count, const T& value) {
+        real_vector.insert(real_vector.begin() + position, count, value);
+        pre_vector.insert(pre_vector.begin() + position, count, value);
+        test();
+    }
+
+    template<typename I>
+    void insert_range(Size position, I first, I last) {
+        real_vector.insert(real_vector.begin() + position, first, last);
+        pre_vector.insert(pre_vector.begin() + position, first, last);
+        test();
+    }
+
+    void erase(Size position) {
+        real_vector.erase(real_vector.begin() + position);
+        pre_vector.erase(pre_vector.begin() + position);
+        test();
+    }
+
+    void erase(Size first, Size last) {
+        real_vector.erase(real_vector.begin() + first, real_vector.begin() + last);
+        pre_vector.erase(pre_vector.begin() + first, pre_vector.begin() + last);
+        test();
+    }
+
+    void update(Size pos, const T& value) {
+        real_vector[pos] = value;
+        pre_vector[pos] = value;
+        test();
+    }
+
+    void push_back(const T& value) {
+        real_vector.push_back(value);
+        pre_vector.push_back(value);
+        test();
+    }
+
+    void pop_back() {
+        real_vector.pop_back();
+        pre_vector.pop_back();
+        test();
+    }
+
+    void clear() {
+        real_vector.clear();
+        pre_vector.clear();
+    }
+
+    void assign(Size n, const T& value) {
+        real_vector.assign(n, value);
+        pre_vector.assign(n, value);
+    }
+
+    Size size() {
+        return real_vector.size();
+    }
+
+    Size capacity() {
+        return pre_vector.capacity();
+    }
+
+    void shrink_to_fit() {
+        pre_vector.shrink_to_fit();
+        test();
+    }
+};
+
+BOOST_AUTO_TEST_CASE(PrevectorTestInt)
+{
+    for (int j = 0; j < 64; j++) {
+        prevector_tester<8, int> test;
+        for (int i = 0; i < 2048; i++) {
+            int r = InsecureRand32();
+            if ((r % 4) == 0) {
+                test.insert(InsecureRand32() % (test.size() + 1), InsecureRand32());
+            }
+            if (test.size() > 0 && ((r >> 2) % 4) == 1) {
+                test.erase(InsecureRand32() % test.size());
+            }
+            if (((r >> 4) % 8) == 2) {
+                int new_size = std::max<int>(0, std::min<int>(30, test.size() + (InsecureRand32() % 5) - 2));
+                test.resize(new_size);
+            }
+            if (((r >> 7) % 8) == 3) {
+                test.insert(InsecureRand32() % (test.size() + 1), 1 + (InsecureRand32() % 2), InsecureRand32());
+            }
+            if (((r >> 10) % 8) == 4) {
+                int del = std::min<int>(test.size(), 1 + (InsecureRand32() % 2));
+                int beg = InsecureRand32() % (test.size() + 1 - del);
+                test.erase(beg, beg + del);
+            }
+            if (((r >> 13) % 16) == 5) {
+                test.push_back(InsecureRand32());
+            }
+            if (test.size() > 0 && ((r >> 17) % 16) == 6) {
+                test.pop_back();
+            }
+            if (((r >> 21) % 32) == 7) {
+                int values[4];
+                int num = 1 + (InsecureRand32() % 4);
+                for (int i = 0; i < num; i++) {
+                    values[i] = InsecureRand32();
+                }
+                test.insert_range(InsecureRand32() % (test.size() + 1), values, values + num);
+            }
+            if (((r >> 26) % 32) == 8) {
+                int del = std::min<int>(test.size(), 1 + (InsecureRand32() % 4));
+                int beg = InsecureRand32() % (test.size() + 1 - del);
+                test.erase(beg, beg + del);
+            }
+            r = InsecureRand32();
+            if (r % 32 == 9) {
+                test.reserve(InsecureRand32() % 32);
+            }
+            if ((r >> 5) % 64 == 10) {
+                test.shrink_to_fit();
+            }
+            if (test.size() > 0) {
+                test.update(InsecureRand32() % test.size(), InsecureRand32());
+            }
+            if (((r >> 11) & 1024) == 11) {
+                test.clear();
+            }
+            if (((r >> 21) & 512) == 12) {
+                test.assign(InsecureRand32() % 32, InsecureRand32());
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -19,9 +19,11 @@ template<unsigned int N, typename T>
 class prevector_tester {
     typedef std::vector<T> realtype;
     realtype real_vector;
+    realtype real_vector_alt;
 
     typedef prevector<N, T> pretype;
     pretype pre_vector;
+    pretype pre_vector_alt;
 
     typedef typename pretype::size_type Size;
 
@@ -145,6 +147,12 @@ public:
         pre_vector.shrink_to_fit();
         test();
     }
+
+    void swap() {
+        real_vector.swap(real_vector_alt);
+        pre_vector.swap(pre_vector_alt);
+        test();
+    }
 };
 
 BOOST_AUTO_TEST_CASE(PrevectorTestInt)
@@ -200,11 +208,14 @@ BOOST_AUTO_TEST_CASE(PrevectorTestInt)
             if (test.size() > 0) {
                 test.update(InsecureRand32() % test.size(), InsecureRand32());
             }
-            if (((r >> 11) & 1024) == 11) {
+            if (((r >> 11) % 1024) == 11) {
                 test.clear();
             }
-            if (((r >> 21) & 512) == 12) {
+            if (((r >> 21) % 512) == 12) {
                 test.assign(InsecureRand32() % 32, InsecureRand32());
+            }
+            if (((r >> 15) % 64) == 3) {
+                test.swap();
             }
         }
     }

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -153,6 +153,18 @@ public:
         pre_vector.swap(pre_vector_alt);
         test();
     }
+
+    void move() {
+        real_vector = std::move(real_vector_alt);
+        real_vector_alt.clear();
+        pre_vector = std::move(pre_vector_alt);
+        pre_vector_alt.clear();
+    }
+
+    void copy() {
+        real_vector = real_vector_alt;
+        pre_vector = pre_vector_alt;
+    }
 };
 
 BOOST_AUTO_TEST_CASE(PrevectorTestInt)
@@ -214,8 +226,14 @@ BOOST_AUTO_TEST_CASE(PrevectorTestInt)
             if (((r >> 21) % 512) == 12) {
                 test.assign(InsecureRand32() % 32, InsecureRand32());
             }
-            if (((r >> 15) % 64) == 3) {
+            if (((r >> 15) % 8) == 3) {
                 test.swap();
+            }
+            if (((r >> 15) % 16) == 8) {
+                test.copy();
+            }
+            if (((r >> 15) % 32) == 18) {
+                test.move();
             }
         }
     }

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -264,7 +264,7 @@ public:
 
     TestBuilder& PushRedeem()
     {
-        DoPush(static_cast<std::vector<unsigned char> >(scriptPubKey));
+        DoPush(std::vector<unsigned char>(scriptPubKey.begin(), scriptPubKey.end()));
         return *this;
     }
 
@@ -876,7 +876,7 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     combined = CombineSignatures(scriptPubKey, txTo, 0, scriptSigCopy, scriptSig);
     BOOST_CHECK(combined == scriptSigCopy || combined == scriptSig);
     // dummy scriptSigCopy with placeholder, should always choose non-placeholder:
-    scriptSigCopy = CScript() << OP_0 << static_cast<vector<unsigned char> >(pkSingle);
+    scriptSigCopy = CScript() << OP_0 << std::vector<unsigned char>(pkSingle.begin(), pkSingle.end());
     combined = CombineSignatures(scriptPubKey, txTo, 0, scriptSigCopy, scriptSig);
     BOOST_CHECK(combined == scriptSig);
     combined = CombineSignatures(scriptPubKey, txTo, 0, scriptSig, scriptSigCopy);

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -18,7 +18,7 @@
 /*static std::vector<unsigned char>
 Serialize(const CScript& s)
 {
-    std::vector<unsigned char> sSerialized(s);
+    std::vector<unsigned char> sSerialized(s.begin(), s.end());
     return sSerialized;
 }*/
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -128,31 +128,31 @@ bool CWalletDB::WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey)
 bool CWalletDB::WriteCScript(const uint160& hash, const CScript& redeemScript)
 {
     nWalletDBUpdated++;
-    return Write(std::make_pair(std::string("cscript"), hash), redeemScript, false);
+    return Write(std::make_pair(std::string("cscript"), hash), *(const CScriptBase*)(&redeemScript), false);
 }
 
 bool CWalletDB::WriteWatchOnly(const CScript& dest)
 {
     nWalletDBUpdated++;
-    return Write(std::make_pair(std::string("watchs"), dest), '1');
+    return Write(std::make_pair(std::string("watchs"), *(const CScriptBase*)(&dest)), '1');
 }
 
 bool CWalletDB::EraseWatchOnly(const CScript& dest)
 {
     nWalletDBUpdated++;
-    return Erase(std::make_pair(std::string("watchs"), dest));
+    return Erase(std::make_pair(std::string("watchs"), *(const CScriptBase*)(&dest)));
 }
 
 bool CWalletDB::WriteMultiSig(const CScript& dest)
 {
     nWalletDBUpdated++;
-    return Write(std::make_pair(std::string("multisig"), dest), '1');
+    return Write(std::make_pair(std::string("multisig"), *(const CScriptBase*)(&dest)), '1');
 }
 
 bool CWalletDB::EraseMultiSig(const CScript& dest)
 {
     nWalletDBUpdated++;
-    return Erase(std::make_pair(std::string("multisig"), dest));
+    return Erase(std::make_pair(std::string("multisig"), *(const CScriptBase*)(&dest)));
 }
 
 bool CWalletDB::WriteReserveAmount(const double& amount)
@@ -584,7 +584,7 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
             }
         } else if (strType == "watchs") {
             CScript script;
-            ssKey >> script;
+            ssKey >> *(CScriptBase*)(&script);
             char fYes;
             ssValue >> fYes;
             if (fYes == '1')
@@ -708,7 +708,7 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
             uint160 hash;
             ssKey >> hash;
             CScript script;
-            ssValue >> script;
+            ssValue >> *(CScriptBase*)(&script);
             if (!pwallet->LoadCScript(script)) {
                 strErr = "Error reading wallet database: LoadCScript failed";
                 return false;


### PR DESCRIPTION
> Based on:
> 
> * [x]  [[Core] Big endian support #1554](https://github.com/PIVX-Project/PIVX/pull/1554)
> 
> This introduces `prevector<N, T>`, a new basic data type which is a fully API compatible drop-in replacement for `std::vector<T>` and uses it for the script, to reduce the considerable memory overhead of vectors in cases where they normally contain a small number of small elements.
> 
> Original tests in Bitcoin showed a reduction in dbcache memory usage by **23%**, and made an initial sync **13%** faster.
> 
> Backported from the following upstream's PRs, with only additional edits in the 2nd layer scripts (`masternode-payments`, `masternode-budget`) and in the unit tests (to address the differences in `insecure_rand`):
> 
> * [Add pre-allocated vector type and use it for CScript bitcoin/bitcoin#6914](https://github.com/bitcoin/bitcoin/pull/6914)
> * [prevector: fix 2 bugs in currently unreached code paths bitcoin/bitcoin#7888](https://github.com/bitcoin/bitcoin/pull/7888)
> * [Implement (begin|end)_ptr in C++11 and add deprecation comment bitcoin/bitcoin#8850](https://github.com/bitcoin/bitcoin/pull/8850)
> * [Make CScript (and prevector) c++11 movable. bitcoin/bitcoin#9349](https://github.com/bitcoin/bitcoin/pull/9349)
> * [Prevector Quick Destruct bitcoin/bitcoin#9505](https://github.com/bitcoin/bitcoin/pull/9505)
> * [Terminate immediately when allocation fails bitcoin/bitcoin#9856](https://github.com/bitcoin/bitcoin/pull/9856)
> * [Clarify prevector::erase and avoid swap-to-clear bitcoin/bitcoin#10534](https://github.com/bitcoin/bitcoin/pull/10534)
> * [[Trivial] Add a comment on the use of prevector in script. bitcoin/bitcoin#11011](https://github.com/bitcoin/bitcoin/pull/11011)
> * [Explicitly initialize prevector _union bitcoin/bitcoin#14028](https://github.com/bitcoin/bitcoin/pull/14028)
> 
> ~NOTE: Updates to `memusage.h` needed as well, when #1531 is merged.~

from https://github.com/PIVX-Project/PIVX/pull/1557

additional info:
- our `payee` is a `std::vector<unsigned char>` vs a `CScript` - adapted in https://github.com/PRCYCoin/PRCYCoin/commit/ddba8512d38d866c2f4c71744694f9ac17e756bc - leads to a memory error if not done