### PR TITLE
[Qt] Fix incorrect fees displayed for new deposits on Options page

### DIFF
--- a/src/qt/forms/optionspage.ui
+++ b/src/qt/forms/optionspage.ui
@@ -497,7 +497,7 @@
               <item>
                <widget class="QCheckBox" name="addNewFunds">
                 <property name="toolTip">
-                 <string>Enabling this will incur a minimum 1 PRCY fee each time you receive a new deposit that needs to be consolidated for staking.</string>
+                 <string>Enabling this will incur a maximum 0.1 PRCY fee each time you receive a new deposit that needs to be consolidated for staking.</string>
                 </property>
                 <property name="text">
                  <string>Automatically add any new deposits received to your staked balance</string>

--- a/src/qt/optionspage.cpp
+++ b/src/qt/optionspage.cpp
@@ -149,7 +149,7 @@ OptionsPage::OptionsPage(QWidget* parent) : QDialog(parent, Qt::WindowSystemMenu
         QFont font = ui->addNewFunds->font();
         font.setStrikeOut(true);
         ui->addNewFunds->setFont(font);
-        ui->addNewFunds->setToolTip("Disabled by default due to controlling Masternode(s) from this wallet.\nEnabling this will incur a minimum 1 PRCY fee each time you receive a new deposit that needs to be consolidated for staking.");
+        ui->addNewFunds->setToolTip("Disabled by default due to controlling Masternode(s) from this wallet.\nEnabling this will incur a maximum 0.1 PRCY fee each time you receive a new deposit that needs to be consolidated for staking.");
     }
     ui->mapPortUpnp->setChecked(settings.value("fUseUPnP", false).toBool());
     ui->minimizeToTray->setChecked(settings.value("fMinimizeToTray", false).toBool());


### PR DESCRIPTION
Brought to our attention by a user on Telegram, fee text was leftover from forking the code.