### PR TITLE
[Upstream] [net] Remove assert(nMaxInbound > 0) 

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -950,7 +950,6 @@ static void AcceptConnection(const ListenSocket& hListenSocket) {
     CAddress addr;
     int nInbound = 0;
     int nMaxInbound = nMaxConnections - (MAX_OUTBOUND_CONNECTIONS + MAX_FEELER_CONNECTIONS);
-    assert(nMaxInbound > 0);
 
     if (hSocket != INVALID_SOCKET)
         if (!addr.SetSockAddr((const struct sockaddr*)&sockaddr))


### PR DESCRIPTION
> Backports [bitcoin#9008](https://github.com/bitcoin/bitcoin/pull/9008).
> 
> > nMaxInbound might very well be 0 or -1, if the user prefers to keep a small number of maxconnections.
> > Note: nMaxInbound of -1 means that the user set maxconnections
> > to 8 or less, but we still want to keep an additional slot for
> > the feeler connection.
> 
> Have faced this assertion crash few times in testnet already.

from https://github.com/PIVX-Project/PIVX/pull/2682