### PR TITLE
[Upstream] [GUI] Add missing QPainterPath include

### DIFF
--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -7,6 +7,7 @@
 
 #include <QColor>
 #include <QPainter>
+#include <QPainterPath>
 #include <QTimer>
 
 #include <cmath>


### PR DESCRIPTION
> Qt 5.15 no longer implicitly includes QPainterPath, so explicitly
> include it here.

from https://github.com/PIVX-Project/PIVX/pull/1683

Simple backport/fix. Testing and compiling with Qt5.15 on macOS today and ran into this.