### PR TITLE
[Net] [Cleanup] Fix ProcessMessage(s) / Edit IsUnsupportedVersion to DisconnectOldVersion

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6002,9 +6002,6 @@ void static ProcessGetData(CNode* pfrom)
 
 bool static ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, int64_t nTimeReceived)
 {
-    CNodeState* state = State(pfrom->GetId());
-    if (state == NULL)
-        return false;
     LogPrint(BCLog::NET, "received: %s (%u bytes) peer=%d, chainheight=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->id, chainActive.Height());
     if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0) {
         LogPrintf("dropmessagestest DROPPING RECV MESSAGE\n");
@@ -6057,7 +6054,6 @@ bool static ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vR
         if (IsUnsupportedVersion(pfrom->strSubVer, chainActive.Height())) {
                 // disconnect from peers other than these sub versions
                 LogPrintf("peer %s using unsupported version %s; disconnecting and banning\n", pfrom->addr.ToString().c_str(), pfrom->strSubVer.c_str());
-                state->fShouldBan = true;
                 pfrom->fDisconnect = true;
                 return false;
         }
@@ -6799,11 +6795,8 @@ bool ProcessMessages(CNode* pfrom)
     //
     bool fOk = true;
 
-    if (!pfrom) return false;
-
-    if (!pfrom->vRecvGetData.empty()) {
+    if (!pfrom->vRecvGetData.empty())
         ProcessGetData(pfrom);
-    }
 
     // this maintains the order of responses
     if (!pfrom->vRecvGetData.empty()) return fOk;
@@ -6813,6 +6806,7 @@ bool ProcessMessages(CNode* pfrom)
         // Don't bother if send buffer is too full to respond anyway
         if (pfrom->nSendSize >= SendBufferSize())
             break;
+
         // get next message
         CNetMessage& msg = *it;
 
@@ -6825,8 +6819,7 @@ bool ProcessMessages(CNode* pfrom)
 
         // Scan for message start
         if (memcmp(msg.hdr.pchMessageStart, Params().MessageStart(), MESSAGE_START_SIZE) != 0) {
-            LogPrintf("PROCESSMESSAGE: INVALID MESSAGESTART %s peer=%d\n", SanitizeString(msg.hdr.GetCommand()),
-                pfrom->id);
+            LogPrintf("PROCESSMESSAGE: INVALID MESSAGESTART %s peer=%d\n", SanitizeString(msg.hdr.GetCommand()), pfrom->id);
             fOk = false;
             break;
         }
@@ -6851,6 +6844,7 @@ bool ProcessMessages(CNode* pfrom)
                 SanitizeString(strCommand), nMessageSize, nChecksum, hdr.nChecksum);
             continue;
         }
+
         // Process message
         bool fRet = false;
         try {
@@ -6860,13 +6854,10 @@ bool ProcessMessages(CNode* pfrom)
             pfrom->PushMessage(NetMsgType::REJECT, strCommand, REJECT_MALFORMED, std::string("error parsing message"));
             if (strstr(e.what(), "end of data")) {
                 // Allow exceptions from under-length message on vRecv
-                LogPrintf(
-                    "ProcessMessages(%s, %u bytes): Exception '%s' caught, normally caused by a message being shorter than its stated length\n",
-                    SanitizeString(strCommand), nMessageSize, e.what());
+                LogPrintf("ProcessMessages(%s, %u bytes): Exception '%s' caught, normally caused by a message being shorter than its stated length\n", SanitizeString(strCommand), nMessageSize, e.what());
             } else if (strstr(e.what(), "size too large")) {
                 // Allow exceptions from over-long size
-                LogPrintf("ProcessMessages(%s, %u bytes): Exception '%s' caught\n", SanitizeString(strCommand),
-                    nMessageSize, e.what());
+                LogPrintf("ProcessMessages(%s, %u bytes): Exception '%s' caught\n", SanitizeString(strCommand), nMessageSize, e.what());
             } else {
                 PrintExceptionContinue(&e, "ProcessMessages()");
             }
@@ -6879,8 +6870,7 @@ bool ProcessMessages(CNode* pfrom)
         }
 
         if (!fRet)
-            LogPrintf("ProcessMessage(%s, %u bytes) FAILED peer=%d\n", SanitizeString(strCommand), nMessageSize,
-                pfrom->id);
+            LogPrintf("ProcessMessage(%s, %u bytes) FAILED peer=%d\n", SanitizeString(strCommand), nMessageSize, pfrom->id);
 
         break;
     }
@@ -6888,6 +6878,7 @@ bool ProcessMessages(CNode* pfrom)
     // In case the connection got shut down, its receive buffer was wiped
     if (!pfrom->fDisconnect)
         pfrom->vRecvMsg.erase(pfrom->vRecvMsg.begin(), it);
+
     return fOk;
 }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -127,13 +127,6 @@ unsigned short GetListenPort() {
     return (unsigned short) (GetArg("-port", Params().GetDefaultPort()));
 }
 
-bool IsUnsupportedVersion(std::string strSubVer, int nHeight) {
-    /*if (nHeight >= Params().HardFork()) {
-        return (strSubVer == "/PRCY:1.0.0.2/" || strSubVer == "/PRCY:1.0.0.3/" || strSubVer == "/PRCY:1.0.0.4/" || strSubVer == "/PRCY:1.0.0.5/" || strSubVer == "/PRCY:1.0.0.6/" || strSubVer == "/PRCY:1.0.0.7/");
-    }*/
-    return (strSubVer == "/PRCY:1.0.0.2/" || strSubVer == "/PRCY:1.0.0.3/" || strSubVer == "/PRCY:1.0.0.4/" || strSubVer == "/PRCY:1.0.0.5/" || strSubVer == "/PRCY:1.0.0.6/" || strSubVer == "/PRCY:1.0.0.7/" || strSubVer == "/PRCY:1.0.0.8/" || strSubVer == "/PRCY:1.0.0.9/");
-}
-
 // find 'best' local address for a particular peer
 bool GetLocal(CService &addr, const CNetAddr *paddrPeer) {
     if (!fListen)
@@ -455,6 +448,22 @@ bool CNode::DisconnectOldProtocol(int nVersionRequired, std::string strLastComma
         fDisconnect = true;
     }
 
+    return fDisconnect;
+}
+
+bool CNode::DisconnectOldVersion(std::string strSubVer, int nHeight, std::string strLastCommand) {
+    fDisconnect = false;
+    //if (nHeight >= Params().HardFork()) {
+        if (strSubVer == "/PRCY:1.0.0.2/" || strSubVer == "/PRCY:1.0.0.3/" ||
+                strSubVer == "/PRCY:1.0.0.4/" || strSubVer == "/PRCY:1.0.0.5/" ||
+                strSubVer == "/PRCY:1.0.0.6/" || strSubVer == "/PRCY:1.0.0.7/" ||
+                strSubVer == "/PRCY:1.0.0.8/" || strSubVer == "/PRCY:1.0.0.9/") {
+            LogPrintf("%s : peer=%d using unsupported version %i; disconnecting\n",  __func__, id, strSubVer);
+            PushMessage(NetMsgType::REJECT, strLastCommand, REJECT_OBSOLETE,
+                        strprintf("Using unsupported version %i; disconnecting\n", strSubVer));
+            fDisconnect = true;
+        }
+    //}
     return fDisconnect;
 }
 

--- a/src/net.h
+++ b/src/net.h
@@ -713,6 +713,7 @@ public:
     void CancelSubscribe(unsigned int nChannel);
     void CloseSocketDisconnect();
     bool DisconnectOldProtocol(int nVersionRequired, std::string strLastCommand = "");
+    bool DisconnectOldVersion(std::string strSubVer, int nHeight, std::string strLastCommand = "");
 
     // Denial-of-service detection/prevention
     // The idea is to detect peers that are behaving
@@ -791,8 +792,6 @@ public:
     bool Write(const banmap_t& banSet);
     bool Read(banmap_t& banSet);
 };
-
-bool IsUnsupportedVersion(std::string strSubVer, int nHeight);
 
 struct AddedNodeInfo {
     std::string strAddedNode;


### PR DESCRIPTION
This fixes the following errors that were showing up in the debug.log since #249:
```
ProcessMessage(version, 100 bytes) FAILED peer=1
ProcessMessage(verack, 0 bytes) FAILED peer=1
ProcessMessage(ping, 8 bytes) FAILED peer=1
ProcessMessage(addr, 31 bytes) FAILED peer=1
ProcessMessage(inv, 37 bytes) FAILED peer=1
```
The cause was returning false immediately if CNodeState* state was NULL. This was causing the Qt Wallet to be blocked attempting to Process Messages from peers until there was a state. This was only added for our IsUnsupportedVersion function that we use to block older versions, but can be done with a better approach: Rename and edit our IsUnsupportedVersion to align with DisconnectOldProtocol.