### PR TITLE
Add parameter to sendalltostealthaddress to include locked coins or not

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -298,7 +298,8 @@ void SendCoinsDialog::sendTx() {
             // Send All
             success = pwalletMain->SendAll(
                 send_address.toStdString(),
-                resultTx
+                resultTx,
+                false
             );
         } else {
             // Send

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2830,13 +2830,14 @@ UniValue sendtostealthaddress(const UniValue& params, bool fHelp)
 
 UniValue sendalltostealthaddress(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
+    if (fHelp || params.size() < 1 || params.size() > 2)
         throw std::runtime_error(
-                "sendalltostealthaddress \"prcystealthaddress\"\n"
+                "sendalltostealthaddress \"prcystealthaddress\" ( includeLocked )\n"
                 "\nSend all PRCY to stealth address\n" +
                 HelpRequiringPassphrase() +
                 "\nArguments:\n"
                 "1. \"prcystealthaddress\"  (string, required) The prcycoin stealth address to send to.\n"
+                "2. \"include_locked\"      (bool, optional, default=false) Whether to include locked coins or not.\n"
                 "\nResult:\n"
                 "\"transactionid\"  (string) The transaction id.\n"
                 "\nExamples:\n" +
@@ -2850,7 +2851,12 @@ UniValue sendalltostealthaddress(const UniValue& params, bool fHelp)
     // Wallet comments
     CWalletTx wtx;
 
-    if (!pwalletMain->SendAll(stealthAddr, wtx)) {
+    // Include Locked Coins
+    bool inclLocked = false;
+    if (params.size() > 1)
+        inclLocked = params[1].get_bool();
+
+    if (!pwalletMain->SendAll(stealthAddr, wtx, inclLocked)) {
         throw JSONRPCError(RPC_WALLET_ERROR,
                            "Cannot create transaction.");
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4827,7 +4827,7 @@ bool CWallet::LoadDestData(const CTxDestination& dest, const std::string& key, c
     return true;
 }
 
-bool CWallet::SendAll(std::string des, CWalletTx& wtxNew)
+bool CWallet::SendAll(std::string des, CWalletTx& wtxNew, bool inclLocked)
 {
     if (this->IsLocked()) {
         throw std::runtime_error("Wallet is locked! Please unlock it to make transactions.");
@@ -4885,6 +4885,9 @@ bool CWallet::SendAll(std::string des, CWalletTx& wtxNew)
                     {
                         COutPoint outpoint(wtxid, i);
                         if (inSpendQueueOutpoints.count(outpoint)) {
+                            continue;
+                        }
+                        if (!inclLocked && IsCollateralized(outpoint)) {
                             continue;
                         }
                     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -310,7 +310,7 @@ public:
     CAmount nAutoCombineThreshold;
     CAmount nAutoCombineTarget;
     bool CreateSweepingTransaction(CAmount target, CAmount threshold, uint32_t nTimeBefore);
-    bool SendAll(std::string des, CWalletTx& wtxNew);
+    bool SendAll(std::string des, CWalletTx& wtxNew, bool inclLocked);
 
     CWallet();
     CWallet(std::string strWalletFileIn);


### PR DESCRIPTION
SendAll was not taking into account Masternodes that were collateralized so we add it as a parameter when attempting to send all.
`default=false`

`sendalltostealthaddress ADDRESS` [false] - does not include MNs to be sent
`sendalltostealthaddress ADDRESS true` includes ALL coins, locked or not