### PR TITLE
[Upstream] [Build] Require minimum boost version 1.57.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -933,26 +933,6 @@ dnl Boost 1.56 through 1.62 allow using std::atomic instead of its own atomic
 dnl counter implementations. In 1.63 and later the std::atomic approach is default.
 m4_pattern_allow(DBOOST_AC_USE_STD_ATOMIC) dnl otherwise it's treated like a macro
 BOOST_CPPFLAGS="-DBOOST_SP_USE_STD_ATOMIC -DBOOST_AC_USE_STD_ATOMIC $BOOST_CPPFLAGS"
-
-if test x$use_reduce_exports = xyes; then
-  AC_MSG_CHECKING([for working boost reduced exports])
-  TEMP_CPPFLAGS="$CPPFLAGS"
-  CPPFLAGS="$BOOST_CPPFLAGS $CPPFLAGS"
-  AC_PREPROC_IFELSE([AC_LANG_PROGRAM([[
-      @%:@include <boost/version.hpp>
-    ]], [[
-      #if BOOST_VERSION >= 104900
-      // Everything is okay
-      #else
-      #  error Boost version is too old
-      #endif
-    ]])],[
-      AC_MSG_RESULT(yes)
-    ],[
-    AC_MSG_ERROR([boost versions < 1.49 are known to be broken with reduced exports. Use --disable-reduce-exports.])
-  ])
-  CPPFLAGS="$TEMP_CPPFLAGS"
-fi
 fi
 
 if test x$use_reduce_exports = xyes; then
@@ -993,98 +973,7 @@ if test x$use_tests = xyes; then
 fi
 
 if test x$use_boost = xyes; then
-
-BOOST_LIBS="$BOOST_LDFLAGS $BOOST_SYSTEM_LIB $BOOST_FILESYSTEM_LIB $BOOST_PROGRAM_OPTIONS_LIB $BOOST_THREAD_LIB"
-
-dnl If boost (prior to 1.57) was built without c++11, it emulated scoped enums
-dnl using c++98 constructs. Unfortunately, this implementation detail leaked into
-dnl the abi. This was fixed in 1.57.
-
-dnl When building against that installed version using c++11, the headers pick up
-dnl on the native c++11 scoped enum support and enable it, however it will fail to
-dnl link. This can be worked around by disabling c++11 scoped enums if linking will
-dnl fail.
-dnl BOOST_NO_SCOPED_ENUMS was changed to BOOST_NO_CXX11_SCOPED_ENUMS in 1.51.
-
-TEMP_LIBS="$LIBS"
-LIBS="$BOOST_LIBS $LIBS"
-TEMP_CPPFLAGS="$CPPFLAGS"
-CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
-AC_MSG_CHECKING([for mismatched boost c++11 scoped enums])
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-  #include <boost/config.hpp>
-  #include <boost/version.hpp>
-  #if !defined(BOOST_NO_SCOPED_ENUMS) && !defined(BOOST_NO_CXX11_SCOPED_ENUMS) && BOOST_VERSION < 105700
-  #define BOOST_NO_SCOPED_ENUMS
-  #define BOOST_NO_CXX11_SCOPED_ENUMS
-  #define CHECK
-  #endif
-  #include <boost/filesystem.hpp>
-  ]],[[
-  #if defined(CHECK)
-    boost::filesystem::copy_file("foo", "bar");
-  #else
-    choke;
-  #endif
-  ]])],
-  [AC_MSG_RESULT(mismatched); BOOST_CPPFLAGS="$BOOST_CPPFLAGS -DBOOST_NO_SCOPED_ENUMS -DBOOST_NO_CXX11_SCOPED_ENUMS"], [AC_MSG_RESULT(ok)])
-LIBS="$TEMP_LIBS"
-CPPFLAGS="$TEMP_CPPFLAGS"
-
-dnl Boost >= 1.50 uses sleep_for rather than the now-deprecated sleep, however
-dnl it was broken from 1.50 to 1.52 when backed by nanosleep. Use sleep_for if
-dnl a working version is available, else fall back to sleep. sleep was removed
-dnl after 1.56.
-dnl If neither is available, abort.
-dnl If sleep_for is used, boost_chrono becomes a requirement.
-if test x$ax_cv_boost_chrono = xyes; then
-TEMP_LIBS="$LIBS"
-LIBS="$BOOST_LIBS $BOOST_CHRONO_LIB $LIBS"
-TEMP_CPPFLAGS="$CPPFLAGS"
-CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-  #include <boost/thread/thread.hpp>
-  #include <boost/version.hpp>
-  ]],[[
-  #if BOOST_VERSION >= 105000 && (!defined(BOOST_HAS_NANOSLEEP) || BOOST_VERSION >= 105200)
-      boost::this_thread::sleep_for(boost::chrono::milliseconds(0));
-  #else
-   choke me
-  #endif
-  ]])],
-  [boost_sleep=yes; BOOST_LIBS="$BOOST_LIBS $BOOST_CHRONO_LIB";
-     AC_DEFINE(HAVE_WORKING_BOOST_SLEEP_FOR, 1, [Define this symbol if boost sleep_for works])],
-  [boost_sleep=no])
-LIBS="$TEMP_LIBS"
-CPPFLAGS="$TEMP_CPPFLAGS"
-fi
-
-if test x$boost_sleep != xyes; then
-TEMP_LIBS="$LIBS"
-LIBS="$BOOST_LIBS $LIBS"
-TEMP_CPPFLAGS="$CPPFLAGS"
-CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-  #include <boost/version.hpp>
-  #include <boost/thread.hpp>
-  #include <boost/date_time/posix_time/posix_time_types.hpp>
-  ]],[[
-  #if BOOST_VERSION <= 105600
-      boost::this_thread::sleep(boost::posix_time::milliseconds(0));
-  #else
-   choke me
-  #endif
-  ]])],
-  [boost_sleep=yes; AC_DEFINE(HAVE_WORKING_BOOST_SLEEP, 1, [Define this symbol if boost sleep works])],
-  [boost_sleep=no])
-LIBS="$TEMP_LIBS"
-CPPFLAGS="$TEMP_CPPFLAGS"
-fi
-
-if test x$boost_sleep != xyes; then
-  AC_MSG_ERROR(No working boost sleep implementation found.)
-fi
-
+BOOST_LIBS="$BOOST_LDFLAGS $BOOST_SYSTEM_LIB $BOOST_FILESYSTEM_LIB $BOOST_PROGRAM_OPTIONS_LIB $BOOST_THREAD_LIB $BOOST_CHRONO_LIB"
 fi
 
 if test x$use_pkgconfig = xyes; then

--- a/configure.ac
+++ b/configure.ac
@@ -916,7 +916,7 @@ fi
 if test x$use_boost = xyes; then
 
 dnl Minimum required Boost version
-define(MINIMUM_REQUIRED_BOOST, 1.47.0)
+define(MINIMUM_REQUIRED_BOOST, 1.57.0)
 
 dnl Check for boost libs
 AX_BOOST_BASE([MINIMUM_REQUIRED_BOOST])

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -6,7 +6,7 @@ These are the dependencies currently used by PRCYCoin. You can find instructions
 | Dependency | Version used | Minimum required | CVEs | Shared | [Bundled Qt library](https://doc.qt.io/qt-5/configure-options.html#third-party-libraries) |
 | --- | --- | --- | --- | --- | --- |
 | Berkeley DB | [4.8.30](https://www.oracle.com/technetwork/database/database-technologies/berkeleydb/downloads/index.html) | 4.8.x | No |  |  |
-| Boost | [1.71.0](https://www.boost.org/users/download/) | [1.47.0](https://github.com/bitcoin/bitcoin/pull/8920) | No |  |  |
+| Boost | [1.71.0](https://www.boost.org/users/download/) | [1.57.0](https://github.com/PRCYCoin/PRCYCoin/pull/286) | No |  |  |
 | Clang |  | [3.3+](https://llvm.org/releases/download.html) (C++11 support) |  |  |  |
 | D-Bus | [1.10.18](https://cgit.freedesktop.org/dbus/dbus/tree/NEWS?h=dbus-1.10) |  | No | Yes |  |
 | Expat | [2.2.6](https://libexpat.github.io/) |  | No | Yes |  |

--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -5,6 +5,7 @@
 
 #include "fs.h"
 
+#define BOOST_FILESYSTEM_NO_DEPRECATED
 #include <boost/filesystem.hpp>
 
 namespace fsbridge {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1046,7 +1046,8 @@ bool AppInit2(bool isDaemon)
     std::string strDataDir = GetDataDir().string();
 #ifdef ENABLE_WALLET
     // Wallet file must be a plain filename without a directory
-    if (strWalletFile != fs::basename(strWalletFile) + fs::extension(strWalletFile))
+    fs::path wallet_file_path(strWalletFile);
+    if (strWalletFile != wallet_file_path.filename().string())
         return UIError(strprintf(_("Wallet %s resides outside data directory %s"), strWalletFile, strDataDir));
 #endif
     // Make sure only a single PRCY process is using the data directory.

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -62,9 +62,7 @@
 
 void ForceActivation();
 
-#if BOOST_FILESYSTEM_VERSION >= 3
 static fs::detail::utf8_codecvt_facet utf8;
-#endif
 
 #define URI_SCHEME "prcycoin"
 
@@ -800,7 +798,6 @@ void setClipboard(const QString& str)
     QApplication::clipboard()->setText(str, QClipboard::Selection);
 }
 
-#if BOOST_FILESYSTEM_VERSION >= 3
 fs::path qstringToBoostPath(const QString& path)
 {
     return fs::path(path.toStdString(), utf8);
@@ -810,18 +807,6 @@ QString boostPathToQString(const fs::path& path)
 {
     return QString::fromStdString(path.string(utf8));
 }
-#else
-#warning Conversion between boost path and QString can use invalid character encoding with boost_filesystem v2 and older
-fs::path qstringToBoostPath(const QString& path)
-{
-    return fs::path(path.toStdString());
-}
-
-QString boostPathToQString(const fs::path& path)
-{
-    return QString::fromStdString(path.string());
-}
-#endif
 
 QString formatDurationStr(int secs)
 {

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -76,8 +76,7 @@ static const std::string COOKIEAUTH_FILE = ".cookie";
 fs::path GetAuthCookieFile()
 {
     fs::path path(GetArg("-rpccookiefile", COOKIEAUTH_FILE));
-    if (!path.is_complete()) path = GetDataDir() / path;
-    return path;
+    return AbsPathForConfigVal(path);
 }
 
 bool GenerateAuthCookie(std::string *cookie_out)

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -18,14 +18,6 @@ CScheduler::~CScheduler() {
     assert(nThreadsServicingQueue == 0);
 }
 
-#if BOOST_VERSION < 105000
-
-static boost::system_time toPosixTime(const boost::chrono::system_clock::time_point &t) {
-    return boost::posix_time::from_time_t(boost::chrono::system_clock::to_time_t(t));
-}
-
-#endif
-
 void CScheduler::serviceQueue() {
     boost::unique_lock <boost::mutex> lock(newTaskMutex);
     ++nThreadsServicingQueue;
@@ -45,20 +37,12 @@ void CScheduler::serviceQueue() {
             }
             // Wait until either there is a new task, or until
             // the time of the first item on the queue:
-// wait_until needs boost 1.50 or later; older versions have timed_wait:
-#if BOOST_VERSION < 105000
-            while (!shouldStop() && !taskQueue.empty() &&
-                   newTaskScheduled.timed_wait(lock, toPosixTime(taskQueue.begin()->first))) {
-                // Keep waiting until timeout
-            }
-#else
             // Some boost versions have a conflicting overload of wait_until that returns void.
             // Explicitly use a template here to avoid hitting that overload.
             while (!shouldStop() && !taskQueue.empty() &&
                    newTaskScheduled.wait_until<>(lock, taskQueue.begin()->first) != boost::cv_status::timeout) {
                 // Keep waiting until timeout
             }
-#endif
             // If there are multiple threads, the queue can empty while we're waiting (another
             // thread may service the task we were waiting on).
             if (shouldStop() || taskQueue.empty())

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -9,8 +9,6 @@
 
 #if defined(HAVE_CONFIG_H)
 #include "config/prcycoin-config.h"
-#else
-#define HAVE_WORKING_BOOST_SLEEP_FOR
 #endif
 
 #include <boost/bind.hpp>
@@ -37,14 +35,7 @@ static void microTask(CScheduler &s, boost::mutex &mutex, int &counter, int delt
 }
 
 static void MicroSleep(uint64_t n) {
-#if defined(HAVE_WORKING_BOOST_SLEEP_FOR)
     boost::this_thread::sleep_for(boost::chrono::microseconds(n));
-#elif defined(HAVE_WORKING_BOOST_SLEEP)
-    boost::this_thread::sleep(boost::posix_time::microseconds(n));
-#else
-    //should never get here
-#error missing boost sleep implementation
-#endif
 }
 
 BOOST_AUTO_TEST_CASE(manythreads)

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -767,12 +767,9 @@ void InterruptTorControl()
 
 void StopTorControl()
 {
+    // try_join_for() avoids the wallet not closing during a repair-restart. For a 'normal' wallet exit
     if (gBase) {
-#if BOOST_VERSION >= 105000
         torControlThread.try_join_for(boost::chrono::seconds(1));
-#else
-        torControlThread.timed_join(boost::posix_time::seconds(1));
-#endif
         event_base_free(gBase);
         gBase = 0;
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -608,25 +608,7 @@ fs::path GetSpecialFolderPath(int nFolder, bool fCreate)
 
 fs::path GetTempPath()
 {
-#if BOOST_FILESYSTEM_VERSION == 3
     return fs::temp_directory_path();
-#else
-    // TODO: remove when we don't support filesystem v2 anymore
-    fs::path path;
-#ifdef WIN32
-    char pszPath[MAX_PATH] = "";
-
-    if (GetTempPathA(MAX_PATH, pszPath))
-        path = fs::path(pszPath);
-#else
-    path = fs::path("/tmp");
-#endif
-    if (path.empty() || !fs::is_directory(path)) {
-        LogPrintf("GetTempPath(): failed to find temp path\n");
-        return fs::path("");
-    }
-    return path;
-#endif
 }
 
 void runCommand(std::string strCommand)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -394,17 +394,13 @@ void ClearDatadirCache()
 fs::path GetConfigFile()
 {
     fs::path pathConfigFile(GetArg("-conf", "prcycoin.conf"));
-    if (!pathConfigFile.is_complete())
-        pathConfigFile = GetDataDir(false) / pathConfigFile;
-
-    return pathConfigFile;
+    return AbsPathForConfigVal(pathConfigFile, false);
 }
 
 fs::path GetMasternodeConfigFile()
 {
     fs::path pathConfigFile(GetArg("-mnconf", "masternode.conf"));
-    if (!pathConfigFile.is_complete()) pathConfigFile = GetDataDir() / pathConfigFile;
-    return pathConfigFile;
+    return AbsPathForConfigVal(pathConfigFile);
 }
 
 void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet,
@@ -447,13 +443,7 @@ fs::path AbsPathForConfigVal(const fs::path& path, bool net_specific)
 fs::path GetPidFile()
 {
     fs::path pathPidFile(GetArg("-pid", "prcycoind.pid"));
-    if (!pathPidFile.is_complete()) pathPidFile = GetDataDir() / pathPidFile;
-
-    if (fs::is_directory(fs::status(pathPidFile)) ||
-        fs::exists(fs::status(pathPidFile)))
-        pathPidFile = GetDataDir() / fs::path("prcycoind.pid");
-    
-    return pathPidFile;
+    return AbsPathForConfigVal(pathPidFile);
 }
 
 void CreatePidFile(const fs::path& path, pid_t pid)

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -44,19 +44,7 @@ int64_t GetTimeMicros()
 
 void MilliSleep(int64_t n)
 {
-/**
- * Boost's sleep_for was uninterruptable when backed by nanosleep from 1.50
- * until fixed in 1.52. Use the deprecated sleep method for the broken case.
- * See: https://svn.boost.org/trac/boost/ticket/7238
- */
-#if defined(HAVE_WORKING_BOOST_SLEEP_FOR)
     boost::this_thread::sleep_for(boost::chrono::milliseconds(n));
-#elif defined(HAVE_WORKING_BOOST_SLEEP)
-    boost::this_thread::sleep(boost::posix_time::milliseconds(n));
-#else
-//should never get here
-#error missing boost sleep implementation
-#endif
 }
 
 std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime)


### PR DESCRIPTION
> The configure script has been updated to require a detected version of at least 1.57.0, and now-redundant sub-checks have been removed. Precompiler macros that offered version or feature fallbacks have also been largely removed as they are unnecessary.
> 
> Finally, this also updates some Boost Filesystem Path codebase that was using deprecated methods, and sets the `BOOST_FILESYSTEM_NO_DEPRECATED` macro so that such methods do not get re-added to the codebase in the future.

from https://github.com/PIVX-Project/PIVX/pull/1703