### PR TITLE
[Tests] Fix/Enable all tests that were `DISABLE_PASSED_TEST`

### DIFF
--- a/src/test/Checkpoints_tests.cpp
+++ b/src/test/Checkpoints_tests.cpp
@@ -14,7 +14,6 @@
 #include <boost/test/unit_test.hpp>
 
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(Checkpoints_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(sanity)
@@ -37,4 +36,3 @@ BOOST_AUTO_TEST_CASE(sanity)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/accounting_tests.cpp
+++ b/src/test/accounting_tests.cpp
@@ -11,7 +11,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#ifdef DISABLE_PASSED_TEST
 extern CWallet* pwalletMain;
 
 BOOST_FIXTURE_TEST_SUITE(accounting_tests, TestingSetup)
@@ -139,4 +138,3 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/allocator_tests.cpp
+++ b/src/test/allocator_tests.cpp
@@ -9,7 +9,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(allocator_tests, BasicTestingSetup)
 
 // Dummy memory page locker for platform independent tests
@@ -119,4 +118,3 @@ BOOST_AUTO_TEST_CASE(test_LockedPageManagerBase)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/base32_tests.cpp
+++ b/src/test/base32_tests.cpp
@@ -7,7 +7,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(base32_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(base32_testvectors)
@@ -24,4 +23,3 @@ BOOST_AUTO_TEST_CASE(base32_testvectors)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -20,7 +20,6 @@
 
 extern UniValue read_json(const std::string& jsondata);
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(base58_tests, BasicTestingSetup)
 
 // Goal: test low-level base58 encoding functionality
@@ -274,4 +273,3 @@ BOOST_AUTO_TEST_CASE(base58_keys_invalid)
 
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/base64_tests.cpp
+++ b/src/test/base64_tests.cpp
@@ -7,7 +7,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(base64_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(base64_testvectors)
@@ -24,4 +23,3 @@ BOOST_AUTO_TEST_CASE(base64_testvectors)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -108,7 +108,6 @@ void RunTest(const TestVector &test) {
     }
 }
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(bip32_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(bip32_test1) {
@@ -120,4 +119,3 @@ BOOST_AUTO_TEST_CASE(bip32_test2) {
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -22,7 +22,6 @@
 #include <boost/tuple/tuple.hpp>
 
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(bloom_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(bloom_create_insert_serialize)
@@ -538,4 +537,3 @@ BOOST_AUTO_TEST_CASE(merkle_block_4_test_update_none)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/budget_tests.cpp
+++ b/src/test/budget_tests.cpp
@@ -10,7 +10,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(budget_tests, TestingSetup)
 
 void CheckBudgetValue(int nHeight, std::string strNetwork, CAmount nExpectedValue)
@@ -33,4 +32,3 @@ BOOST_AUTO_TEST_CASE(budget_value)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/checkblock_tests.cpp
+++ b/src/test/checkblock_tests.cpp
@@ -18,7 +18,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(CheckBlock_tests, BasicTestingSetup)
 
 bool read_block(const std::string& filename, CBlock& block)
@@ -66,4 +65,3 @@ BOOST_AUTO_TEST_CASE(May15)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -22,7 +22,6 @@
 // amounts 50 .. 21000000
 #define NUM_MULTIPLES_50BTC 420000
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(compress_tests, BasicTestingSetup)
 
 bool static TestEncode(uint64_t in) {
@@ -64,4 +63,3 @@ BOOST_AUTO_TEST_CASE(compress_amounts)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -20,7 +20,6 @@
 #include <boost/assign/list_of.hpp>
 #include <boost/test/unit_test.hpp>
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(crypto_tests, BasicTestingSetup)
 
 template<typename Hasher, typename In, typename Out>
@@ -540,4 +539,3 @@ BOOST_AUTO_TEST_CASE(aes_cbc_testvectors) {
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -11,7 +11,6 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(getarg_tests, BasicTestingSetup)
 
 static void ResetArgs(const std::string& strArg)
@@ -160,4 +159,3 @@ BOOST_AUTO_TEST_CASE(boolargno)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/hash_tests.cpp
+++ b/src/test/hash_tests.cpp
@@ -11,7 +11,6 @@
 #include <boost/test/unit_test.hpp>
 
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(hash_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(murmurhash3)
@@ -48,4 +47,3 @@ BOOST_AUTO_TEST_CASE(murmurhash3)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/hdchain_tests.cpp
+++ b/src/test/hdchain_tests.cpp
@@ -4,13 +4,14 @@
 
 #include "keystore.h"
 #include "chainparams.h"
+#include "test_prcycoin.h"
 
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
 
 
-BOOST_AUTO_TEST_SUITE(hd_tests)
+BOOST_FIXTURE_TEST_SUITE(hd_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(hd_test1)
 {

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -57,7 +57,6 @@ void dumpKeyInfo(uint256 privkey)
 }
 #endif
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(key_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(key_test1)
@@ -110,12 +109,12 @@ BOOST_AUTO_TEST_CASE(key_test1)
 
     for (int n=0; n<16; n++)
     {
-        string strMsg = strprintf("Very secret message %i: 11", n);
+        std::string strMsg = strprintf("Very secret message %i: 11", n);
         uint256 hashMsg = Hash(strMsg.begin(), strMsg.end());
 
         // normal signatures
 
-        vector<unsigned char> sign1, sign2, sign1C, sign2C;
+        std::vector<unsigned char> sign1, sign2, sign1C, sign2C;
 
         BOOST_CHECK(key1.Sign (hashMsg, sign1));
         BOOST_CHECK(key2.Sign (hashMsg, sign2));
@@ -144,7 +143,7 @@ BOOST_AUTO_TEST_CASE(key_test1)
 
         // compact signatures (with key recovery)
 
-        vector<unsigned char> csign1, csign2, csign1C, csign2C;
+        std::vector<unsigned char> csign1, csign2, csign1C, csign2C;
 
         BOOST_CHECK(key1.SignCompact (hashMsg, csign1));
         BOOST_CHECK(key2.SignCompact (hashMsg, csign2));
@@ -167,7 +166,7 @@ BOOST_AUTO_TEST_CASE(key_test1)
     // test deterministic signing
 
     std::vector<unsigned char> detsig, detsigc;
-    string strMsg = "Very deterministic message";
+    std::string strMsg = "Very deterministic message";
     uint256 hashMsg = Hash(strMsg.begin(), strMsg.end());
     BOOST_CHECK(key1.Sign(hashMsg, detsig));
     BOOST_CHECK(key1C.Sign(hashMsg, detsigc));
@@ -188,4 +187,3 @@ BOOST_AUTO_TEST_CASE(key_test1)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -9,7 +9,6 @@
 #include <boost/test/unit_test.hpp>
 #include <list>
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_AUTO_TEST_SUITE(mempool_tests)
 
 BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
@@ -101,4 +100,3 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -13,7 +13,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(miner_tests, TestingSetup)
 
 static
@@ -268,4 +267,3 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -27,7 +27,6 @@ public:
     }
 };
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(pmt_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(pmt_test1)
@@ -107,4 +106,3 @@ BOOST_AUTO_TEST_CASE(pmt_test1)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -9,7 +9,7 @@
 #include "serialize.h"
 #include "streams.h"
 
-#include "test/test_pivx.h"
+#include "test/test_prcycoin.h"
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/reverselock_tests.cpp
+++ b/src/test/reverselock_tests.cpp
@@ -11,7 +11,6 @@
 #include <boost/thread.hpp>
 #include <boost/test/unit_test.hpp>
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_AUTO_TEST_SUITE(reverselock_tests)
 BOOST_AUTO_TEST_CASE(reverselock_basics)
         {
@@ -53,4 +52,3 @@ BOOST_AUTO_TEST_CASE(reverselock_errors)
         }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/sanity_tests.cpp
+++ b/src/test/sanity_tests.cpp
@@ -8,7 +8,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(sanity_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(basic_sanity)
@@ -19,4 +18,3 @@ BOOST_AUTO_TEST_CASE(basic_sanity)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -17,7 +17,6 @@
 #include <boost/thread.hpp>
 #include <boost/test/unit_test.hpp>
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_AUTO_TEST_SUITE(scheduler_tests)
 
 static void microTask(CScheduler &s, boost::mutex &mutex, int &counter, int delta,
@@ -117,4 +116,3 @@ BOOST_AUTO_TEST_CASE(manythreads)
         }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/scriptnum_tests.cpp
+++ b/src/test/scriptnum_tests.cpp
@@ -10,7 +10,6 @@
 #include <limits.h>
 #include <stdint.h>
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(scriptnum_tests, BasicTestingSetup)
 
 static const long values[] = \
@@ -198,4 +197,3 @@ BOOST_AUTO_TEST_CASE(operators)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -15,14 +15,13 @@
 
 
 // Helpers:
-/*static std::vector<unsigned char>
+static std::vector<unsigned char>
 Serialize(const CScript& s)
 {
     std::vector<unsigned char> sSerialized(s.begin(), s.end());
     return sSerialized;
-}*/
+}
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(sigopcount_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(GetSigOpCount)
@@ -64,4 +63,3 @@ BOOST_AUTO_TEST_CASE(GetSigOpCount)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -12,7 +12,6 @@
 
 #define SKIPLIST_LENGTH 300000
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(skiplist_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(skiplist_test)
@@ -101,4 +100,3 @@ BOOST_AUTO_TEST_CASE(getlocator_test)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/test_prcycoin.cpp
+++ b/src/test/test_prcycoin.cpp
@@ -48,7 +48,7 @@ TestingSetup::TestingSetup()
         bitdb.MakeMock();
 #endif
         ClearDatadirCache();
-        pathTemp = GetTempPath() / strprintf("test_pivx_%lu_%i", (unsigned long)GetTime(), (int)(InsecureRandRange(100000)));
+        pathTemp = GetTempPath() / strprintf("test_prcycoin_%lu_%i", (unsigned long)GetTime(), (int)(InsecureRandRange(100000)));
         fs::create_directories(pathTemp);
         mapArgs["-datadir"] = pathTemp.string();
         pblocktree = new CBlockTreeDB(1 << 20, true);

--- a/src/test/timedata_tests.cpp
+++ b/src/test/timedata_tests.cpp
@@ -7,7 +7,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(timedata_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(util_MedianFilter)
@@ -36,4 +35,3 @@ BOOST_AUTO_TEST_CASE(util_MedianFilter)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/torcontrol_tests.cpp
+++ b/src/test/torcontrol_tests.cpp
@@ -6,7 +6,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_AUTO_TEST_SUITE(torcontrol_tests)
 
 void CheckSplitTorReplyLine(std::string input, std::string command, std::string args)
@@ -196,4 +195,3 @@ BOOST_AUTO_TEST_CASE(util_ParseTorReplyMapping)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/univalue_tests.cpp
+++ b/src/test/univalue_tests.cpp
@@ -12,7 +12,6 @@
 #include <boost/test/unit_test.hpp>
 
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(univalue_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(univalue_constructor)
@@ -52,7 +51,7 @@ BOOST_AUTO_TEST_CASE(univalue_constructor)
                 BOOST_CHECK(v7.isNum());
                 BOOST_CHECK_EQUAL(v7.getValStr(), "-7.21");
 
-                string vs("yawn");
+                std::string vs("yawn");
                 UniValue v8(vs);
                 BOOST_CHECK(v8.isStr());
                 BOOST_CHECK_EQUAL(v8.getValStr(), "yawn");
@@ -68,41 +67,41 @@ BOOST_AUTO_TEST_CASE(univalue_typecheck)
                 UniValue v1;
                 BOOST_CHECK(v1.setNumStr("1"));
                 BOOST_CHECK(v1.isNum());
-                BOOST_CHECK_THROW(v1.get_bool(), runtime_error);
+                BOOST_CHECK_THROW(v1.get_bool(), std::runtime_error);
 
                 UniValue v2;
                 BOOST_CHECK(v2.setBool(true));
                 BOOST_CHECK_EQUAL(v2.get_bool(), true);
-                BOOST_CHECK_THROW(v2.get_int(), runtime_error);
+                BOOST_CHECK_THROW(v2.get_int(), std::runtime_error);
 
                 UniValue v3;
                 BOOST_CHECK(v3.setNumStr("32482348723847471234"));
-                BOOST_CHECK_THROW(v3.get_int64(), runtime_error);
+                BOOST_CHECK_THROW(v3.get_int64(), std::runtime_error);
                 BOOST_CHECK(v3.setNumStr("1000"));
                 BOOST_CHECK_EQUAL(v3.get_int64(), 1000);
 
                 UniValue v4;
                 BOOST_CHECK(v4.setNumStr("2147483648"));
                 BOOST_CHECK_EQUAL(v4.get_int64(), 2147483648);
-                BOOST_CHECK_THROW(v4.get_int(), runtime_error);
+                BOOST_CHECK_THROW(v4.get_int(), std::runtime_error);
                 BOOST_CHECK(v4.setNumStr("1000"));
                 BOOST_CHECK_EQUAL(v4.get_int(), 1000);
-                BOOST_CHECK_THROW(v4.get_str(), runtime_error);
+                BOOST_CHECK_THROW(v4.get_str(), std::runtime_error);
                 BOOST_CHECK_EQUAL(v4.get_real(), 1000);
-                BOOST_CHECK_THROW(v4.get_array(), runtime_error);
-                BOOST_CHECK_THROW(v4.getKeys(), runtime_error);
-                BOOST_CHECK_THROW(v4.getValues(), runtime_error);
-                BOOST_CHECK_THROW(v4.get_obj(), runtime_error);
+                BOOST_CHECK_THROW(v4.get_array(), std::runtime_error);
+                BOOST_CHECK_THROW(v4.getKeys(), std::runtime_error);
+                BOOST_CHECK_THROW(v4.getValues(), std::runtime_error);
+                BOOST_CHECK_THROW(v4.get_obj(), std::runtime_error);
 
                 UniValue v5;
                 BOOST_CHECK(v5.read("[true, 10]"));
                 BOOST_CHECK_NO_THROW(v5.get_array());
                 std::vector<UniValue> vals = v5.getValues();
-                BOOST_CHECK_THROW(vals[0].get_int(), runtime_error);
+                BOOST_CHECK_THROW(vals[0].get_int(), std::runtime_error);
                 BOOST_CHECK_EQUAL(vals[0].get_bool(), true);
 
                 BOOST_CHECK_EQUAL(vals[1].get_int(), 10);
-                BOOST_CHECK_THROW(vals[1].get_bool(), runtime_error);
+                BOOST_CHECK_THROW(vals[1].get_bool(), std::runtime_error);
         }
 
 BOOST_AUTO_TEST_CASE(univalue_set)
@@ -171,13 +170,13 @@ BOOST_AUTO_TEST_CASE(univalue_array)
                 UniValue v((int64_t)1023LL);
                 BOOST_CHECK(arr.push_back(v));
 
-                string vStr("zippy");
+                std::string vStr("zippy");
                 BOOST_CHECK(arr.push_back(vStr));
 
                 const char *s = "pippy";
                 BOOST_CHECK(arr.push_back(s));
 
-                vector<UniValue> vec;
+                std::vector<UniValue> vec;
                 v.setStr("boing");
                 vec.push_back(v);
 
@@ -205,7 +204,7 @@ BOOST_AUTO_TEST_CASE(univalue_array)
 BOOST_AUTO_TEST_CASE(univalue_object)
         {
                 UniValue obj(UniValue::VOBJ);
-                string strKey, strVal;
+                std::string strKey, strVal;
                 UniValue v;
 
                 strKey = "age";
@@ -265,7 +264,7 @@ BOOST_AUTO_TEST_CASE(univalue_object)
 
                 BOOST_CHECK(!obj.exists("nyuknyuknyuk"));
 
-                map<string, UniValue::VType> objTypes;
+                std::map<std::string, UniValue::VType> objTypes;
                 objTypes["age"] = UniValue::VNUM;
                 objTypes["first"] = UniValue::VSTR;
                 objTypes["last"] = UniValue::VSTR;
@@ -293,7 +292,7 @@ BOOST_AUTO_TEST_CASE(univalue_readwrite)
                 UniValue v;
                 BOOST_CHECK(v.read(json1));
 
-                string strJson1(json1);
+                std::string strJson1(json1);
                 BOOST_CHECK(v.read(strJson1));
 
                 BOOST_CHECK(v.isArray());
@@ -315,4 +314,3 @@ BOOST_AUTO_TEST_CASE(univalue_readwrite)
         }
 
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -17,7 +17,6 @@
 #include <boost/test/unit_test.hpp>
 
 
-#ifdef DISABLE_PASSED_TEST
 BOOST_FIXTURE_TEST_SUITE(util_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(util_criticalsection)
@@ -425,4 +424,3 @@ BOOST_AUTO_TEST_CASE(test_FormatSubVersion)
     BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments2),std::string("/Test:0.9.99(comment1; comment2)/"));
 }
 BOOST_AUTO_TEST_SUITE_END()
-#endif


### PR DESCRIPTION
Tests compile by default unless explicitly disabled during configure - this would cause unexpected compile errors due to the `ifdef DISABLE_PASSED_TEST` / `#endif`

This removes that definition and also fixes any tests that were failing to compile due to missing `std::` conversions and incorrect includes.