### PR TITLE
[Upstream] [Consensus] Time checks

### DIFF
--- a/src/kernel.h
+++ b/src/kernel.h
@@ -33,7 +33,7 @@ bool Stake(CStakeInput* stakeInput, unsigned int nBits, unsigned int nTimeBlockF
 
 // Check kernel hash target and coinstake signature
 // Sets hashProofOfStake on success return
-bool CheckProofOfStake(const CBlock block, uint256& hashProofOfStake, std::unique_ptr<CStakeInput>& stake);
+bool CheckProofOfStake(const CBlock block, uint256& hashProofOfStake, std::unique_ptr<CStakeInput>& stake, int nPreviousBlockHeight);
 
 // Get stake modifier checksum
 unsigned int GetStakeModifierChecksum(const CBlockIndex* pindex);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4575,7 +4575,7 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
         uint256 hashProofOfStake = 0;
         std::unique_ptr<CStakeInput> stake;
 
-        if (!CheckProofOfStake(block, hashProofOfStake, stake))
+        if (!CheckProofOfStake(block, hashProofOfStake, stake, pindexPrev->nHeight))
             return state.DoS(100, error("%s: proof of stake check failed", __func__));
 
         if (!stake)


### PR DESCRIPTION
cherry-picked from https://github.com/PIVX-Project/PIVX/pull/925

Two checks on the age of a transaction used to stake were removed by mistake in https://github.com/PRCYCoin/PRCYCoin/pull/320/commits/177429130261ce2cb79a06dfc90dda3ac565056c. We reintroduce them here. 