### PR TITLE
[Upstream] qt: Do not use QClipboard::Selection on Windows and macOS.

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -794,8 +794,11 @@ void colorCalendarWidgetWeekends(QCalendarWidget* widget, QColor color)
 
 void setClipboard(const QString& str)
 {
-    QApplication::clipboard()->setText(str, QClipboard::Clipboard);
-    QApplication::clipboard()->setText(str, QClipboard::Selection);
+    QClipboard* clipboard = QApplication::clipboard();
+    clipboard->setText(str, QClipboard::Clipboard);
+    if (clipboard->supportsSelection()) {
+        clipboard->setText(str, QClipboard::Selection);
+    }
 }
 
 fs::path qstringToBoostPath(const QString& path)


### PR DESCRIPTION
> Windows and macOS do not support the global mouse selection.

cherry-picked fix/backport from https://github.com/bitcoin/bitcoin/pull/22427

fixes log item: `GUI: Data set on unsupported clipboard mode. QMimeData object will be deleted.` when copying to clipboard on Windows and macOS.