### PR TITLE
[Upstream] [Net] Remove bogus assert on number of oubound connections.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1520,7 +1520,6 @@ void ThreadOpenConnections() {
                 }
             }
         }
-        assert(nOutbound <= (MAX_OUTBOUND_CONNECTIONS + MAX_FEELER_CONNECTIONS));
 
         // Feeler Connections
         //


### PR DESCRIPTION
> Value can be significantly higher if the users uses addnode.
> 
> Coming from upstream#[8944](https://github.com/bitcoin/bitcoin/pull/8944)

from https://github.com/PIVX-Project/PIVX/pull/1769