### PR TITLE
[Wallet] Fix runtime_error with -disablewallet

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1961,12 +1961,11 @@ bool AppInit2(bool isDaemon)
         }
         //read decoy confirmation min
         pwalletMain->DecoyConfirmationMinimum = GetArg("-decoyconfirm", 15);
+        CWalletDB walletdb(strWalletFile);
+        double reserveBalance;
+        if (walletdb.ReadReserveAmount(reserveBalance))
+            nReserveBalance = reserveBalance * COIN;
     }
-
-    CWalletDB walletdb(strWalletFile);
-    double reserveBalance;
-    if (walletdb.ReadReserveAmount(reserveBalance))
-        nReserveBalance = reserveBalance * COIN;
 #endif
 
     return !fRequestShutdown;


### PR DESCRIPTION
Fixes this error on init when running with -disablewallet

```
************************
EXCEPTION: St13runtime_error       
CDB : Error 2, can't open database wallet.dat       
prcycoin in AppInit()
```