### PR TITLE
[Cleanup] Thread-safety-analysis warnings

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -95,7 +95,6 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
                     decoy.push_back(Pair("txid", allDecoys[i].hash.GetHex()));
                     decoy.push_back(Pair("vout", (int64_t)allDecoys[i].n));
 #ifdef ENABLE_WALLET
-                    LOCK(pwalletMain->cs_wallet);
                     std::map<uint256, CWalletTx>::const_iterator mi = pwalletMain->mapWallet.find(allDecoys[i].hash);
                     if (mi != pwalletMain->mapWallet.end()) {
                         const CWalletTx& prev = (*mi).second;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -6270,7 +6270,6 @@ bool CWallet::IsTransactionForMe(const CTransaction& tx)
                 }
 
                 if (ret) {
-                    LOCK(cs_wallet);
                     //Compute private key to spend
                     //x = Hs(aR) + b, b = spend private key
                     unsigned char HStemp[32];


### PR DESCRIPTION
More from compiling on macOS, turning on `-Wthread-safety-analysis` shows a number of compiler warnings with c++11 for acquiring mutexes that are already held.

This cleans up those warnings.

`wallet/wallet.cpp:6273:21: warning: acquiring mutex 'cs_wallet' that is already held [-Wthread-safety-analysis]
                    LOCK(cs_wallet);`

`rpc/rawtransaction.cpp:98:21: warning: acquiring mutex 'pwalletMain->cs_wallet' that is already held [-Wthread-safety-analysis]
                    LOCK(pwalletMain->cs_wallet);`