### PR TITLE
[Qt] History Tab Cleanup

### DIFF
--- a/src/qt/historypage.cpp
+++ b/src/qt/historypage.cpp
@@ -264,7 +264,7 @@ void HistoryPage::updateFilter()
 
     for (int row = 0; row < ui->tableView->rowCount(); row++) {
         bool hide = false;
-        QDateTime date = QDateTime::fromString(ui->tableView->item(row, 0)->text(), "M/d/yyyy h:m");
+        QDateTime date = QDateTime::fromString(ui->tableView->item(row, 0)->text(), "yyyy-MM-ddThh:mm:ss");
         QString type = ui->tableView->item(row, 1)->text();
         QString address = ui->tableView->item(row, 2)->text();
         auto amount = ui->tableView->item(row, 3)->text().toFloat();
@@ -277,21 +277,22 @@ void HistoryPage::updateFilter()
             hide = true;
         if (selectedType != tr("All Types")) {
             if (selectedType == tr("Received")) {
-                hide = !(type == tr("Received"));
+                hide = hide || !(type == tr("Received"));
             } else if (selectedType == tr("Sent")) {
-                hide = !(type == tr("Sent"));
+                hide = hide || !(type == tr("Sent"));
             } else if (selectedType == tr("Mined")) {
-                hide = !(type == tr("Mined"));
+                hide = hide || !(type == tr("Mined"));
             } else if (selectedType == tr("Minted")) {
-                hide = !(type == tr("Minted"));
+                hide = hide || !(type == tr("Minted"));
             } else if (selectedType == tr("Masternode")) {
-                hide = !(type == tr("Masternode"));
+                hide = hide || !(type == tr("Masternode"));
             } else if (selectedType == tr("Payment to yourself")) {
-                hide = !(type == tr("Payment to yourself"));
+                hide = hide || !(type == tr("Payment to yourself"));
             }
         } else {
-            hide = !(type == tr("Received")) && !(type == tr("Sent")) && !(type == tr("Mined")) && !(type == tr("Minted")) && !(type == tr("Masternode")) && !(type == tr("Payment to yourself"));
+            hide= hide || !(type == tr("Received")) && !(type == tr("Sent")) && !(type == tr("Mined")) && !(type == tr("Minted")) && !(type == tr("Masternode")) && !(type == tr("Payment to yourself"));
         }
+
         if (ui->lineEditDesc->currentText() != allAddressString) {
             bool found = false;
             for (QString selectedAddress : selectedAddresses)

--- a/src/qt/historypage.cpp
+++ b/src/qt/historypage.cpp
@@ -206,26 +206,7 @@ void HistoryPage::updateTableData(CWallet* wallet)
         }
         ui->tableView->setRowCount(0);
         std::vector<std::map<QString, QString> > txs;
-        if (wallet->IsLocked()) {
-            {
-                LOCK(pwalletMain->cs_wallet);
-                std::vector<std::map<QString, QString>> txs;// = WalletUtil::getTXs(pwalletMain);
-
-                std::map<uint256, CWalletTx> txMap = pwalletMain->mapWallet;
-                std::vector<CWalletTx> latestTxes;
-                for (std::map<uint256, CWalletTx>::iterator tx = txMap.begin(); tx != txMap.end(); ++tx) {
-                    if (tx->second.GetDepthInMainChain() > 0) {
-                        latestTxes.push_back(tx->second);
-                    }
-                }
-
-                for (int i = 0; i < (int)latestTxes.size(); i++) {
-                    txs.push_back(WalletUtil::getTx(pwalletMain, latestTxes[i]));
-                }
-            }
-        } else {
-            txs = WalletUtil::getTXs(wallet);
-        }
+        txs = WalletUtil::getTXs(wallet);
         for (int row = 0; row < (short)txs.size(); row++) {
             ui->tableView->insertRow(row);
             int col = 0;
@@ -239,9 +220,7 @@ void HistoryPage::updateTableData(CWallet* wallet)
                     cell->setData(0, date);
                     break;
                 case 3: /*amount*/
-                    if (wallet->IsLocked()) {
-                        cell->setData(0, QString("Locked; Hidden"));
-                    } else if (settings.value("fHideBalance", false).toBool()) {
+                    if (settings.value("fHideBalance", false).toBool()) {
                         cell->setData(0, QString("Hidden"));
                     } else {
                         cell->setData(0, data);

--- a/src/qt/historypage.cpp
+++ b/src/qt/historypage.cpp
@@ -191,6 +191,7 @@ void HistoryPage::updateTableData()
 
 void HistoryPage::updateTableData(CWallet* wallet)
 {
+    if (!wallet || wallet->IsLocked()) return;
     TRY_LOCK(cs_main, lockMain);
     if (!lockMain)
         return;
@@ -198,7 +199,6 @@ void HistoryPage::updateTableData(CWallet* wallet)
     if (!lockWallet)
         return;
     {
-        if (!wallet || wallet->IsLocked()) return;
         ui->tableView->setSortingEnabled(false);
         while (ui->tableView->rowCount() > 0)
         {


### PR DESCRIPTION
 - Remove unreachable code on History tab
   - We can't get the transactions with the wallet unlocked
   - There is a return above this code when the wallet is locked preventing ever reaching the code (which doesn't work anyway)
   - On further inspection, part of this was also a copy of the Overview screen's Recent Transactions code that didn't belong here 
- Return immediately if wallet doesn't exist/is locked in updateTableData
  - No point to check TRY_LOCK for a function that won't work without an unlocked wallet
- Fix Date/Amount/Address search on History page
  - Incorrect QDateTime::fromString format was being used and so the date was invalid (Date selection was being compared to nothing)
  - Due to the above, the `hide` boolean was also not being used correctly for other searches as it would break them