### PR TITLE
[Qt] Fix incorrect Staking Status

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1388,25 +1388,10 @@ void BitcoinGUI::setStakingStatus()
             stakingAction->setIcon(QIcon(":/icons/staking_waiting"));
             return;
         }
-        if (stakingState->text().contains("Enabling")) {
-            if (!nLastCoinStakeSearchInterval) return;
-        }
-        if (nLastCoinStakeSearchInterval) {
-            LogPrint(BCLog::STAKING,"Checking Staking Status: Enabled.\n");
-            stakingState->setText(tr("Staking Enabled"));
-            stakingState->setToolTip("Staking Enabled");
-            stakingAction->setIcon(QIcon(":/icons/staking_active"));
-        /*} else if (nConsolidationTime > 0) {
-            nConsolidationTime --;
-            stakingState->setText(tr("Consolidating Transactions…"));
-            stakingState->setToolTip("Consolidating Transactions… Please wait few minutes for it to be consolidated.");
-            stakingAction->setIcon(QIcon(":/icons/staking_active"));*/
-        } else {
-            LogPrint(BCLog::STAKING,"Checking Staking Status: Enabling...\n");
-            stakingState->setText(tr("Enabling Staking..."));
-            stakingState->setToolTip("Enabling Staking... Please wait up to 1.5 hours for it to be properly enabled after consolidation.");
-            stakingAction->setIcon(QIcon(":/icons/staking_active"));
-        }
+        LogPrint(BCLog::STAKING,"Checking Staking Status: Enabled.\n");
+        stakingState->setText(tr("Staking Enabled"));
+        stakingState->setToolTip("Staking Enabled");
+        stakingAction->setIcon(QIcon(":/icons/staking_active"));
     }
 }
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -187,15 +187,9 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
         ui->labelBalance->setText("Hidden");
         ui->labelUnconfirmed->setText("Hidden");
     } else {
-        if (stkStatus && !nLastCoinStakeSearchInterval && !fLiteMode) {
-            ui->labelBalance_2->setText("Enabling Staking...");
-            ui->labelBalance_2->setToolTip("Enabling Staking... Please wait up to 1.5 hours for it to be properly enabled after consolidation.");
-            ui->labelBalance->setText("Enabling Staking...");
-        } else {
-            ui->labelBalance_2->setText(BitcoinUnits::formatHtmlWithUnit(0, balance, false, BitcoinUnits::separatorAlways));
-            ui->labelBalance_2->setToolTip("Your current balance");
-            ui->labelBalance->setText(BitcoinUnits::formatHtmlWithUnit(0, nSpendableDisplayed, false, BitcoinUnits::separatorAlways));
-        }
+        ui->labelBalance_2->setText(BitcoinUnits::formatHtmlWithUnit(0, balance, false, BitcoinUnits::separatorAlways));
+        ui->labelBalance_2->setToolTip("Your current balance");
+        ui->labelBalance->setText(BitcoinUnits::formatHtmlWithUnit(0, nSpendableDisplayed, false, BitcoinUnits::separatorAlways));
         ui->labelUnconfirmed->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, unconfirmedBalance, false, BitcoinUnits::separatorAlways));
         ui->btnLockUnlock->setStyleSheet("border-image: url(:/images/unlock) 0 0 0 0 stretch stretch; width: 30px;");
     }


### PR DESCRIPTION
This fixes the incorrectly displayed Staking Status in Qt after the changes to the Staking flow. Will be re-adjusted when CStakerStatus is introduced from Upstream.