### PR TITLE
[Net] Restore check for Importing/IBD on resend wallet transactions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6989,7 +6989,7 @@ bool SendMessages(CNode* pto)
         // Resend wallet transactions that haven't gotten in a block yet
         // Except during reindex, importing and IBD, when old wallet
         // transactions become unconfirmed and spams other nodes.
-        if (!fReindex) {
+        if (!fReindex && !fImporting && !IsInitialBlockDownload()) {
             GetMainSignals().Broadcast();
         }
 


### PR DESCRIPTION
These were incorrectly removed at some point. Restoring them, as per the comment above it:
> // Resend wallet transactions that haven't gotten in a block yet
> // Except during reindex, **_importing and IBD_**, when old wallet
> // transactions become unconfirmed and spams other nodes.