### PR TITLE
[GitHub Actions] Use Ubuntu 18 for Releases / Add Separate Ubuntu 20 Workflow 

### DIFF
--- a/.github/workflows/prcy-build-factory-debug.yml
+++ b/.github/workflows/prcy-build-factory-debug.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   create-source-distribution:
     name: Create Source Distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     if: "contains(github.event.head_commit.message, '[debug]')"
     env:
       ARTIFACT_DIR: source
@@ -59,7 +59,7 @@ jobs:
   build-x86_64-linux:
     name: Build for x86 Linux 64bit
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     env:
       ARTIFACT_DIR: prcycoin-x86_64-linux-debug
       TEST_LOG_ARTIFACT_DIR: test-logs
@@ -105,7 +105,7 @@ jobs:
   build-win64:
     name: Build for Win64
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     env:
       ARTIFACT_DIR: prcycoin-win64-debug
     steps:
@@ -154,7 +154,7 @@ jobs:
   build-osx64:
     name: Build for MacOSX
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     env:
       ARTIFACT_DIR: prcycoin-macosx-debug
       SDK_URL: https://bitcoincore.org/depends-sources/sdks
@@ -217,7 +217,7 @@ jobs:
   build-aarch64-linux:
     name: Build for ARM Linux 64bit
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     env:
       ARTIFACT_DIR: prcycoin-aarch64-linux-debug
     steps:
@@ -261,7 +261,7 @@ jobs:
   build-arm-linux-gnueabihf:
     name: Build for ARM Linux 32bit
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     env:
       ARTIFACT_DIR: prcycoin-arm32-debug
     steps:
@@ -305,7 +305,7 @@ jobs:
   build-riscv64-linux-gnu:
     name: Build for RISC-V 64-bit
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     env:
       ARTIFACT_DIR: prcycoin-riscv64-debug
     steps:

--- a/.github/workflows/prcy-build-factory-ubuntu20.yml
+++ b/.github/workflows/prcy-build-factory-ubuntu20.yml
@@ -1,0 +1,432 @@
+# Copyright (c) 2018-2020 The Veil developers
+# Copyright (c) 2020 The DAPS Project
+# Copyright (c) 2020 The PRivaCY Coin Developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+name: Github Actions CI for PRCY (Ubuntu 20)
+on: [push, pull_request]
+env:
+  SOURCE_ARTIFACT: source
+jobs:
+  create-source-distribution:
+    name: Create Source Distribution
+    runs-on: ubuntu-20.04
+    if: "contains(github.event.head_commit.message, '[focal]')"
+    env:
+      ARTIFACT_DIR: source
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Create Version Variable
+      run: |
+        export VERSION=$(cat version.txt | sed 's/[^0-9,.]//g')
+        export TAG=v${VERSION}
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+        echo "TAG=${TAG}" >> $GITHUB_ENV
+    - name: Append Commit Hash to Development Builds
+      if: "!contains(github.ref, 'master')"
+      shell: bash
+      run: |
+        export VERSION=${{ env.VERSION }}-${GITHUB_SHA::7}
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+    - name: Print Variables
+      run: |
+        echo "VERSION=${VERSION}"
+        echo "TAG=${TAG}"
+        printenv
+    - name: Create Distribution Tarball
+      run: |
+        mkdir -p $ARTIFACT_DIR
+        touch prcycoin.tar.gz
+        tar -czf prcycoin.tar.gz --exclude=prcycoin.tar.gz .
+    - name: Download Dependencies
+      run: make -C depends download
+    - name: Create Dependencies Tarball
+      run: tar -czf depends.tar.gz depends
+    - name: Prepare Files for Artifact
+      run: |
+        mv depends.tar.gz prcycoin.tar.gz $ARTIFACT_DIR
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: ${{ env.SOURCE_ARTIFACT }}
+        path: ${{ env.ARTIFACT_DIR }}
+  build-linux:
+    name: Build for Linux
+    needs: create-source-distribution
+    runs-on: ubuntu-18.04
+    env:
+      ARTIFACT_DIR: prcycoin-linux
+      TEST_LOG_ARTIFACT_DIR: test-logs
+    steps:
+    - name: Getting Source
+      uses: actions/download-artifact@v1
+      with:
+        name: ${{ env.SOURCE_ARTIFACT }}
+    - name: Extract Archives
+      run: |
+        tar -xzf prcycoin.tar.gz --strip-components=1
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Set Env
+      shell: bash
+      run: |
+        export VERSION=$(cat $SOURCE_ARTIFACT/version.txt | sed 's/[^0-9,.]//g')
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+    - name: Append Commit Hash to Development Builds
+      if: "!contains(github.ref, 'master')"
+      shell: bash
+      run: |
+        export VERSION=${{ env.VERSION }}-${GITHUB_SHA::7}
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+    # May need qt and protobuf to configure qt and include prcycoin-qt.1 in distribution
+    - name: Install Required Packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libssl1.0-dev libevent-dev libboost-all-dev
+        sudo apt-get install -y libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler libqrencode-dev
+        sudo add-apt-repository ppa:pivx/pivx
+        sudo apt-get update
+        sudo apt-get install -y libdb4.8-dev libdb4.8++-dev
+    - name: Build PRCY
+      run: |
+        ./autogen.sh
+        ./configure --disable-jni --disable-tests --disable-gui-tests --disable-bench --enable-upnp-default
+        make -j$(nproc)
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Prepare Files for Artifact
+      run: |
+        mkdir -p $ARTIFACT_DIR
+        strip $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt}
+        chmod +x $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt}
+        mv $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt} $ARTIFACT_DIR
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: prcycoin-v${{ env.VERSION }}-linux
+        path: ${{ env.ARTIFACT_DIR }}
+  build-x86_64-linux:
+    name: Build for x86 Linux 64bit
+    needs: create-source-distribution
+    runs-on: ubuntu-20.04
+    env:
+      ARTIFACT_DIR: prcycoin-x86_64-linux
+      TEST_LOG_ARTIFACT_DIR: test-logs
+    steps:
+    - name: Getting Source
+      uses: actions/download-artifact@v1
+      with:
+        name: ${{ env.SOURCE_ARTIFACT }}
+    - name: Extract Archives
+      run: |
+        tar -xzf depends.tar.gz
+        tar -xzf prcycoin.tar.gz --strip-components=1
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Set Env
+      shell: bash
+      run: |
+        export VERSION=$(cat $SOURCE_ARTIFACT/version.txt | sed 's/[^0-9,.]//g')
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+    - name: Append Commit Hash to Development Builds
+      if: "!contains(github.ref, 'master')"
+      shell: bash
+      run: |
+        export VERSION=${{ env.VERSION }}-${GITHUB_SHA::7}
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+    - name: Install Required Packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y python3-zmq
+    - name: Build Dependencies
+      run: make -C depends -j$(nproc)
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Build PRCY 
+      run: |
+        ./autogen.sh
+        ./configure --disable-jni --disable-tests --disable-gui-tests --disable-bench --prefix=$(realpath depends/x86_64-pc-linux-gnu) --enable-upnp-default
+        make -j$(nproc)
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Prepare Files for Artifact
+      run: |
+        mkdir -p $ARTIFACT_DIR
+        strip $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt}
+        chmod +x $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt}
+        mv $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt} $ARTIFACT_DIR
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: prcycoin-v${{ env.VERSION }}-x86_64-linux
+        path: ${{ env.ARTIFACT_DIR }}
+  build-win64:
+    name: Build for Win64
+    needs: create-source-distribution
+    runs-on: ubuntu-20.04
+    env:
+      ARTIFACT_DIR: prcycoin-win64
+    steps:
+    - name: Getting Source
+      uses: actions/download-artifact@v1
+      with:
+        name: ${{ env.SOURCE_ARTIFACT }}
+    - name: Extract Archives
+      run: |
+        tar -xzf depends.tar.gz
+        tar -xzf prcycoin.tar.gz --strip-components=1
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Set Env
+      shell: bash
+      run: |
+        export VERSION=$(cat $SOURCE_ARTIFACT/version.txt | sed 's/[^0-9,.]//g')
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+    - name: Append Commit Hash to Development Builds
+      if: "!contains(github.ref, 'master')"
+      shell: bash
+      run: |
+        export VERSION=${{ env.VERSION }}-${GITHUB_SHA::7}
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+    - name: Install Required Packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64 nsis
+    - name: Switch MinGW GCC and G++ to POSIX Threading
+      run: |
+        sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
+        sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
+    - name: Build Dependencies
+      run: make -C depends -j$(nproc) HOST=x86_64-w64-mingw32
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Build PRCY
+      run: |
+        ./autogen.sh
+        ./configure --disable-jni --disable-tests --disable-gui-tests --disable-bench --prefix=$(realpath depends/x86_64-w64-mingw32) --enable-upnp-default
+        make -j$(nproc)
+        make deploy -j$(nproc)
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Prepare Files for Artifact
+      run: |
+        mkdir -p $ARTIFACT_DIR
+        strip $SOURCE_ARTIFACT/src/{prcycoin-cli.exe,prcycoin-tx.exe,prcycoind.exe,qt/prcycoin-qt.exe}
+        mv $SOURCE_ARTIFACT/{prcycoin-*.exe,src/prcycoin-cli.exe,src/prcycoin-tx.exe,src/prcycoind.exe,src/qt/prcycoin-qt.exe} $ARTIFACT_DIR
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: prcycoin-v${{ env.VERSION }}-win64
+        path: ${{ env.ARTIFACT_DIR }}
+  build-osx64:
+    name: Build for MacOSX
+    needs: create-source-distribution
+    runs-on: ubuntu-20.04
+    env:
+      ARTIFACT_DIR: prcycoin-macosx
+      SDK_URL: https://bitcoincore.org/depends-sources/sdks
+    steps:
+    - name: Getting Source
+      uses: actions/download-artifact@v1
+      with:
+        name: ${{ env.SOURCE_ARTIFACT }}
+    - name: Extract Archives
+      run: |
+        tar -xzf depends.tar.gz
+        tar -xzf prcycoin.tar.gz --strip-components=1
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Set Env
+      shell: bash
+      run: |
+        export VERSION=$(cat $SOURCE_ARTIFACT/version.txt | sed 's/[^0-9,.]//g')
+        export XCODE_VERSION=11.3.1
+        export XCODE_BUILD_ID=11C505
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+        echo "XCODE_VERSION=${XCODE_VERSION}" >> $GITHUB_ENV
+        echo "XCODE_BUILD_ID=${XCODE_BUILD_ID}" >> $GITHUB_ENV
+        export OSX_SDK_BASENAME=Xcode-$XCODE_VERSION-$XCODE_BUILD_ID-extracted-SDK-with-libcxx-headers.tar.gz
+        export OSX_SDK_PATH=depends/sdk-sources/$OSX_SDK_BASENAME
+        echo "OSX_SDK_BASENAME=${OSX_SDK_BASENAME}" >> $GITHUB_ENV
+        echo "OSX_SDK_PATH=${OSX_SDK_PATH}" >> $GITHUB_ENV
+    - name: Append Commit Hash to Development Builds
+      if: "!contains(github.ref, 'master')"
+      shell: bash
+      run: |
+        export VERSION=${{ env.VERSION }}-${GITHUB_SHA::7}
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+    - name: Install Required Packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y python3-setuptools libcap-dev librsvg2-bin libtiff-tools
+    - name: Get macOS SDK
+      run: |
+        mkdir -p depends/sdk-sources depends/SDKs
+        if [ -n "${{ env.XCODE_VERSION }}" ] && [ ! -f "${{ env.OSX_SDK_PATH }}" ]; then
+          curl --location --fail "${{ env.SDK_URL }}/${{ env.OSX_SDK_BASENAME }}" -o "${{ env.OSX_SDK_PATH }}"
+        fi
+        if [ -n "${{ env.XCODE_VERSION }}" ] && [ -f "${{ env.OSX_SDK_PATH }}" ]; then
+          tar -C "depends/SDKs" -xf "${{ env.OSX_SDK_PATH }}"
+        fi
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Build Dependencies
+      run: make -C depends HOST=x86_64-apple-darwin16 -j$(nproc)
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Build PRCY
+      run: |
+        ./autogen.sh
+        ./configure --disable-jni --disable-tests --disable-gui-tests --disable-bench --prefix=$(realpath depends/x86_64-apple-darwin16) --enable-upnp-default
+        make -j$(nproc)
+        make deploy -j$(nproc)
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Prepare Files for Artifact
+      run: |
+        mkdir -p $ARTIFACT_DIR
+        mv $SOURCE_ARTIFACT/{*.dmg,src/prcycoin-cli,src/prcycoin-tx,src/prcycoind,src/qt/prcycoin-qt} $ARTIFACT_DIR
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: prcycoin-v${{ env.VERSION }}-macosx
+        path: ${{ env.ARTIFACT_DIR }}
+  build-aarch64-linux:
+    name: Build for ARM Linux 64bit
+    needs: create-source-distribution
+    runs-on: ubuntu-20.04
+    env:
+      ARTIFACT_DIR: prcycoin-aarch64-linux
+    steps:
+    - name: Getting Source
+      uses: actions/download-artifact@v1
+      with:
+        name: ${{ env.SOURCE_ARTIFACT }}
+    - name: Extract Archives
+      run: |
+        tar -xzf depends.tar.gz
+        tar -xzf prcycoin.tar.gz --strip-components=1
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Set Env
+      shell: bash
+      run: |
+        export VERSION=$(cat $SOURCE_ARTIFACT/version.txt | sed 's/[^0-9,.]//g')
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+    - name: Append Commit Hash to Development Builds
+      if: "!contains(github.ref, 'master')"
+      shell: bash
+      run: |
+        export VERSION=${{ env.VERSION }}-${GITHUB_SHA::7}
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+    - name: Install Required Packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y python3-zmq g++-aarch64-linux-gnu
+    - name: Build Dependencies
+      run: make -C depends HOST=aarch64-linux-gnu -j$(nproc)
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Build PRCY
+      run: |
+        ./autogen.sh
+        ./configure --disable-jni --disable-tests --disable-gui-tests --disable-bench --prefix=$(realpath depends/aarch64-linux-gnu) --enable-upnp-default
+        make -j$(nproc)
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Prepare Files for Artifact
+      run: |
+        mkdir -p $ARTIFACT_DIR
+        chmod +x $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt}
+        mv $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt} $ARTIFACT_DIR
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: prcycoin-v${{ env.VERSION }}-aarch64-linux
+        path: ${{ env.ARTIFACT_DIR }}
+  build-arm-linux-gnueabihf:
+    name: Build for ARM Linux 32bit
+    needs: create-source-distribution
+    runs-on: ubuntu-20.04
+    env:
+      ARTIFACT_DIR: prcycoin-arm32
+    steps:
+    - name: Getting Source
+      uses: actions/download-artifact@v1
+      with:
+        name: ${{ env.SOURCE_ARTIFACT }}
+    - name: Extract Archives
+      run: |
+        tar -xzf depends.tar.gz
+        tar -xzf prcycoin.tar.gz --strip-components=1
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Set Env
+      shell: bash
+      run: |
+        export VERSION=$(cat $SOURCE_ARTIFACT/version.txt | sed 's/[^0-9,.]//g')
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+    - name: Append Commit Hash to Development Builds
+      if: "!contains(github.ref, 'master')"
+      shell: bash
+      run: |
+        export VERSION=${{ env.VERSION }}-${GITHUB_SHA::7}
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+    - name: Install Required Packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y g++-arm-linux-gnueabihf
+    - name: Build Dependencies
+      run: make -C depends -j$(nproc) HOST=arm-linux-gnueabihf
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Build PRCY
+      run: |
+        ./autogen.sh
+        ./configure --disable-jni --disable-tests --disable-gui-tests --disable-bench --prefix=$(realpath depends/arm-linux-gnueabihf) --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++ --enable-upnp-default
+        make -j$(nproc)
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Prepare Files for Artifact
+      run: |
+        mkdir -p $ARTIFACT_DIR
+        chmod +x $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt}
+        mv $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt} $ARTIFACT_DIR
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: prcycoin-v${{ env.VERSION }}-arm32
+        path: ${{ env.ARTIFACT_DIR }}
+  build-riscv64-linux-gnu:
+    name: Build for RISC-V 64-bit
+    needs: create-source-distribution
+    runs-on: ubuntu-20.04
+    env:
+      ARTIFACT_DIR: prcycoin-riscv64
+    steps:
+    - name: Getting Source
+      uses: actions/download-artifact@v1
+      with:
+        name: ${{ env.SOURCE_ARTIFACT }}
+    - name: Extract Archives
+      run: |
+        tar -xzf depends.tar.gz
+        tar -xzf prcycoin.tar.gz --strip-components=1
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Set Env
+      shell: bash
+      run: |
+        export VERSION=$(cat $SOURCE_ARTIFACT/version.txt | sed 's/[^0-9,.]//g')
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+    - name: Append Commit Hash to Development Builds
+      if: "!contains(github.ref, 'master')"
+      shell: bash
+      run: |
+        export VERSION=${{ env.VERSION }}-${GITHUB_SHA::7}
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+    - name: Install Required Packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y g++-riscv64-linux-gnu binutils-riscv64-linux-gnu
+    - name: Build Dependencies
+      run: make -C depends -j$(nproc) HOST=riscv64-linux-gnu NO_QT=1
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Build PRCY
+      run: |
+        ./autogen.sh
+        ./configure --disable-jni --disable-tests --disable-gui-tests --disable-bench --prefix=$(realpath depends/riscv64-linux-gnu) --enable-reduce-exports LDFLAGS=-static-libstdc++ --enable-upnp-default
+        make -j$(nproc)
+      working-directory: ${{ env.SOURCE_ARTIFACT }}
+    - name: Prepare Files for Artifact
+      run: |
+        mkdir -p $ARTIFACT_DIR
+        chmod +x $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind}
+        mv $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind} $ARTIFACT_DIR
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: prcycoin-v${{ env.VERSION }}-riscv64
+        path: ${{ env.ARTIFACT_DIR }}

--- a/.github/workflows/prcy-build-factory.yml
+++ b/.github/workflows/prcy-build-factory.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   create-source-distribution:
     name: Create Source Distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     env:
       ARTIFACT_DIR: source
     steps:
@@ -106,7 +106,7 @@ jobs:
   build-x86_64-linux:
     name: Build for x86 Linux 64bit
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     env:
       ARTIFACT_DIR: prcycoin-x86_64-linux
       TEST_LOG_ARTIFACT_DIR: test-logs
@@ -158,7 +158,7 @@ jobs:
   build-win64:
     name: Build for Win64
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     env:
       ARTIFACT_DIR: prcycoin-win64
     steps:
@@ -213,7 +213,7 @@ jobs:
   build-osx64:
     name: Build for MacOSX
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     env:
       ARTIFACT_DIR: prcycoin-macosx
       SDK_URL: https://bitcoincore.org/depends-sources/sdks
@@ -282,7 +282,7 @@ jobs:
   build-aarch64-linux:
     name: Build for ARM Linux 64bit
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     env:
       ARTIFACT_DIR: prcycoin-aarch64-linux
     steps:
@@ -332,7 +332,7 @@ jobs:
   build-arm-linux-gnueabihf:
     name: Build for ARM Linux 32bit
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     env:
       ARTIFACT_DIR: prcycoin-arm32
     steps:
@@ -382,7 +382,7 @@ jobs:
   build-riscv64-linux-gnu:
     name: Build for RISC-V 64-bit
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     env:
       ARTIFACT_DIR: prcycoin-riscv64
     steps:


### PR DESCRIPTION
Jumping to building with Ubuntu 20 too early caused issues on older distros. Go back to Ubuntu 18, while adding a Ubuntu 20 Workflow that is disabled by default, but can be run with `[focal]` in the commit