### PR TITLE
[ChainParams] Move Stealth and Integrated Address Prefixes to ChainParams

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -222,6 +222,8 @@ public:
         base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x57)(0x41)(0x71)(0x65).convert_to_container<std::vector<unsigned char> >();
         //  BIP44 coin type is from https://github.com/satoshilabs/slips/blob/master/slip-0044.md
         nExtCoinType = 0x80000355;
+        nStealthPrefix = 135; // Stealth Addresses start with a P
+        nIntegratedPrefix = 136; // Integrated Addresses start with a Pk
 
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_main, pnSeed6_main + ARRAYLEN(pnSeed6_main));
 
@@ -340,6 +342,8 @@ public:
         base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x3a)(0x80)(0x58)(0x37).convert_to_container<std::vector<unsigned char> >();
         // Testnet prcycoin BIP44 coin type is '1' (All coin's testnet default)
         nExtCoinType = 0x80000001;
+        nStealthPrefix = 135; // Stealth Addresses start with a P
+        nIntegratedPrefix = 136; // Integrated Addresses start with a Pk
 
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_test, pnSeed6_test + ARRAYLEN(pnSeed6_test));
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -103,6 +103,8 @@ public:
     CBaseChainParams::Network NetworkID() const { return networkID; }
     bool IsRegTestNet() const { return NetworkID() == CBaseChainParams::REGTEST; }
     int ExtCoinType() const { return nExtCoinType; }
+    int StealthPrefix() const { return nStealthPrefix; }
+    int IntegratedPrefix() const { return nIntegratedPrefix; }
 
     /** Height or Time Based Activations **/
     int ModifierUpgradeBlock() const { return nModifierUpdateBlock; }
@@ -133,6 +135,8 @@ protected:
     //! Raw pub key bytes for the broadcast alert signing key.
     int nDefaultPort;
     int nExtCoinType;
+    int nStealthPrefix;
+    int nIntegratedPrefix;
     uint256 bnProofOfWorkLimit;
     mutable int nMaxReorganizationDepth;
     int nSubsidyHalvingInterval;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -6091,7 +6091,7 @@ bool CWallet::encodeStealthBase58(const std::vector<unsigned char>& raw, std::st
 bool CWallet::EncodeStealthPublicAddress(const std::vector<unsigned char>& pubViewKey, const std::vector<unsigned char>& pubSpendKey, std::string& pubAddrb58)
 {
     std::vector<unsigned char> pubAddr;
-    pubAddr.push_back(135);                                                                 //1 byte
+    pubAddr.push_back(Params().StealthPrefix());                                                                 //1 byte
     std::copy(pubSpendKey.begin(), pubSpendKey.begin() + 33, std::back_inserter(pubAddr)); //copy 33 bytes
     std::copy(pubViewKey.begin(), pubViewKey.begin() + 33, std::back_inserter(pubAddr));   //copy 33 bytes
     uint256 h = Hash(pubAddr.begin(), pubAddr.end());
@@ -6107,7 +6107,7 @@ bool CWallet::EncodeStealthPublicAddress(const std::vector<unsigned char>& pubVi
 bool CWallet::EncodeIntegratedAddress(const std::vector<unsigned char>& pubViewKey, const std::vector<unsigned char>& pubSpendKey, uint64_t paymentID, std::string& pubAddrb58)
 {
     std::vector<unsigned char> pubAddr;
-    pubAddr.push_back(136);                                                                            //1 byte 19 for integrated address
+    pubAddr.push_back(Params().IntegratedPrefix());                                                                            //1 byte 19 for integrated address
     std::copy(pubSpendKey.begin(), pubSpendKey.begin() + 33, std::back_inserter(pubAddr));            //copy 33 bytes
     std::copy(pubViewKey.begin(), pubViewKey.begin() + 33, std::back_inserter(pubAddr));              //copy 33 bytes
     std::copy((char*)&paymentID, (char*)&paymentID + sizeof(paymentID), std::back_inserter(pubAddr)); //8 bytes of payment id


### PR DESCRIPTION
This makes it easier to add, change prefixes vs using hard numbers