### PR TITLE
[Qt] Fix broken link for large wallet warning

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -550,6 +550,9 @@
        <property name="text">
         <string>It is advised not to send or receive coins until your current sync is complete.</string>
        </property>
+       <property name="textFormat">
+        <enum>Qt::RichText</enum>
+       </property>
        <property name="openExternalLinks">
         <bool>true</bool>
        </property>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -516,11 +516,9 @@ void OverviewPage::updateRecentTransactions() {
                 }
                 if (latestTxes.size() >= 10000) {
                     QString txWarning = "Your wallet has more than 10,000 Transactions. It may run slowly. It's recommended to send your funds to a new wallet.";
-                    QString kbURL = "https://prcycoin.com/knowledge-base/wallets/sluggish-large-wallet-dat-solution/";
-                    QString kbTitle = "Need Help?";
-                    txWarning.append(" <a href=\"" + kbURL + "\">" + kbTitle + "</a>");
+                    txWarning.append(" <a href=\"https://prcycoin.com/knowledge-base/wallets/sluggish-large-wallet-dat-solution/\">Need Help?</a>");
                     if (!ui->lblHelp->text().contains(txWarning)) {
-                        ui->lblHelp->setText(ui->lblHelp->text() + "\n" + txWarning);
+                        ui->lblHelp->setText(ui->lblHelp->text() + "<br>" + txWarning);
                     }
                 }
 


### PR DESCRIPTION
Previous iteration did not correctly set the link, fix that and use less variables
![image](https://user-images.githubusercontent.com/2319897/213301317-f46d44c5-c445-481f-a86b-6ecab80a73d1.png)
