### PR TITLE
[Build] Fix missing zxcvbn PIE_FLAGS

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -250,7 +250,7 @@ libbitcoin_zmq_a_SOURCES = \
   zmq/zmqpublishnotifier.cpp
 endif
 
-libbitcoin_zxcvbn_a_CPPFLAGS = $(BITCOIN_INCLUDES)
+libbitcoin_zxcvbn_a_CPPFLAGS = $(BITCOIN_INCLUDES) $(PIE_FLAGS)
 libbitcoin_zxcvbn_a_CXXFLAGS = $(AM_CXXFLAGS)
 libbitcoin_zxcvbn_a_SOURCES = \
   zxcvbn/_frequency_lists.cpp \


### PR DESCRIPTION
This was causing compile issues on Ubuntu 16 to create the AppImage (AppImage should be created on a lower OS to support more OSs).
Might also fix RISCV64 Qt compile, as it was failing with a similar error -> it does. https://github.com/PRCYCoin/PRCYCoin/actions/runs/3926350006/jobs/6712007359