### PR TITLE
[Upstream] Remove obsolete reference to CValidationState from UpdateCoins.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2636,7 +2636,7 @@ void static InvalidBlockFound(CBlockIndex* pindex, const CValidationState& state
     }
 }
 
-void UpdateCoins(const CTransaction& tx, CValidationState& state, CCoinsViewCache& inputs, CTxUndo& txundo, int nHeight)
+void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo& txundo, int nHeight)
 {
     // mark inputs spent
     if (!tx.IsCoinAudit() && !tx.IsCoinBase() && tx.IsCoinStake()) {
@@ -3168,7 +3168,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         if (i > 0) {
             blockundo.vtxundo.emplace_back();
         }
-        UpdateCoins(tx, state, view, i == 0 ? undoDummy : blockundo.vtxundo.back(), nHeight);
+        UpdateCoins(tx, view, i == 0 ? undoDummy : blockundo.vtxundo.back(), nHeight);
 
         vPos.emplace_back(tx.GetHash(), pos);
         pos.nTxOffset += ::GetSerializeSize(tx, SER_DISK, CLIENT_VERSION);

--- a/src/main.h
+++ b/src/main.h
@@ -322,7 +322,7 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
 bool CheckInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& view, bool fScriptChecks, unsigned int flags, bool cacheStore, std::vector<CScriptCheck>* pvChecks = NULL);
 
 /** Apply the effects of this transaction on the UTXO set represented by view */
-void UpdateCoins(const CTransaction& tx, CValidationState& state, CCoinsViewCache& inputs, CTxUndo& txundo, int nHeight);
+void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo& txundo, int nHeight);
 
 /** Context-independent validity checks */
 bool IsTransactionInChain(uint256 txId, int& nHeightTx);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -360,7 +360,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, const CPubKey& txP
 
             CTxUndo txundo;
             if (tx.IsCoinStake()) {
-                UpdateCoins(tx, state, view, txundo, nHeight);
+                UpdateCoins(tx, view, txundo, nHeight);
             }
 
             // Added

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -579,7 +579,7 @@ void CTxMemPool::check(const CCoinsViewCache* pcoins) const
             CValidationState state;
             CTxUndo undo;
             assert(CheckInputs(tx, state, mempoolDuplicate, false, 0, false, NULL));
-            UpdateCoins(tx, state, mempoolDuplicate, undo, 1000000);
+            UpdateCoins(tx, mempoolDuplicate, undo, 1000000);
         }
     }
     unsigned int stepsSinceLastRemove = 0;
@@ -594,7 +594,7 @@ void CTxMemPool::check(const CCoinsViewCache* pcoins) const
         } else {
             assert(CheckInputs(entry->GetTx(), state, mempoolDuplicate, false, 0, false, NULL));
             CTxUndo undo;
-            UpdateCoins(entry->GetTx(), state, mempoolDuplicate, undo, 1000000);
+            UpdateCoins(entry->GetTx(), mempoolDuplicate, undo, 1000000);
             stepsSinceLastRemove = 0;
         }
     }


### PR DESCRIPTION
> Coming from btc@c8b92486c4eca1287546b0683b6af3551db1fe67

Cherry-pick from https://github.com/PIVX-Project/PIVX/pull/1631 (leaving out the first commit as we do not have zerocoin)