### PR TITLE
[GitHub Actions] Update actions/checkout to v3

### DIFF
--- a/.github/workflows/prcy-build-factory-debug.yml
+++ b/.github/workflows/prcy-build-factory-debug.yml
@@ -16,7 +16,7 @@ jobs:
       ARTIFACT_DIR: source
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Create Version Variable
       run: |
         export VERSION=$(cat version.txt | sed 's/[^0-9,.]//g')

--- a/.github/workflows/prcy-build-factory-ubuntu20.yml
+++ b/.github/workflows/prcy-build-factory-ubuntu20.yml
@@ -16,7 +16,7 @@ jobs:
       ARTIFACT_DIR: source
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Create Version Variable
       run: |
         export VERSION=$(cat version.txt | sed 's/[^0-9,.]//g')

--- a/.github/workflows/prcy-build-factory.yml
+++ b/.github/workflows/prcy-build-factory.yml
@@ -15,7 +15,7 @@ jobs:
       ARTIFACT_DIR: source
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Create Version Variable
       run: |
         export VERSION=$(cat version.txt | sed 's/[^0-9,.]//g')


### PR DESCRIPTION
Solving the following in our GitHub Actions Workflows: 
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2