### PR TITLE
[Wallet][Model] Use const CAmount minStakingAmount / access Params() only from walletModel

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3175,6 +3175,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     }
 
     if (block.IsProofOfStake()) {
+        const CAmount minStakingAmount = Params().MinimumStakeAmount();
         const CTransaction coinstake = block.vtx[1];
         size_t numUTXO = coinstake.vout.size();
         if (mapBlockIndex.count(block.hashPrevBlock) < 1) {
@@ -3186,8 +3187,9 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         if (!VerifyDerivedAddress(mnOut, mnsa))
             return state.DoS(100, error("ConnectBlock() : Incorrect derived address for masternode rewards"));
 
-        if (nHeight >= Params().HardFork() && nValueIn < Params().MinimumStakeAmount())
-            return state.DoS(100, error("ConnectBlock() : Incorrect Minimum Stake Amount"));
+        if (nHeight >= Params().HardFork() && nValueIn < minStakingAmount)
+            return state.DoS(100, error("ConnectBlock() : amount (%d) not allowed for staking. Min amount: %d",
+                    __func__, nValueIn, minStakingAmount), REJECT_INVALID, "bad-txns-stake");
     }
 
     // track money supply and mint amount info

--- a/src/qt/optionspage.cpp
+++ b/src/qt/optionspage.cpp
@@ -531,12 +531,13 @@ void OptionsPage::on_EnableStaking(ToggleButton* widget)
             pwalletMain->combineMode = CombineMode::ON;
             saveConsolidationSettingTime(ui->addNewFunds->isChecked());
             bool success = false;
+            const CAmount minStakingAmount = Params().MinimumStakeAmount();
             try {
                 uint32_t nTime = pwalletMain->ReadAutoConsolidateSettingTime();
                 nTime = (nTime == 0)? GetAdjustedTime() : nTime;
                 success = model->getCWallet()->CreateSweepingTransaction(
-                                Params().MinimumStakeAmount(),
-                                Params().MinimumStakeAmount(), nTime);
+                                minStakingAmount,
+                                minStakingAmount, nTime);
                 if (success) {
                     //nConsolidationTime = 1800;
                     QString msg = "Consolidation transaction created!";
@@ -589,7 +590,7 @@ void OptionsPage::on_EnableStaking(ToggleButton* widget)
                     try {
                         success = model->getCWallet()->SendToStealthAddress(
                                 masterAddr,
-                                Params().MinimumStakeAmount(),
+                                minStakingAmount,
                                 resultTx,
                                 false
                         );

--- a/src/qt/optionspage.cpp
+++ b/src/qt/optionspage.cpp
@@ -531,7 +531,7 @@ void OptionsPage::on_EnableStaking(ToggleButton* widget)
             pwalletMain->combineMode = CombineMode::ON;
             saveConsolidationSettingTime(ui->addNewFunds->isChecked());
             bool success = false;
-            const CAmount minStakingAmount = Params().MinimumStakeAmount();
+            const CAmount minStakingAmount = model->getMinStakingAmount();;
             try {
                 uint32_t nTime = pwalletMain->ReadAutoConsolidateSettingTime();
                 nTime = (nTime == 0)? GetAdjustedTime() : nTime;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -69,6 +69,11 @@ WalletModel::~WalletModel()
     unsubscribeFromCoreSignals();
 }
 
+CAmount WalletModel::getMinStakingAmount() const
+{
+    return Params().MinimumStakeAmount();
+}
+
 CAmount WalletModel::getBalance(const CCoinControl* coinControl) const
 {
     if (coinControl) {

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -710,19 +710,20 @@ StakingStatusError WalletModel::getStakingStatusError(QString& error)
     /* {
         bool fMintable = wallet->MintableCoins();
         CAmount balance = wallet->GetSpendableBalance();
+        const CAmount minStakingAmount = Params().MinimumStakeAmount();
         if (!fMintable || nReserveBalance > balance) {
-            if (balance < Params().MinimumStakeAmount()) {
-                error = "\nBalance is under the minimum 400,000 staking threshold.\nPlease send more PRCY to this wallet.\n";
+            if (balance < minStakingAmount) {
+                error = "\nBalance is under the minimum 2,5000 staking threshold.\nPlease send more PRCY to this wallet.\n";
                 return StakingStatusError::STAKING_OK;
             }
-            if (nReserveBalance > balance || (balance > nReserveBalance && balance - nReserveBalance < Params().MinimumStakeAmount())) {
+            if (nReserveBalance > balance || (balance > nReserveBalance && balance - nReserveBalance < minStakingAmount)) {
                 error = "Reserve balance is too high.\nPlease lower it in order to turn staking on.";
                 return StakingStatusError::RESERVE_TOO_HIGH;
             }
             if (!fMintable) {
-                if (balance > Params().MinimumStakeAmount()) {
-                    //10 is to cover transaction fees
-                    if (balance >= Params().MinimumStakeAmount() + 10*COIN) {
+                if (balance > minStakingAmount) {
+                    //1 is to cover transaction fees
+                    if (balance >= minStakingAmount + 1*COIN) {
                         error = "Not enough mintable coins.\nDo you want to merge & make a sent-to-yourself transaction to make the wallet stakable?";
                         return StakingStatusError::UTXO_UNDER_THRESHOLD;
                     }

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -136,6 +136,8 @@ public:
 
     bool isShutdownRequested();
 
+    CAmount getMinStakingAmount() const;
+
     CAmount getBalance(const CCoinControl* coinControl = NULL) const;
     CAmount getUnconfirmedBalance() const;
     CAmount getImmatureBalance() const;


### PR DESCRIPTION
dfc732be - Use const CAmount minStakingAmount where possible instead of accessing Params directly
8da9aeaf - based on this commmit: https://github.com/PIVX-Project/PIVX/commit/4ad94922e33190279fc52439b731f3d34ce748ab / comment: https://github.com/PIVX-Project/PIVX/pull/1174#issuecomment-562321755  
> to keep the abstraction from the backend, calls to chain params are executed only from the mode

Also adds a more informative error message for "Incorrect Minimum Stake Amount"