### PR TITLE
[Qt] Add "Delete Transaction" button on TX Dialog

### DIFF
--- a/src/qt/forms/revealtxdialog.ui
+++ b/src/qt/forms/revealtxdialog.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayoutTXID" stretch="0,1,5">
+    <layout class="QHBoxLayout" name="horizontalLayoutTXID" stretch="0,1,5,0">
      <item>
       <widget class="QPushButton" name="pushButtonCopyID">
        <property name="toolTip">
@@ -349,7 +349,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Ok|QDialogButtonBox::Reset</set>
      </property>
     </widget>
    </item>

--- a/src/qt/revealtxdialog.h
+++ b/src/qt/revealtxdialog.h
@@ -1,8 +1,11 @@
 #ifndef REVEALTXDIALOG_H
 #define REVEALTXDIALOG_H
 
-#include <QDialog>
 #include "amount.h"
+
+#include <QCheckBox>
+#include <QDialog>
+#include <QSettings>
 
 namespace Ui {
 class RevealTxDialog;
@@ -34,9 +37,14 @@ private Q_SLOTS:
     void copyTxPaymentID();
     void copyTxRingSize();
     void openTXinExplorer();
+    void deleteTransaction();
 
 private:
     Ui::RevealTxDialog *ui;
+    QSettings settings;
+
+protected:
+    void keyPressEvent(QKeyEvent* event);
 };
 
 #endif // REVEALTXDIALOG_H


### PR DESCRIPTION
Button location:
![image](https://user-images.githubusercontent.com/2319897/218214236-1922a75d-0b05-45d0-b0ff-92317320c36c.png)

Confirm dialog:
![image](https://user-images.githubusercontent.com/2319897/218214249-354d0eab-2191-4c34-b306-0e81b0bfb0e3.png)

Success dialog:
![image](https://user-images.githubusercontent.com/2319897/218214310-5a49605e-528a-4ef8-95f9-f307213d88cb.png)

Potential Masternode dialog:
![image](https://user-images.githubusercontent.com/2319897/218216615-3f2487b5-d904-4cc0-8ef7-c201f15d33f1.png)

Preliminary UI version of deleting transactions. With option to hide success dialog to speed up the process (which sets a value for `fHideDeleteSuccess` of true or false - default is true). Checks for a "Potential Masternode Collateral" transaction by the value. Further additions/updates to follow.

Keyboard shortcuts on the TX Dialog screen
Delete/Backspace - will initiate the process.:
Enter -> Accept
Esc -> Reject

