### PR TITLE
[RPC] Add `erasefromwallet`

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -441,7 +441,8 @@ static const CRPCCommand vRPCCommands[] =
         {"wallet", "walletpassphrasechange", &walletpassphrasechange, true, false, true},
         {"wallet", "unlockwallet", &unlockwallet, true, false, true},
         {"wallet", "revealmnemonicphrase", &revealmnemonicphrase, true, false, true},
-        {"wallet", "createmasternode", &createmasternode, true, false, true}
+        {"wallet", "createmasternode", &createmasternode, true, false, true},
+        {"wallet", "erasefromwallet", &erasefromwallet, true, false, true}
 
 #endif // ENABLE_WALLET
         };

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -270,6 +270,7 @@ extern UniValue getstakesplitthreshold(const UniValue& params, bool fHelp);
 extern UniValue multisend(const UniValue& params, bool fHelp);
 extern UniValue autocombinedust(const UniValue& params, bool fHelp);
 extern UniValue revealmnemonicphrase(const UniValue& params, bool fHelp);
+extern UniValue erasefromwallet(const UniValue& params, bool fHelp);
 
 extern UniValue getrawtransaction(const UniValue& params, bool fHelp); // in rcprawtransaction.cpp
 extern UniValue getrawtransactionbyblockheight(const UniValue& params, bool fHelp); // in rcprawtransaction.cpp

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3095,3 +3095,28 @@ UniValue revealmnemonicphrase(const UniValue& params, bool fHelp)
 
     return mPhrase;
 }
+
+UniValue erasefromwallet(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw std::runtime_error(
+            "erasefromwallet\n"
+            "\nErase a transaction from the wallet.\n"
+            "\nResult:\n"
+            "n    (result) Done\n"
+            "\nExamples:\n" +
+            HelpExampleCli("erasefromwallet", "") + HelpExampleRpc("erasefromwallet", ""));
+
+    EnsureWalletIsUnlocked();
+
+    uint256 hash;
+    hash.SetHex(params[0].get_str());
+
+    if (!pwalletMain->mapWallet.count(hash))
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id");
+
+    pwalletMain->EraseFromWallet(hash);
+
+    return "Done";
+}
+

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1287,6 +1287,7 @@ void CWallet::EraseFromWallet(const uint256& hash)
         LOCK(cs_wallet);
         if (mapWallet.erase(hash))
             CWalletDB(strWalletFile).EraseTx(hash);
+        LogPrintf("%s: Erased wtx %s from wallet\n", __func__, hash.GetHex());
     }
     return;
 }


### PR DESCRIPTION
RPC command to erase a transaction from the wallet.
Usage: `erasefromwallet TXID`
Result: Done or Invalid or non-wallet transaction id (if the TXID does not exist)
In debug.log, a line will be added `Erased wtx TXID from wallet`

Works well with #352 -> Transactions that are logged there can be erased to get past the error.