### PR TITLE
[Upstream] [Refactor] Fix stake age checks for regtest

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -108,9 +108,10 @@ public:
         nRejectBlockOutdatedMajority = 10260; // 95%
         nToCheckBlockUpgradeMajority = 10800; // Approximate expected amount of blocks in 7 days (1440*7.5)
         nMinerThreads = 0;
-        nTargetTimespan = 1 * 60; // PRCYcoin: 1 day
+        nTargetTimespan = 1 * 60; // PRCYcoin: 1 minute
         nTargetSpacing = 1 * 60;  // PRCYcoin: 1 minute
         nMaturity = 100;
+        nStakeMinAge = 60 * 60;   // PRCYcoin: 1 hour
         nMasternodeCountDrift = 20;
         nMNCollateralAmt = 5000 * COIN;
         nMinimumStakeAmount = 2500 * COIN;
@@ -391,6 +392,7 @@ public:
         bnProofOfWorkLimit = ~UINT256_ZERO >> 1;
         nLastPOWBlock = 250;
         nMaturity = 100;
+        nStakeMinAge = 0;
         nMasternodeCountDrift = 4;
         nModifierUpdateBlock = 0; //approx Mon, 17 Apr 2017 04:00:00 GMT
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -61,6 +61,7 @@ public:
     int RejectBlockOutdatedMajority() const { return nRejectBlockOutdatedMajority; }
     int ToCheckBlockUpgradeMajority() const { return nToCheckBlockUpgradeMajority; }
     int MaxReorganizationDepth() const { return nMaxReorganizationDepth; }
+    int StakeMinAge() const { return nStakeMinAge; }
 
     /** Used if GeneratePrcycoins is called with a negative number of threads */
     int DefaultMinerThreads() const { return nMinerThreads; }
@@ -137,6 +138,7 @@ protected:
     int nStealthPrefix;
     int nIntegratedPrefix;
     uint256 bnProofOfWorkLimit;
+    int nStakeMinAge;
     mutable int nMaxReorganizationDepth;
     int nSubsidyHalvingInterval;
     int nEnforceBlockUpgradeMajority;

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -36,18 +36,18 @@ static std::map<int, unsigned int> mapStakeModifierCheckpoints =
 // Get time weight
 int64_t GetWeight(int64_t nIntervalBeginning, int64_t nIntervalEnd)
 {
-    return nIntervalEnd - nIntervalBeginning - nStakeMinAge;
+    return nIntervalEnd - nIntervalBeginning - Params().StakeMinAge();
 }
 
 // Get the last stake modifier and its generation time from a given block
 static bool GetLastStakeModifier(const CBlockIndex* pindex, uint64_t& nStakeModifier, int64_t& nModifierTime)
 {
     if (!pindex)
-        return error("GetLastStakeModifier: null pindex");
+        return error("%s : null pindex", __func__);
     while (pindex && pindex->pprev && !pindex->GeneratedStakeModifier())
         pindex = pindex->pprev;
     if (!pindex->GeneratedStakeModifier())
-        return error("GetLastStakeModifier: no generation at genesis block");
+        return error("%s : no generation at genesis block", __func__);
     nStakeModifier = pindex->nStakeModifier;
     nModifierTime = pindex->GetBlockTime();
     return true;
@@ -88,7 +88,7 @@ static bool SelectBlockFromCandidates(
     *pindexSelected = (const CBlockIndex*)0;
     for (const PAIRTYPE(int64_t, uint256) & item : vSortedByTimestamp) {
         if (!mapBlockIndex.count(item.second))
-            return error("SelectBlockFromCandidates: failed to find block index for candidate block %s", item.second.ToString().c_str());
+            return error("%s : failed to find block index for candidate block %s", __func__, item.second.ToString().c_str());
 
         const CBlockIndex* pindex = mapBlockIndex[item.second];
         if (fSelected && pindex->GetBlockTime() > nSelectionIntervalStop)
@@ -130,7 +130,7 @@ static bool SelectBlockFromCandidates(
         }
     }
     if (GetBoolArg("-printstakemodifier", false))
-        LogPrintf("SelectBlockFromCandidates: selection hash=%s\n", hashBest.ToString().c_str());
+        LogPrintf("%s : selection hash=%s\n", __func__, hashBest.ToString().c_str());
     return fSelected;
 }
 
@@ -166,10 +166,10 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
     // if it's not old enough, return the same stake modifier
     int64_t nModifierTime = 0;
     if (!GetLastStakeModifier(pindexPrev, nStakeModifier, nModifierTime))
-        return error("ComputeNextStakeModifier: unable to get last modifier");
+        return error("%s : unable to get last modifier", __func__);
 
     if (GetBoolArg("-printstakemodifier", false))
-        LogPrint(BCLog::STAKING, "ComputeNextStakeModifier: prev modifier= %s time=%s\n", std::to_string(nStakeModifier).c_str(), DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nModifierTime).c_str());
+        LogPrintf("%s : prev modifier= %s time=%s\n", __func__, std::to_string(nStakeModifier).c_str(), DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nModifierTime).c_str());
 
     if (nModifierTime / getIntervalVersion(fTestNet) >= pindexPrev->GetBlockTime() / getIntervalVersion(fTestNet))
         return true;
@@ -200,7 +200,7 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
 
         // select a block from the candidates of current round
         if (!SelectBlockFromCandidates(vSortedByTimestamp, mapSelectedBlocks, nSelectionIntervalStop, nStakeModifier, &pindex))
-            return error("ComputeNextStakeModifier: unable to select block at round %d", nRound);
+            return error("%s : unable to select block at round %d", __func__, nRound);
 
         // write the entropy bit of the selected block
         nStakeModifierNew |= (((uint64_t)pindex->GetStakeEntropyBit()) << nRound);
@@ -208,7 +208,7 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
         // add the selected block from candidates to selected list
         mapSelectedBlocks.insert(std::make_pair(pindex->GetBlockHash(), pindex));
         if (GetBoolArg("-printstakemodifier", false))
-            LogPrintf("ComputeNextStakeModifier: selected round %d stop=%s height=%d bit=%d\n",
+            LogPrintf("%s : selected round %d stop=%s height=%d bit=%d\n", __func__,
                 nRound, DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nSelectionIntervalStop).c_str(), pindex->nHeight, pindex->GetStakeEntropyBit());
     }
 
@@ -229,10 +229,10 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
             // 'W' indicates selected proof-of-work blocks
             strSelectionMap.replace(item.second->nHeight - nHeightFirstCandidate, 1, item.second->IsProofOfStake() ? "S" : "W");
         }
-        LogPrint(BCLog::STAKING, "ComputeNextStakeModifier: selection height [%d, %d] map %s\n", nHeightFirstCandidate, pindexPrev->nHeight, strSelectionMap.c_str());
+        LogPrintf("%s : selection height [%d, %d] map %s\n", __func__, nHeightFirstCandidate, pindexPrev->nHeight, strSelectionMap.c_str());
     }
     if (GetBoolArg("-printstakemodifier", false)) {
-        LogPrintf("ComputeNextStakeModifier: new modifier=%s time=%s\n", std::to_string(nStakeModifierNew).c_str(), DateTimeStrFormat("%Y-%m-%d %H:%M:%S", pindexPrev->GetBlockTime()).c_str());
+        LogPrintf("%s : new modifier=%s time=%s\n", __func__, std::to_string(nStakeModifierNew).c_str(), DateTimeStrFormat("%Y-%m-%d %H:%M:%S", pindexPrev->GetBlockTime()).c_str());
     }
 
     nStakeModifier = nStakeModifierNew;
@@ -246,7 +246,7 @@ bool GetKernelStakeModifier(uint256 hashBlockFrom, uint64_t& nStakeModifier, int
 {
     nStakeModifier = 0;
     if (!mapBlockIndex.count(hashBlockFrom))
-        return error("GetKernelStakeModifier() : block not indexed");
+        return error("%s : block not indexed", __func__);
     const CBlockIndex* pindexFrom = mapBlockIndex[hashBlockFrom];
     nStakeModifierHeight = pindexFrom->nHeight;
     nStakeModifierTime = pindexFrom->GetBlockTime();
@@ -293,7 +293,7 @@ bool CheckStake(const CDataStream& ssUniqueID, CAmount nValueIn, const uint64_t 
     ss << nStakeModifier << nTimeBlockFrom << ssUniqueID << nTimeTx;
     hashProofOfStake = Hash(ss.begin(), ss.end());
 
-    //LogPrintf("%s: modifier:%d nTimeBlockFrom:%d nTimeTx:%d hash:%s\n", __func__, nStakeModifier, nTimeBlockFrom, nTimeTx, hashProofOfStake.GetHex());
+    //LogPrintf("%s : modifier:%d nTimeBlockFrom:%d nTimeTx:%d hash:%s\n", __func__, nStakeModifier, nTimeBlockFrom, nTimeTx, hashProofOfStake.GetHex());
 
     return stakeTargetHit(hashProofOfStake, nValueIn, bnTarget);
 }
@@ -302,12 +302,11 @@ bool Stake(CStakeInput* stakeInput, unsigned int nBits, unsigned int nTimeBlockF
 {
     if(!Params().IsRegTestNet()) {
         if (nTimeTx < nTimeBlockFrom)
-            return error("CheckStakeKernelHash() : nTime violation");
+            return error("%s : nTime violation", __func__);
 
-        if ((nTimeBlockFrom + nStakeMinAge > nTimeTx)) // Min age requirement
-            return error("CheckStakeKernelHash() : min age violation - nTimeBlockFrom=%d nStakeMinAge=%d nTimeTx=%d",
-                         nTimeBlockFrom, nStakeMinAge, nTimeTx);
-
+        if (nTimeBlockFrom + Params().StakeMinAge() > nTimeTx) // Min age requirement
+            return error("%s : min age violation - nTimeBlockFrom=%d nStakeMinAge=%d nTimeTx=%d",
+                         __func__, nTimeBlockFrom, Params().StakeMinAge(), nTimeTx);
     }
 
     //grab difficulty
@@ -317,7 +316,7 @@ bool Stake(CStakeInput* stakeInput, unsigned int nBits, unsigned int nTimeBlockF
     //grab stake modifier
     uint64_t nStakeModifier = 0;
     if (!stakeInput->GetModifier(nStakeModifier))
-        return error("failed to get kernel stake modifier");
+        return error("%s : failed to get kernel stake modifier", __func__);
 
     bool fSuccess = false;
     unsigned int nTryTime = 0;
@@ -339,7 +338,7 @@ bool Stake(CStakeInput* stakeInput, unsigned int nBits, unsigned int nTimeBlockF
             continue;
 
         fSuccess = true; // if we make it this far then we have successfully created a stake hash
-        //LogPrintf("%s: hashproof=%s\n", __func__, hashProofOfStake.GetHex());
+        //LogPrintf("%s : hashproof=%s\n", __func__, hashProofOfStake.GetHex());
         nTimeTx = nTryTime;
         break;
     }
@@ -360,7 +359,7 @@ bool CheckProofOfStake(const CBlock block, uint256& hashProofOfStake, std::uniqu
     nValueOut = tx.GetValueOut();
 
     if (!tx.IsCoinStake())
-        return error("CheckProofOfStake() : called on non-coinstake %s", tx.GetHash().ToString().c_str());
+        return error("%s : called on non-coinstake %s", __func__, tx.GetHash().ToString().c_str());
 
     // Kernel (input 0) must match the stake hash target per coin age (nBits)
     const CTxIn& txin = tx.vin[0];
@@ -370,11 +369,12 @@ bool CheckProofOfStake(const CBlock block, uint256& hashProofOfStake, std::uniqu
     uint256 hashBlock;
     CTransaction txPrev;
     if (!GetTransaction(txin.prevout.hash, txPrev, hashBlock, true))
-        return error("CheckProofOfStake() : INFO: read txPrev failed");
+        return error("%s : INFO: read txPrev failed, tx id prev: %s, block id %s",
+                __func__, txin.prevout.hash.GetHex(), block.GetHash().GetHex());
 
     //verify signature and script
     if (!VerifyScript(txin.scriptSig, txPrev.vout[txin.prevout.n].scriptPubKey, STANDARD_SCRIPT_VERIFY_FLAGS, TransactionSignatureChecker(&tx, 0)))
-        return error("CheckProofOfStake() : VerifySignature failed on coinstake %s", tx.GetHash().ToString().c_str());
+        return error("%s : VerifySignature failed on coinstake %s", __func__, tx.GetHash().ToString().c_str());
 
     CPrcyStake* prcyInput = new CPrcyStake();
     prcyInput->SetInput(txPrev, txin.prevout.n);
@@ -383,32 +383,35 @@ bool CheckProofOfStake(const CBlock block, uint256& hashProofOfStake, std::uniqu
     //Get the
     CBlockIndex* pindexfrom = stake->GetIndexFrom();
     if (!pindexfrom)
-        return error("%s: Failed to find the block index for stake origin", __func__);
+        return error("%s : Failed to find the block index for stake origin", __func__);
 
     // Read block header
     CBlock blockfrom;
     if (!ReadBlockFromDisk(blockfrom, pindexfrom->GetBlockPos()))
-        return error("CheckProofOfStake(): INFO: failed to find block");
+        return error("%s : INFO: failed to find block", __func__);
 
     uint256 bnTargetPerCoinDay;
     bnTargetPerCoinDay.SetCompact(block.nBits);
 
     uint64_t nStakeModifier = 0;
     if (!stake->GetModifier(nStakeModifier))
-        return error("%s failed to get modifier for stake input\n", __func__);
+        return error("%s : failed to get modifier for stake input\n", __func__);
 
     unsigned int nBlockFromTime = blockfrom.nTime;
     unsigned int nTxTime = block.nTime;
 
-    if (nTxTime < nBlockFromTime) // Transaction timestamp nTxTime
-        return error("CheckStakeKernelHash() : nTime violation - nBlockFromTime=%d nTimeTx=%d", nBlockFromTime, nTxTime);
-    if (nBlockFromTime + nStakeMinAge > nTxTime) // Min age requirement
-        return error("CheckStakeKernelHash() : min age violation - nBlockFromTime=%d nStakeMinAge=%d nTimeTx=%d", nBlockFromTime, nStakeMinAge, nTxTime);
+    if (!Params().IsRegTestNet()) {
+        if (nTxTime < nBlockFromTime) // Transaction timestamp nTxTime
+            return error("%s : nTime violation - nBlockFromTime=%d nTimeTx=%d", __func__, nBlockFromTime, nTxTime);
+        if (nBlockFromTime + Params().StakeMinAge() > nTxTime) // Min age requirement
+            return error("%s : min age violation - nBlockFromTime=%d nStakeMinAge=%d nTimeTx=%d",
+                    __func__, nBlockFromTime, Params().StakeMinAge(), nTxTime);
 
+    }
     if (!CheckStake(stake->GetUniqueness(), nValueIn, nStakeModifier, bnTargetPerCoinDay, nBlockFromTime,
                     nTxTime, hashProofOfStake)) {
-        return error("CheckProofOfStake() : INFO: check kernel failed on coinstake %s, hashProof=%s, GetValue=%d, nValueIn=%d, nValueOut=%d\n",
-                     tx.GetHash().GetHex(), hashProofOfStake.GetHex(), stake->GetValue());
+        return error("%s : INFO: check kernel failed on coinstake %s, hashProof=%s, GetValue=%d, nValueIn=%d, nValueOut=%d\n",
+                     __func__, tx.GetHash().GetHex(), hashProofOfStake.GetHex(), stake->GetValue(), nValueIn, nValueOut);
     }
     return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,8 +86,6 @@ size_t nCoinCacheUsage = 5000 * 300;
 /* If the tip is older than this (in seconds), the node is considered to be in initial block download. */
 int64_t nMaxTipAge = DEFAULT_MAX_TIP_AGE;
 
-unsigned int nStakeMinAge = 60 * 60;
-
 int MIN_RING_SIZE;
 int MAX_RING_SIZE;
 const int MAX_TX_INPUTS = 50;

--- a/src/main.h
+++ b/src/main.h
@@ -158,7 +158,6 @@ extern bool fGeneratePrcycoins;
 extern bool fLargeWorkForkFound;
 extern bool fLargeWorkInvalidChainFound;
 
-extern unsigned int nStakeMinAge;
 extern int64_t nLastCoinStakeSearchInterval;
 //extern int64_t nConsolidationTime;
 extern int64_t nLastCoinStakeSearchTime;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2185,7 +2185,7 @@ bool CWallet::SelectStakeCoins(std::list<std::unique_ptr<CStakeInput> >& listInp
             int64_t nTxTime = out.tx->GetTxTime();
 
             //check for min age
-            if ((GetAdjustedTime() - nTxTime < nStakeMinAge ) && !Params().IsRegTestNet())
+            if (GetAdjustedTime() - nTxTime < Params().StakeMinAge() && !Params().IsRegTestNet())
                 continue;
 
             //check that it is matured
@@ -2227,7 +2227,7 @@ bool CWallet::MintableCoins()
             //add in-wallet minimum staking
             CAmount nVal = getCOutPutValue(out);
             //nTxTime <= nTime: only stake with UTXOs that are received before nTime time
-            if ((GetAdjustedTime() > nStakeMinAge + nTxTime) && (nVal >= Params().MinimumStakeAmount()))
+            if (Params().IsRegTestNet() || (GetAdjustedTime() > Params().StakeMinAge() + nTxTime) && (nVal >= Params().MinimumStakeAmount()))
                 return true;
         }
     }


### PR DESCRIPTION
> There is a bug occurring sometimes on regtest where a block is not accepted due to `CheckStakeKernelHash() : min age violation`. This is because the min age requirement for RegTest was changed (in #812) inside `Stake` but not in `CheckProofOfStake` (the error indicates also the wrong function).
> 
> This fixes it and moves `nStakeMinAge` to chain params (instead of having it as rogue external variable) and sets it to `0` for RegTest (for consistency). Also fixes the error messages in kernel.cpp.

from https://github.com/PIVX-Project/PIVX/pull/976