### PR TITLE
Fix unused-value warning for fCombineDust

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1932,7 +1932,6 @@ bool AppInit2(bool isDaemon)
     if (pwalletMain) {
         // Add wallet transactions that aren't already in a block to mapTransactions
         pwalletMain->ReacceptWalletTransactions();
-        pwalletMain->fCombineDust = GetBoolArg("-combinedust", true);
         // Run a thread to flush wallet periodically
         threadGroup.create_thread(boost::bind(&ThreadFlushWalletDB, boost::ref(pwalletMain->strWalletFile)));
 		

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5652,7 +5652,7 @@ void CWallet::SetNull()
     vDisabledAddresses.clear();
 
     //Auto Combine Dust
-    fCombineDust;
+    fCombineDust = GetBoolArg("-combinedust", true);
     nAutoCombineThreshold = 150;
     nAutoCombineTarget = GetArg("-autocombinetarget", 15);
 }


### PR DESCRIPTION
Fixes:
```
wallet/wallet.cpp:5655:5: warning: expression result unused [-Wunused-value]
    fCombineDust;
    ^~~~~~~~~~~~
```

A unique, and super annoying, case where even when you set `combinedust=false` in prcycoin.conf your UTXOs would still get consolidated, wasting the time spent to split the UTXOs in the first place.