### PR TITLE
[Upstream] [GUI] Start masternodes polling timer only when is needed.

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -49,8 +49,6 @@ ClientModel::ClientModel(OptionsModel* optionsModel, QObject* parent) : QObject(
 
     pollMnTimer = new QTimer(this);
     connect(pollMnTimer, SIGNAL(timeout()), this, SLOT(updateMnTimer()));
-    // no need to update as frequent as data for balances/txes/blocks
-    pollMnTimer->start(MODEL_UPDATE_DELAY * 40);
 
     subscribeToCoreSignals();
 }
@@ -147,6 +145,21 @@ void ClientModel::updateMnTimer()
         cachedMasternodeCountString = newMasternodeCountString;
 
         Q_EMIT strMasternodesChanged(cachedMasternodeCountString);
+    }
+}
+
+void ClientModel::startMasternodesTimer()
+{
+    if (!pollMnTimer->isActive()) {
+        // no need to update as frequent as data for balances/txes/blocks
+        pollMnTimer->start(MODEL_UPDATE_DELAY * 40);
+    }
+}
+
+void ClientModel::stopMasternodesTimer()
+{
+    if (pollMnTimer->isActive()) {
+        pollMnTimer->stop();
     }
 }
 

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -83,6 +83,10 @@ public:
 
     bool getTorInfo(std::string& ip_port) const;
 
+    // Start/Stop the masternode polling timer
+    void startMasternodesTimer();
+    void stopMasternodesTimer();
+
     void setCacheTip(const CBlockIndex* const tip) { cacheTip = tip; }
     void setCacheReindexing(bool reindex) { cachedReindexing = reindex; }
     void setCacheImporting(bool import) { cachedImporting = import; }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -939,6 +939,7 @@ void RPCConsole::showEvent(QShowEvent* event)
 
     // start PeerTableModel auto refresh
     clientModel->getPeerTableModel()->startAutoRefresh();
+    clientModel->startMasternodesTimer();
 }
 
 void RPCConsole::hideEvent(QHideEvent* event)
@@ -950,6 +951,7 @@ void RPCConsole::hideEvent(QHideEvent* event)
 
     // stop PeerTableModel auto refresh
     clientModel->getPeerTableModel()->stopAutoRefresh();
+    clientModel->stopMasternodesTimer();
 }
 
 void RPCConsole::showDataDir()


### PR DESCRIPTION
> The masternodes polling was starting when the clientModel object is generated, locking `cs_main` every certain amount of time without care on whether the information is being presented or not. This PR changes it, the polling timer will only be started when the information is needed on the screen and stopped when the user leaves such screen.

from https://github.com/PIVX-Project/PIVX/pull/1782
