### PR TITLE
[Upstream] [Staking] Modify miner and staking thread for efficency

### DIFF
--- a/src/miner.h
+++ b/src/miner.h
@@ -20,23 +20,29 @@ class CWallet;
 
 struct CBlockTemplate;
 
-/** Run the miner threads */
-void GeneratePrcycoins(bool fGenerate, CWallet* pwallet, int nThreads);
-/** Run the PoA miner threads */
-void GeneratePoAPrcycoin(CWallet* pwallet, int period);
 /** Generate a new block, without valid proof-of-work */
 CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, const CPubKey& txPub, const CKey& txPriv, CWallet* pwallet, bool fProofOfStake);
-CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey, CWallet* pwallet, bool fProofOfStake);
-CBlockTemplate* CreateNewPoABlock(const CScript& scriptPubKeyIn, const CPubKey& txPub, const CKey& txPriv, CWallet* pwallet);
-CBlockTemplate* CreateNewPoABlockWithKey(CReserveKey& reservekey, CWallet* pwallet);
 
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce);
 /** Check mined block */
 void UpdateTime(CBlockHeader* block, const CBlockIndex* pindexPrev);
 
-void BitcoinMiner(CWallet* pwallet, bool fProofOfStake);
-void ThreadStakeMinter();
+#ifdef ENABLE_WALLET
+    /** Run the miner threads */
+    void GeneratePrcycoins(bool fGenerate, CWallet* pwallet, int nThreads);
+    /** Generate a new block, without valid proof-of-work */
+    CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey, CWallet* pwallet, bool fProofOfStake);
+
+    /** Run the PoA miner threads */
+    void GeneratePoAPrcycoin(CWallet* pwallet, int period);
+    /** Generate a new PoA block */
+    CBlockTemplate* CreateNewPoABlock(const CScript& scriptPubKeyIn, const CPubKey& txPub, const CKey& txPriv, CWallet* pwallet);
+    CBlockTemplate* CreateNewPoABlockWithKey(CReserveKey& reservekey, CWallet* pwallet);
+
+    void BitcoinMiner(CWallet* pwallet, bool fProofOfStake);
+    void ThreadStakeMinter();
+#endif // ENABLE_WALLET
 
 extern double dHashesPerSec;
 extern int64_t nHPSTimerStart;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -199,7 +199,7 @@ UniValue setgenerate(const UniValue& params, bool fHelp)
         throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Method not found (disabled)");
 
     if (Params().MineBlocksOnDemand())
-        throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Use the generate method instead of setgenerate on this network");
+        throw JSONRPCError(RPC_INVALID_REQUEST, "Use the generate method instead of setgenerate on this network");
 
     bool fGenerate = true;
     if (params.size() > 0)


### PR DESCRIPTION
> ### **Release notes**
> * [Mining] Unnecessary mining threads now exit after PoS has begun
> * [Staking] The staking thread dormancy is more efficient during PoW
> * [Performance] Some unnecessary processing in the mining thread removed
> * [RPC] setgenerate errors if attempted to turn on after end of PoW
> * [Build] Wallet only routines conditionalized in miner.h
> * [Refactoring] Log messages with bitcoin named routines changed for easier rename of routines in the future.
> 
> In order to better explain the changes in this PR, a review of the existing code would be helpful.
> 
> ### **Backstory**
> When fixing a PIVX forked coin's transition from PoW to PoS, it was observed that mining threads go into tight infinite loops after the switch to proof of stake. This can be seen with a simple `pivx-qt -testnet -gen`, and watching the debug log.
> 
> This observation triggered the below code review (re-written for the current release; some of the findings in the code originally reviewed had already been addressed in PIVX).
> 
> ### **Code Review**
> _BitcoinMiner()_ This routine is a worker routine for both staking and mining threads; fProofOfStake is set to true when running in the staking thread, false when running in the mining thread. fGeneratedBitcoins is set when mining is started; and cleared on shutdown or when mining is stopped.
> 
> _In the initial fProofOfStake section:_
> 
> ```
>             if ((GetTime() - nMintableLastCheck > 5 * 60)) // 5 minute check time
>             {
>                 nMintableLastCheck = GetTime();
>                 fMintableCoins = pwallet->MintableCoins();
>             }
> 
>             if (chainActive.Tip()->nHeight < Params().LAST_POW_BLOCK()) {
>                 MilliSleep(5000);
>                 continue;
>             }
> ```
> 
> Every 5 minutes this code will scan through the wallet and look to see if mintable coins exist. After it's done that, it checks if the network is still in the proof of work phase. It doesn't make sense to scan the wallet until after the proof of work phase is ending.
> 
> If it is in the proof of work phase; the staking thread sleeps for 5 seconds (`MilliSleep(5000)`). This only makes sense if the block time is 5 seconds. Technically the thread could determine the number of blocks remaining in the proof of work phase, and use that to calculate a hibernation of sorts. Using the target spacing to wait for the block to pass is a 91% reduction in the number of passes through the loop (12 vs. 1 when the target spacing is one minute), and doesn't run into issues where adjustments to the actual spacing throw the timing of a hibernation off.
> 
> ```
>                 if (!fMintableCoins) {
>                     if (GetTime() - nMintableLastCheck > 1 * 60) // 1 minute check time
>                     {
>                         nMintableLastCheck = GetTime();
>                         fMintableCoins = pwallet->MintableCoins();
>                     }
>                 }
>                 MilliSleep(5000);
> ```
> 
> We come to this section of code in the waiting while loop; if we don't have mintable coins yet, or our wallet is locked, or we're not synched; or a host of other potential things that would prevent staking. However, we check again for mintable coins; and then we wait 5 seconds after that check before we come out.
> 
> Since the first time we come into this loop; we have already checked mintable coins (within the last 5 minutes); we should sleep first, and then do the check closer to the time we're actually going to go around the loop again; so we're working with the most recent data.
> 
> ```
>                 if (!fGenerateBitcoins && !fProofOfStake)
>                     continue;
> ```
> 
> This check is buried in a `if (fProofOfStake)` conditional, where fProofOfStake is a parameter that is passed in by the caller to BitcoinMiner(). `!fProofOfStake` will never be true; so this condition will never be true. Removing it we are left with !fGenerateBitcoins; which is unrelated to this section of code anyway. If we're down to this point, we're not in PoW mode anymore, so there shouldn't be a mining thread (more on that later). But the most compelling part of this condition,whether it passes or not, is that it "continues" the while loop it's in; and since it's at the end of the actual while loop, it's going to iterate into another round of the while loop as soon as it finishes with this conditional anyway. Long story short; the code doesn't do anything.
> 
> _Overall logic_ The mining thread will run until mining is turned off (`setgenerate false`, or the mining flags taken off the invocation). However, there is no need to continue to mine with proof of work after the proof of stake phase begins. In fact, there really is no consideration of that at all; PoW will continue to try to generate blocks well after PoS has begun. Yes, it's within the users control to stop mining; but it's within the power of the code to take care of that for the user, and stop the mining thread(s) after the transition to proof of stake.
> 
> ### **This PR:**
> The logical issues above have been corrected. The dormancy for the proof of stake thread is held for just one block rather than any extreme hibernation. Combined with moving that code to be the first thing in the while loop; it also removes the processing done to search through the wallets looking for stakeable coins.
> 
> Since a significant amount of code assumes there will not be a transition from PoS to PoW; code was added to BitcoinMiner() to exit the mining threads if it's transitioned into the PoS phase. The threads will continue for a little bit, in case there is any rewind on the chain; but after 6 PoS blocks are accepted, the miner threads will exit.
> 
> To prevent the PoW thread from trying to generate blocks after the PoS phase has begun, logic was added in CreateNewBlockWithKey() to return quickly. Rather than create a situation where the mining thread ends up in a tight loop in the initial phases of PoS, the mining thread will be held for 1/2 of the target spacing before returning.
> 
> Lastly; Some tweaks were made to the logging; removing hardcoded references to "BitcoinMiner()", in case refactoring in the future changes the name of the routine. Similarly, since there is a log message when the mining thread starts "PIVXMiner started"; rather than reporting thread exits or errors as "ThreadBitcoinMiner", they have been changed to PIVXMiner to match.
> 
> Much of this can be observed with an errant `pivx-qt -gen`. With this PR, it simply tries to start the miner, and then exits.
> 
> _With PR code - `pivx-qt -gen -testnet`_
> 
> ```
> 2019-07-21 20:04:22 PIVXMiner started
> 2019-07-21 20:04:22 BitcoinMiner: Exiting Proof of Work Mining Thread at height: 1160732
> 2019-07-21 20:04:22 PIVXMiner exiting
> ```
> 
> _Current release:_
> 
> ```
> 2019-07-21 19:37:06 CreateNewBlock(): total size 1000
> 2019-07-21 19:37:06 ERROR: CheckProofOfWork() : hash doesn't match nBits
> 2019-07-21 19:37:06 ERROR: CheckBlockHeader() : proof of work failed
> 2019-07-21 19:37:06 ERROR: CheckBlock() : CheckBlockHeader failed
> 2019-07-21 19:37:06 CreateNewBlock() : TestBlockValidity failed
> ```
> 
> is repeated in a tight loop.

from https://github.com/PIVX-Project/PIVX/pull/958
A nice update to the efficiency of the miner/staker threads
Modified for our usage as we use `setegenerate` for enabling Proof of Stake