### PR TITLE
[Wallet] MintableCoins/SelectStakeCoin Fixes

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2343,8 +2343,18 @@ bool CWallet::MintableCoins()
 
             //add in-wallet minimum staking
             CAmount nVal = getCOutPutValue(out);
+
+            //check that it is not MN Collateral
+            bool isCollateral = false;
+            if (nVal == Params().MNCollateralAmt()) {
+                COutPoint outpoint(out.tx->GetHash(), out.i);
+                if (IsCollateralized(outpoint)) {
+                    isCollateral = true;
+                }
+            }
+
             //nTxTime <= nTime: only stake with UTXOs that are received before nTime time
-            if (Params().IsRegTestNet() || (GetAdjustedTime() > Params().StakeMinAge() + nTxTime) && (nVal >= Params().MinimumStakeAmount()))
+            if (Params().IsRegTestNet() || (GetAdjustedTime() > Params().StakeMinAge() + nTxTime && nVal >= Params().MinimumStakeAmount() && !isCollateral))
                 return true;
         }
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2291,6 +2291,18 @@ bool CWallet::SelectStakeCoins(std::list<std::unique_ptr<CStakeInput> >& listInp
             if (nAmountSelected + value > nTargetAmount)
                 continue;
 
+            //check that it is above Minimum Stake Amount
+            if (value < Params().MinimumStakeAmount())
+                continue;
+
+            //check that it is not MN Collateral
+            if (value == Params().MNCollateralAmt()) {
+                COutPoint outpoint(out.tx->GetHash(), out.i);
+                if (IsCollateralized(outpoint)) {
+                    continue;
+                }
+            }
+
             int64_t nTxTime = out.tx->GetTxTime();
 
             //check for min age
@@ -2299,10 +2311,6 @@ bool CWallet::SelectStakeCoins(std::list<std::unique_ptr<CStakeInput> >& listInp
 
             //check that it is matured
             if (out.nDepth < (out.tx->IsCoinStake() ? Params().COINBASE_MATURITY() : 10))
-                continue;
-
-            //check that it is above Minimum Stake Amount
-            if (value < Params().MinimumStakeAmount())
                 continue;
 
             //add to our stake set


### PR DESCRIPTION
This ensures that Masternode Collateral/below Minimum Stake amount UTXOs are not selected for Staking/considered as Mintable Coins

Essentially, duplicated code in AvailableCoins that eventually gets cleaned up better moving into the next larger PRs/Hard Fork.