### PR TITLE
[Wallet] Restore inSpendQueueOutpoints to AvailableCoins

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1985,6 +1985,9 @@ bool CWallet::AvailableCoins(const uint256 wtxid, const CWalletTx* pcoin, std::v
                 if (IsCollateralized(outpoint)) {
                     continue;
                 }
+                if (inSpendQueueOutpoints.count(outpoint)) {
+                    continue;
+                }
                 found = true;
             }
             if (!found) continue;


### PR DESCRIPTION
AvailableCoins was not checking for inSpendQueueOutpoints, this fixes that