### PR TITLE
[Staking] Ensure nCredit is correctly initialized in CreateCoinStake

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3850,12 +3850,13 @@ bool CWallet::CreateCoinStake(
         }
     }
 
-    CAmount nCredit = 0;
+    CAmount nCredit;
     CScript scriptPubKeyKernel;
     bool fKernelFound = false;
     int nAttempts = 0;
     for (std::unique_ptr<CStakeInput>& stakeInput : listInputs) {
         // Make sure the wallet is unlocked and shutdown hasn't been requested
+        nCredit = 0;
         if (IsLocked() || ShutdownRequested())
             return false;
 
@@ -3913,7 +3914,6 @@ bool CWallet::CreateCoinStake(
                 LogPrintf("%s : failed to create TxIn\n", __func__);
                 txNew.vin.clear();
                 txNew.vout.clear();
-                nCredit = 0;
                 continue;
             }
             txNew.vin.push_back(in);


### PR DESCRIPTION
Simple backport 

> Fixes #728 
Thanks to @licobc for catching it.

from https://github.com/PIVX-Project/PIVX/pull/734