### PR TITLE
[Wallet] Better logging for when selected transaction is not in main chain

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3716,7 +3716,7 @@ bool CWallet::selectDecoysAndRealIndex(CTransaction& tx, int& myIndex, int ringS
         CTransaction txPrev;
         uint256 hashBlock;
         if (!GetTransaction(tx.vin[i].prevout.hash, txPrev, hashBlock)) {
-            LogPrintf("Selected transaction is not in the main chain\n");
+            LogPrintf("Selected transaction: %s is not in the main chain\n", tx.vin[i].prevout.hash.GetHex().c_str());
             return false;
         }
 


### PR DESCRIPTION
Example: 
```
2023-01-25 20:04:44 Making RingCT using ring size=30
2023-01-25 20:04:44 Selecting coinbase decoys for transaction
2023-01-25 20:04:44 Selected transaction: 023ea12ec467192cb329a762a896c5b174ed61bfd0931e50c00caf42426e2a07 is not in the main chain
```