### PR TITLE
[Qt] "Request passphrase before sending any transactions" setting

### DIFF
--- a/src/qt/forms/optionspage.ui
+++ b/src/qt/forms/optionspage.ui
@@ -272,6 +272,13 @@
              </widget>
             </item>
             <item>
+             <widget class="QCheckBox" name="alwaysRequestPassphrase">
+              <property name="text">
+               <string>Request passphrase before sending any transactions</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QLabel" name="label_3">
               <property name="text">
                <string>Remember my authentication code for</string>

--- a/src/qt/optionspage.cpp
+++ b/src/qt/optionspage.cpp
@@ -155,6 +155,7 @@ OptionsPage::OptionsPage(QWidget* parent) : QDialog(parent, Qt::WindowSystemMenu
     ui->minimizeToTray->setChecked(settings.value("fMinimizeToTray", false).toBool());
     ui->minimizeOnClose->setChecked(settings.value("fMinimizeOnClose", false).toBool());
     ui->alwaysRequest2FA->setChecked(settings.value("fAlwaysRequest2FA", false).toBool());
+    ui->alwaysRequestPassphrase->setChecked(settings.value("fAlwaysRequestPassphrase", false).toBool());
     ui->hideBalanceStaking->setChecked(settings.value("fHideBalance", false).toBool());
     ui->lockSendStaking->setChecked(settings.value("fLockSendStaking", false).toBool());
     ui->displayCurrencyValue->setChecked(settings.value("fDisplayCurrencyValue", false).toBool());
@@ -994,6 +995,16 @@ void OptionsPage::alwaysRequest2FA_clicked(int state)
         settings.setValue("fAlwaysRequest2FA", true);
     } else {
         settings.setValue("fAlwaysRequest2FA", false);
+    }
+}
+
+void OptionsPage::alwaysRequestPassphrase_clicked(int state)
+{
+    checkForUnlock();
+    if (ui->alwaysRequestPassphrase->isChecked()) {
+        settings.setValue("fAlwaysRequestPassphrase", true);
+    } else {
+        settings.setValue("fAlwaysRequestPassphrase", false);
     }
 }
 

--- a/src/qt/optionspage.h
+++ b/src/qt/optionspage.h
@@ -102,6 +102,7 @@ private Q_SLOTS:
     void minimizeOnClose_clicked(int);
     void changeDigits(int);
     void alwaysRequest2FA_clicked(int);
+    void alwaysRequestPassphrase_clicked(int);
     void hideBalanceStaking_clicked(int);
     void lockSendStaking_clicked(int);
     void checkForUnlock();

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -160,6 +160,7 @@ void SendCoinsDialog::on_sendButton_clicked(){
     bool isValidAddresss = (regex_match(address.toStdString(), std::regex("[a-zA-z0-9]+")))&&(address.length()==99||address.length()==110);
     bool isValidAmount = ((recipient.amount>0) && (recipient.amount<=balance));
     bool fAlwaysRequest2FA = settings.value("fAlwaysRequest2FA").toBool();
+    bool fAlwaysRequestPassphrase = settings.value("fAlwaysRequestPassphrase").toBool();
 
     form->errorAddress(isValidAddresss);
     form->errorAmount(isValidAmount);
@@ -189,7 +190,7 @@ void SendCoinsDialog::on_sendButton_clicked(){
     // and make many transactions while unlocking through this dialog
     // will call relock
     WalletModel::EncryptionStatus encStatus = model->getEncryptionStatus();
-    if (encStatus == model->Locked || encStatus == model->UnlockedForStakingOnly) {
+    if (encStatus == model->Locked || encStatus == model->UnlockedForStakingOnly || fAlwaysRequestPassphrase) {
         WalletModel::UnlockContext ctx(model->requestUnlock(AskPassphraseDialog::Context::Send, true));
         if (!ctx.isValid()) {
             // Unlock wallet was cancelled


### PR DESCRIPTION
Similar to 2FA before, offer a setting to "Request passphrase before sending any transactions" - they can be used together.