### PR TITLE
[Wallet] Add functionality to delete wallet transactions

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -432,6 +432,10 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-custombackupthreshold=<n>", strprintf(_("Number of custom location backups to retain (default: %d)"), DEFAULT_CUSTOMBACKUPTHRESHOLD));
     strUsage += HelpMessageOpt("-disablewallet", _("Do not load the wallet and disable wallet RPC calls"));
     strUsage += HelpMessageOpt("-keypool=<n>", strprintf(_("Set key pool size to <n> (default: %u)"), 100));
+    strUsage += HelpMessageOpt("-deletetx", _("Enable Old Transaction Deletion"));
+    strUsage += HelpMessageOpt("-deleteinterval", strprintf(_("Delete transaction every <n> blocks during inital block download (default: %i)"), DEFAULT_TX_DELETE_INTERVAL));
+    strUsage += HelpMessageOpt("-keeptxnum", strprintf(_("Keep the last <n> transactions (default: %i)"), DEFAULT_TX_RETENTION_LASTTX));
+    strUsage += HelpMessageOpt("-keeptxfornblocks", strprintf(_("Keep transactions for at least <n> blocks (default: %i)"), DEFAULT_TX_RETENTION_BLOCKS));
     if (GetBoolArg("-help-debug", false))
         strUsage += HelpMessageOpt("-mintxfee=<amt>", strprintf(_("Fees (in %s/Kb) smaller than this are considered zero fee for transaction creation (default: %s)"),
                 CURRENCY_UNIT, FormatMoney(CWallet::minTxFee.GetFeePerK())));
@@ -1617,6 +1621,27 @@ bool AppInit2(bool isDaemon)
             if (nMaxVersion < pwalletMain->GetVersion())
                 strErrors << _("Cannot downgrade wallet") << "\n";
             pwalletMain->SetMaxVersion(nMaxVersion);
+        }
+
+        //Set Transaction Deletion Options
+        fTxDeleteEnabled = GetBoolArg("-deletetx", false);
+        fTxConflictDeleteEnabled = GetBoolArg("-deleteconflicttx", true);
+
+        fDeleteInterval = GetArg("-deleteinterval", DEFAULT_TX_DELETE_INTERVAL);
+        if (fDeleteInterval < 1)
+          return UIError("deleteinterval must be greater than 0");
+
+        fKeepLastNTransactions = GetArg("-keeptxnum", DEFAULT_TX_RETENTION_LASTTX);
+        if (fKeepLastNTransactions < 1)
+          return UIError("keeptxnum must be greater than 0");
+
+        fDeleteTransactionsAfterNBlocks = GetArg("-keeptxfornblocks", DEFAULT_TX_RETENTION_BLOCKS);
+        if (fDeleteTransactionsAfterNBlocks < 1)
+          return UIError("keeptxfornblocks must be greater than 0");
+
+        if (fDeleteTransactionsAfterNBlocks < Params().COINBASE_MATURITY() + 1 ) {
+          LogPrintf("keeptxfornblock is less than Params().COINBASE_MATURITY(), Setting to %i\n", Params().COINBASE_MATURITY() + 1);
+          fDeleteTransactionsAfterNBlocks = Params().COINBASE_MATURITY() + 1;
         }
 
         if (fFirstRun) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1673,6 +1673,19 @@ bool AppInit2(bool isDaemon)
         RegisterValidationInterface(pwalletMain);
         int height = -1;
         CBlockIndex* pindexRescan = chainActive.Tip();
+
+        {
+            //Sort Transactions by block and block index, then reorder
+            LOCK2(cs_main, pwalletMain->cs_wallet);
+            if (chainActive.Tip()) {
+                LogPrintf("Runnning transaction reorder\n");
+                int64_t maxOrderPos = 0;
+                std::map<std::pair<int,int>, CWalletTx*> mapSorted;
+                pwalletMain->ReorderWalletTransactions(mapSorted, maxOrderPos);
+                pwalletMain->UpdateWalletTransactionOrder(mapSorted, true);
+            }
+        }
+
         if (GetBoolArg("-rescan", false)) {
             pindexRescan = chainActive.Genesis();
         } else {

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -126,6 +126,7 @@ const CLogCategoryDesc LogCategories[] = {
         {BCLog::MNPING,         "mnping"},
         {BCLog::POA,            "poa"},
         {BCLog::SUPPLY,         "supply"},
+        {BCLog::DELETETX,       "deletetx"},
         {BCLog::ALL,            "1"},
         {BCLog::ALL,            "all"},
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -64,6 +64,7 @@ namespace BCLog {
         MNPING      = (1 << 24),
         POA         = (1 << 25),
         SUPPLY      = (1 << 26),
+        DELETETX    = (1 << 27),
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4868,6 +4868,16 @@ bool ProcessNewBlock(CValidationState& state, CNode* pfrom, CBlock* pblock, CDis
             }
             return error("%s : AcceptBlock FAILED", __func__);
         }
+        bool initialDownloadCheck = IsInitialBlockDownload();
+        if (!initialDownloadCheck &&
+            pblock->IsPoABlockByVersion()) // Run DeleteWalletTransactions on PoA blocks
+        {
+            pwalletMain->DeleteWalletTransactions(pindex);
+        } else {
+            if (initialDownloadCheck && pindex->nHeight % fDeleteInterval == 0) {
+                pwalletMain->DeleteWalletTransactions(pindex);
+            }
+        }
     }
 
     if (!ActivateBestChain(state, pblock, checked))

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -395,6 +395,7 @@ static const CRPCCommand vRPCCommands[] =
         {"wallet", "showtxprivatekeys", &showtxprivatekeys, true, false, true},
         {"wallet", "rescan", &rescan, true, false, true},
         {"wallet", "rescanwallettransactions", &rescanwallettransactions, true, false, true},
+        {"wallet", "erasewallettransactions", &erasewallettransactions, true, false, true},
         {"wallet", "setdecoyconfirmation", &setdecoyconfirmation, true, false, true},
         {"wallet", "getdecoyconfirmation", &getdecoyconfirmation, true, false, true},
         {"wallet", "decodestealthaddress", &decodestealthaddress, true, false, true},

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -254,6 +254,7 @@ extern UniValue revealspendprivatekey(const UniValue& params, bool fHelp);
 extern UniValue showtxprivatekeys(const UniValue& params, bool fHelp);
 extern UniValue rescan(const UniValue& params, bool fHelp);
 extern UniValue rescanwallettransactions(const UniValue& params, bool fHelp);
+extern UniValue erasewallettransactions(const UniValue& params, bool fHelp);
 extern UniValue setdecoyconfirmation(const UniValue& params, bool fHelp);
 extern UniValue getdecoyconfirmation(const UniValue& params, bool fHelp);
 extern UniValue decodestealthaddress(const UniValue& params, bool fHelp);

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -84,7 +84,7 @@ bool CDBEnv::Open(const fs::path& pathIn)
         nEnvFlags |= DB_PRIVATE;
 
     dbenv->set_lg_dir(pathLogDir.string().c_str());
-    dbenv->set_cachesize(0, 0x100000, 1); // 1 MiB should be enough for just the wallet
+    dbenv->set_cachesize(1, 0x100000, 1); // 1 MiB should be enough for just the wallet, Increased by 1 GB
     dbenv->set_lg_bsize(0x10000);
     dbenv->set_lg_max(1048576);
     dbenv->set_lk_max_locks(40000);
@@ -160,6 +160,55 @@ CDBEnv::VerifyResult CDBEnv::Verify(std::string strFile, bool (*recoverFunc)(CDB
     // Try to recover:
     bool fRecovered = (*recoverFunc)(*this, strFile);
     return (fRecovered ? RECOVER_OK : RECOVER_FAIL);
+}
+
+bool CDBEnv::Compact(const std::string& strFile)
+{
+    LOCK(cs_db);
+
+    DB_COMPACT dbcompact;
+    dbcompact.compact_fillpercent = 80;
+    dbcompact.compact_pages = DB_MAX_PAGES;
+    dbcompact.compact_timeout = 0;
+
+    DB_COMPACT *pdbcompact;
+    pdbcompact = &dbcompact;
+
+    int result = 1;
+    if (mapDb[strFile] != NULL) {
+        Db* pdb = mapDb[strFile];
+        result = pdb->compact(NULL, NULL, NULL, pdbcompact, DB_FREE_SPACE, NULL);
+        delete pdb;
+        mapDb[strFile] = NULL;
+
+      switch (result)
+      {
+        case DB_LOCK_DEADLOCK:
+          LogPrint(BCLog::DB,"Deadlock %i\n", result);
+          break;
+        case DB_LOCK_NOTGRANTED:
+          LogPrint(BCLog::DB,"Lock Not Granted %i\n", result);
+          break;
+        case DB_REP_HANDLE_DEAD:
+          LogPrint(BCLog::DB,"Handle Dead %i\n", result);
+          break;
+        case DB_REP_LOCKOUT:
+          LogPrint(BCLog::DB,"Rep Lockout %i\n", result);
+          break;
+        case EACCES:
+          LogPrint(BCLog::DB,"Eacces %i\n", result);
+          break;
+        case EINVAL:
+          LogPrint(BCLog::DB,"Error Invalid %i\n", result);
+          break;
+        case 0:
+          LogPrint(BCLog::DB,"Wallet Compact Sucessful\n");
+          break;
+        default:
+          LogPrint(BCLog::DB,"Compact result int %i\n", result);
+      }
+    }
+    return (result == 0);
 }
 
 bool CDBEnv::Salvage(std::string strFile, bool fAggressive, std::vector<CDBEnv::KeyValPair>& vResult)

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -66,6 +66,7 @@ public:
      * NOTE: reads the entire database into memory, so cannot be used
      * for huge databases.
      */
+    bool Compact(const std::string& strFile);
     typedef std::pair<std::vector<unsigned char>, std::vector<unsigned char> > KeyValPair;
     bool Salvage(std::string strFile, bool fAggressive, std::vector<KeyValPair>& vResult);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3065,6 +3065,27 @@ UniValue rescanwallettransactions(const UniValue& params, bool fHelp) {
     return "Done";
 }
 
+UniValue erasewallettransactions(const UniValue& params, bool fHelp) {
+    if (fHelp || params.size() != 0)
+        throw std::runtime_error(
+                "erasewallettransactions \n"
+                "\nErase wallet transactions based on prcycoin.conf parameters\n"
+                "\nResult:\n"
+                "\"erased wallet transactions\"    \n"
+                "\nExamples:\n" +
+                HelpExampleCli("erasewallettransactions", "") + HelpExampleCli("erasewallettransactions", "\"\"") +
+                HelpExampleRpc("erasewallettransactions", ""));
+
+    EnsureWallet();
+    EnsureWalletIsUnlocked();
+
+    CBlockIndex* pindex = chainActive.Tip();
+
+    pwalletMain->DeleteWalletTransactions(pindex);
+
+    return "Done";
+}
+
 UniValue revealmnemonicphrase(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -54,6 +54,11 @@ bool fSendFreeTransactions = false;
 bool fPayAtLeastCustomFee = true;
 int64_t nStartupTime = GetTime();
 int64_t nReserveBalance = 0;
+bool fTxDeleteEnabled = false;
+bool fTxConflictDeleteEnabled = false;
+int fDeleteInterval = DEFAULT_TX_DELETE_INTERVAL;
+unsigned int fDeleteTransactionsAfterNBlocks = DEFAULT_TX_RETENTION_BLOCKS;
+unsigned int fKeepLastNTransactions = DEFAULT_TX_RETENTION_LASTTX;
 
 #include "uint256.h"
 
@@ -858,6 +863,22 @@ bool CWallet::IsSpent(const uint256& hash, unsigned int n)
     }
 
     return false;
+}
+
+unsigned int CWallet::GetSpendDepth(const uint256& hash, unsigned int n) const
+{
+    const COutPoint outpoint(hash, n);
+    std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range;
+    range = mapTxSpends.equal_range(outpoint);
+
+    for (TxSpends::const_iterator it = range.first; it != range.second; ++it)
+    {
+        const uint256& wtxid = it->second;
+        std::map<uint256, CWalletTx>::const_iterator mit = mapWallet.find(wtxid);
+        if (mit != mapWallet.end() && mit->second.GetDepthInMainChain() >= 0)
+            return mit->second.GetDepthInMainChain(); // Spent
+    }
+    return 0;
 }
 
 void CWallet::AddToSpends(const COutPoint& outpoint, const uint256& wtxid)
@@ -1726,6 +1747,228 @@ bool CWalletTx::WriteToDisk(CWalletDB *pwalletdb)
     if (pwalletdb)
         return pwalletdb->WriteTx(GetHash(), *this);
     return CWalletDB(pwallet->strWalletFile).WriteTx(GetHash(), *this);
+}
+
+/**
+ * Reorder the transactions based on block hieght and block index.
+ * Transactions can get out of order when they are deleted and subsequently
+ * re-added during intial load rescan.
+ */
+void CWallet::ReorderWalletTransactions(std::map<std::pair<int,int>, CWalletTx> &mapSorted, int64_t &maxOrderPos)
+{
+    LOCK2(cs_main, cs_wallet);
+
+    int maxSortNumber = chainActive.Tip()->nHeight + 1;
+
+    for (std::map<uint256, CWalletTx>::iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
+    {
+        CWalletTx wtx = it->second;
+        int confirms = wtx.GetDepthInMainChain();
+        maxOrderPos = std::max(maxOrderPos, wtx.nOrderPos);
+
+        if (confirms > 0) {
+            int wtxHeight = mapBlockIndex[wtx.hashBlock]->nHeight;
+            auto key = std::make_pair(wtxHeight, wtx.nIndex);
+            mapSorted.insert(make_pair(key, wtx));
+        }
+        else {
+          auto key = std::make_pair(maxSortNumber, 0);
+          mapSorted.insert(std::make_pair(key, wtx));
+          maxSortNumber++;
+        }
+    }
+}
+
+/**
+ * Update the nOrderPos with passed in ordered map.
+ */
+void CWallet::UpdateWalletTransactionOrder(std::map<std::pair<int,int>, CWalletTx> &mapSorted, bool resetOrder)
+{
+    LOCK2(cs_main, cs_wallet);
+
+    int64_t previousPosition = 0;
+    std::map<const uint256, CWalletTx> mapUpdatedTxs;
+
+    //Check the postion of each transaction relative to the previous one.
+    for (std::map<std::pair<int,int>, CWalletTx>::iterator it = mapSorted.begin(); it != mapSorted.end(); ++it) {
+        CWalletTx wtx = it->second;
+        const uint256 wtxid = wtx.GetHash();
+
+        if (wtx.nOrderPos <= previousPosition || resetOrder) {
+            previousPosition++;
+            wtx.nOrderPos = previousPosition;
+            mapUpdatedTxs.insert(std::make_pair(wtxid, wtx));
+        }
+        else {
+            previousPosition = wtx.nOrderPos;
+        }
+    }
+
+    //Update transactions nOrderPos for transactions that changed
+    CWalletDB walletdb(strWalletFile, "r+", false);
+    for (std::map<const uint256, CWalletTx>::iterator it = mapUpdatedTxs.begin(); it != mapUpdatedTxs.end(); ++it) {
+        CWalletTx wtx = it->second;
+        LogPrint(BCLog::DELETETX,"Reorder Tx - Updating Positon to %i for Tx %s\n ", wtx.nOrderPos, wtx.GetHash().ToString());
+        wtx.WriteToDisk(&walletdb);
+        mapWallet[wtx.GetHash()].nOrderPos = wtx.nOrderPos;
+    }
+
+    //Update Next Wallet Tx Positon
+    nOrderPosNext = previousPosition++;
+    CWalletDB(strWalletFile).WriteOrderPosNext(nOrderPosNext);
+    LogPrint(BCLog::DELETETX,"Reorder Tx - Total Transactions Reordered %i, Next Position %i\n ", mapUpdatedTxs.size(), nOrderPosNext);
+
+}
+
+/**
+ * Delete transactions from the Wallet
+ */
+void CWallet::DeleteTransactions(std::vector<uint256> &removeTxs)
+{
+    LOCK(cs_wallet);
+
+    CWalletDB walletdb(strWalletFile, "r+", false);
+
+    for (int i = 0; i< removeTxs.size(); i++) {
+        if (mapWallet.erase(removeTxs[i])) {
+            walletdb.EraseTx(removeTxs[i]);
+            LogPrint(BCLog::DELETETX,"Delete Tx - Deleting tx %s, %i.\n", removeTxs[i].ToString(),i);
+        } else {
+            LogPrint(BCLog::DELETETX,"Delete Tx - Deleting tx %failed.\n", removeTxs[i].ToString());
+            return;
+        }
+    }
+}
+
+void CWallet::DeleteWalletTransactions(const CBlockIndex* pindex)
+{
+    LOCK2(cs_main, cs_wallet);
+
+    int nDeleteAfter = (int)fDeleteTransactionsAfterNBlocks;
+    bool runCompact = false;
+
+    if (pindex && fTxDeleteEnabled) {
+
+        //Check for acentries - exit function if found
+        {
+            std::list<CAccountingEntry> acentries;
+            CWalletDB walletdb(strWalletFile);
+            walletdb.ListAccountCreditDebit("*", acentries);
+            if (acentries.size() > 0) {
+                LogPrintf("deletetx not compatible to account entries\n");
+                return;
+            }
+        }
+        //delete transactions
+
+        //Sort Transactions by block and block index
+        int64_t maxOrderPos = 0;
+        std::map<std::pair<int,int>, CWalletTx> mapSorted;
+        ReorderWalletTransactions(mapSorted, maxOrderPos);
+        if (maxOrderPos > int64_t(mapSorted.size())*10) {
+            //reset the postion when the max postion is 10x bigger than the
+            //number of transactions in the wallet
+            LogPrint(BCLog::DELETETX,"Reorder Tx - maxOrderPos %i mapSorted Size %i\n", maxOrderPos, int64_t(mapSorted.size())*10);
+            UpdateWalletTransactionOrder(mapSorted, true);
+        }
+        else {
+            UpdateWalletTransactionOrder(mapSorted, false);
+        }
+
+        //Process Transactions in sorted order
+        int txConflictCount = 0;
+        int txUnConfirmed = 0;
+        int txCount = 0;
+        int txSaveCount = 0;
+        std::vector<uint256> removeTxs;
+
+        for (auto & item : mapSorted)
+        {
+            CWalletTx& wtx = item.second;
+            const uint256& wtxid = wtx.GetHash();
+            bool deleteTx = true;
+            txCount += 1;
+            int wtxDepth = wtx.GetDepthInMainChain();
+
+            //Keep anything newer than N Blocks
+            if (wtxDepth == 0)
+                txUnConfirmed++;
+
+            if (wtxDepth < nDeleteAfter && wtxDepth >= 0) {
+                LogPrint(BCLog::DELETETX,"DeleteTx - Transaction above minimum depth, tx %s\n", wtx.GetHash().ToString());
+                deleteTx = false;
+                txSaveCount++;
+                continue;
+            } else if (wtxDepth == -1) {
+                //Enabled by default
+                if (!fTxConflictDeleteEnabled) {
+                    LogPrint(BCLog::DELETETX,"DeleteTx - Conflict delete is not enabled tx %s\n", wtx.GetHash().ToString());
+                    deleteTx = false;
+                    txSaveCount++;
+                    continue;
+                } else {
+                    txConflictCount++;
+                }
+            } else {
+                //Check for unspent inputs or spend less than N Blocks ago.
+                for (unsigned int i = 0; i < wtx.vout.size(); i++) {
+                    CTxDestination address;
+                    ExtractDestination(wtx.vout[i].scriptPubKey, address);
+                    if(IsMine(wtx.vout[i])) {
+                        if (pwalletMain->GetSpendDepth(wtx.GetHash(), i) <= fDeleteTransactionsAfterNBlocks) {
+                            LogPrint(BCLog::DELETETX,"DeleteTx - Unspent input tx %s\n", wtx.GetHash().ToString());
+                            deleteTx = false;
+                            continue;
+                        }
+                    }
+                }
+
+                if (!deleteTx) {
+                    txSaveCount++;
+                    continue;
+                }
+
+                //Chcek for output with that no longer have parents in the wallet.
+                for (int i = 0; i < wtx.vin.size(); i++) {
+                    const CTxIn& txin = wtx.vin[i];
+                    const uint256& parentHash = txin.prevout.hash;
+                    const CWalletTx* parent = pwalletMain->GetWalletTx(txin.prevout.hash);
+                    if (parent != NULL && parentHash != wtxid) {
+                        LogPrint(BCLog::DELETETX,"DeleteTx - Parent of tx %s found\n", wtx.GetHash().ToString());
+                        deleteTx = false;
+                        continue;
+                    }
+                }
+
+                if (!deleteTx) {
+                    txSaveCount++;
+                    continue;
+                }
+
+                //Keep Last N Transactions
+                if (mapSorted.size() - txCount < fKeepLastNTransactions + txConflictCount + txUnConfirmed) {
+                    LogPrint(BCLog::DELETETX,"DeleteTx - Transaction set position %i, tx %s\n", mapSorted.size() - txCount, wtxid.ToString());
+                    deleteTx = false;
+                    txSaveCount++;
+                    continue;
+                }
+            }
+
+            //Collect everything else for deletion
+            if (deleteTx && int(removeTxs.size()) < MAX_DELETE_TX_SIZE) {
+                removeTxs.push_back(wtxid);
+                runCompact = true;
+            }
+        }
+
+        //Delete Transactions from wallet
+        DeleteTransactions(removeTxs);
+        LogPrintf("Delete Tx - Total Transaction Count %i, Transactions Deleted %i\n ", txCount, int(removeTxs.size()));
+
+        //Compress Wallet
+        if (runCompact)
+            CWalletDB::Compact(bitdb,strWalletFile);
+    }
 }
 
 /**

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -75,7 +75,7 @@ static const unsigned int MAX_FREE_TRANSACTION_CREATE_SIZE = 1000;
 static const int DEFAULT_CUSTOMBACKUPTHRESHOLD = 1;
 
 //Default Transaction Retention N-BLOCKS
-static const int DEFAULT_TX_DELETE_INTERVAL = 1000;
+static const int DEFAULT_TX_DELETE_INTERVAL = 10000;
 
 //Default Transaction Retention N-BLOCKS
 static const unsigned int DEFAULT_TX_RETENTION_BLOCKS = 10000;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -55,6 +55,11 @@ extern bool bdisableSystemnotifications;
 extern bool fSendFreeTransactions;
 extern bool fPayAtLeastCustomFee;
 extern int64_t nReserveBalance;
+extern bool fTxDeleteEnabled;
+extern bool fTxConflictDeleteEnabled;
+extern int fDeleteInterval;
+extern unsigned int fDeleteTransactionsAfterNBlocks;
+extern unsigned int fKeepLastNTransactions;
 
 //! -paytxfee default
 static const CAmount DEFAULT_TRANSACTION_FEE = 0.1 * COIN;//
@@ -68,6 +73,18 @@ static const CAmount nHighTransactionMaxFeeWarning = 100 * nHighTransactionFeeWa
 static const unsigned int MAX_FREE_TRANSACTION_CREATE_SIZE = 1000;
 //! -custombackupthreshold default
 static const int DEFAULT_CUSTOMBACKUPTHRESHOLD = 1;
+
+//Default Transaction Retention N-BLOCKS
+static const int DEFAULT_TX_DELETE_INTERVAL = 1000;
+
+//Default Transaction Retention N-BLOCKS
+static const unsigned int DEFAULT_TX_RETENTION_BLOCKS = 10000;
+
+//Default Retenion Last N-Transactions
+static const unsigned int DEFAULT_TX_RETENTION_LASTTX = 200;
+
+//Amount of transactions to delete per run while syncing
+static const int MAX_DELETE_TX_SIZE = 50000;
 
 // 6666 = 1*5000 + 1*1000 + 1*500 + 1*100 + 1*50 + 1*10 + 1*5 + 1
 static const int ZQ_6666 = 6666;
@@ -382,6 +399,7 @@ public:
     bool GetVinAndKeysFromOutput(COutput out, CTxIn& txinRet, CPubKey& pubKeyRet, CKey& keyRet);
 
     bool IsSpent(const uint256& hash, unsigned int n);
+    unsigned int GetSpendDepth(const uint256& hash, unsigned int n) const;
 
     bool IsLockedCoin(uint256 hash, unsigned int n) const;
     void LockCoin(COutPoint& output);
@@ -459,6 +477,10 @@ public:
     void SyncTransaction(const CTransaction& tx, const CBlock* pblock);
     bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate);
     void EraseFromWallet(const uint256& hash);
+    void ReorderWalletTransactions(std::map<std::pair<int,int>, CWalletTx> &mapSorted, int64_t &maxOrderPos);
+    void UpdateWalletTransactionOrder(std::map<std::pair<int,int>, CWalletTx> &mapSorted, bool resetOrder);
+    void DeleteTransactions(std::vector<uint256> &removeTxs);
+    void DeleteWalletTransactions(const CBlockIndex* pindex);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false, bool fromStartup = false, int height = -1);
     void ReacceptWalletTransactions();
     void ResendWalletTransactions();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -477,8 +477,8 @@ public:
     void SyncTransaction(const CTransaction& tx, const CBlock* pblock);
     bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate);
     void EraseFromWallet(const uint256& hash);
-    void ReorderWalletTransactions(std::map<std::pair<int,int>, CWalletTx> &mapSorted, int64_t &maxOrderPos);
-    void UpdateWalletTransactionOrder(std::map<std::pair<int,int>, CWalletTx> &mapSorted, bool resetOrder);
+    void ReorderWalletTransactions(std::map<std::pair<int,int>, CWalletTx*> &mapSorted, int64_t &maxOrderPos);
+    void UpdateWalletTransactionOrder(std::map<std::pair<int,int>, CWalletTx*> &mapSorted, bool resetOrder);
     void DeleteTransactions(std::vector<uint256> &removeTxs);
     void DeleteWalletTransactions(const CBlockIndex* pindex);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false, bool fromStartup = false, int height = -1);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -463,69 +463,6 @@ void CWalletDB::ListAccountCreditDebit(const std::string& strAccount, std::list<
     pcursor->close();
 }
 
-DBErrors CWalletDB::ReorderTransactions(CWallet* pwallet)
-{
-    LOCK(pwallet->cs_wallet);
-    // Old wallets didn't have any defined order for transactions
-    // Probably a bad idea to change the output of this
-
-    // First: get all CWalletTx and CAccountingEntry into a sorted-by-time multimap.
-    typedef std::pair<CWalletTx*, CAccountingEntry*> TxPair;
-    typedef std::multimap<int64_t, TxPair> TxItems;
-    TxItems txByTime;
-
-    for (std::map<uint256, CWalletTx>::iterator it = pwallet->mapWallet.begin(); it != pwallet->mapWallet.end(); ++it) {
-        CWalletTx* wtx = &((*it).second);
-        txByTime.insert(std::make_pair(wtx->nTimeReceived, TxPair(wtx, (CAccountingEntry*)0)));
-    }
-    std::list<CAccountingEntry> acentries;
-    ListAccountCreditDebit("", acentries);
-    for (CAccountingEntry& entry : acentries) {
-        txByTime.insert(std::make_pair(entry.nTime, TxPair((CWalletTx*)0, &entry)));
-    }
-
-    int64_t& nOrderPosNext = pwallet->nOrderPosNext;
-    nOrderPosNext = 0;
-    std::vector<int64_t> nOrderPosOffsets;
-    for (TxItems::iterator it = txByTime.begin(); it != txByTime.end(); ++it) {
-        CWalletTx* const pwtx = (*it).second.first;
-        CAccountingEntry* const pacentry = (*it).second.second;
-        int64_t& nOrderPos = (pwtx != 0) ? pwtx->nOrderPos : pacentry->nOrderPos;
-
-        if (nOrderPos == -1) {
-            nOrderPos = nOrderPosNext++;
-            nOrderPosOffsets.push_back(nOrderPos);
-
-            if (pwtx) {
-                if (!WriteTx(pwtx->GetHash(), *pwtx))
-                    return DB_LOAD_FAIL;
-            } else if (!WriteAccountingEntry(pacentry->nEntryNo, *pacentry))
-                return DB_LOAD_FAIL;
-        } else {
-            int64_t nOrderPosOff = 0;
-            for (const int64_t& nOffsetStart : nOrderPosOffsets) {
-                if (nOrderPos >= nOffsetStart)
-                    ++nOrderPosOff;
-            }
-            nOrderPos += nOrderPosOff;
-            nOrderPosNext = std::max(nOrderPosNext, nOrderPos + 1);
-
-            if (!nOrderPosOff)
-                continue;
-
-            // Since we're changing the order, write it back
-            if (pwtx) {
-                if (!WriteTx(pwtx->GetHash(), *pwtx))
-                    return DB_LOAD_FAIL;
-            } else if (!WriteAccountingEntry(pacentry->nEntryNo, *pacentry))
-                return DB_LOAD_FAIL;
-        }
-    }
-    WriteOrderPosNext(nOrderPosNext);
-
-    return DB_LOAD_OK;
-}
-
 class CWalletScanState
 {
 public:
@@ -895,8 +832,11 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
     if (wss.nFileVersion < CLIENT_VERSION) // Update
         WriteVersion(CLIENT_VERSION);
 
-    if (wss.fAnyUnordered)
-        result = ReorderTransactions(pwallet);
+    //Sort Transactions by block and block index, then reorder
+    int64_t maxOrderPos = 0;
+    std::map<std::pair<int,int>, CWalletTx> mapSorted;
+    pwallet->ReorderWalletTransactions(mapSorted, maxOrderPos);
+    pwallet->UpdateWalletTransactionOrder(mapSorted, true);
 
     pwallet->laccentries.clear();
     ListAccountCreditDebit("*", pwallet->laccentries);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1180,6 +1180,12 @@ bool AttemptBackupWallet(const CWallet& wallet, const fs::path& pathSrc, const f
     return retStatus;
 }
 
+bool CWalletDB::Compact(CDBEnv& dbenv, const std::string& strFile)
+{
+  bool fSuccess = dbenv.Compact(strFile);
+  return fSuccess;
+}
+
 //
 // Try to (very carefully!) recover wallet.dat if there is a problem.
 //

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -832,12 +832,6 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
     if (wss.nFileVersion < CLIENT_VERSION) // Update
         WriteVersion(CLIENT_VERSION);
 
-    //Sort Transactions by block and block index, then reorder
-    int64_t maxOrderPos = 0;
-    std::map<std::pair<int,int>, CWalletTx*> mapSorted;
-    pwallet->ReorderWalletTransactions(mapSorted, maxOrderPos);
-    pwallet->UpdateWalletTransactionOrder(mapSorted, true);
-
     pwallet->laccentries.clear();
     ListAccountCreditDebit("*", pwallet->laccentries);
     for(CAccountingEntry& entry : pwallet->laccentries) {

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -834,7 +834,7 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
 
     //Sort Transactions by block and block index, then reorder
     int64_t maxOrderPos = 0;
-    std::map<std::pair<int,int>, CWalletTx> mapSorted;
+    std::map<std::pair<int,int>, CWalletTx*> mapSorted;
     pwallet->ReorderWalletTransactions(mapSorted, maxOrderPos);
     pwallet->UpdateWalletTransactionOrder(mapSorted, true);
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -179,7 +179,6 @@ public:
     CAmount GetAccountCreditDebit(const std::string& strAccount);
     void ListAccountCreditDebit(const std::string& strAccount, std::list<CAccountingEntry>& acentries);
 
-    DBErrors ReorderTransactions(CWallet* pwallet);
     DBErrors LoadWallet(CWallet* pwallet);
     DBErrors FindWalletTx(CWallet* pwallet, std::vector<uint256>& vTxHash, std::vector<CWalletTx>& vWtx);
     DBErrors ZapWalletTx(CWallet* pwallet, std::vector<CWalletTx>& vWtx);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -183,6 +183,7 @@ public:
     DBErrors LoadWallet(CWallet* pwallet);
     DBErrors FindWalletTx(CWallet* pwallet, std::vector<uint256>& vTxHash, std::vector<CWalletTx>& vWtx);
     DBErrors ZapWalletTx(CWallet* pwallet, std::vector<CWalletTx>& vWtx);
+    static bool Compact(CDBEnv& dbenv, const std::string& strFile);
     static bool Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys);
     static bool Recover(CDBEnv& dbenv, std::string filename);
 


### PR DESCRIPTION
First implementation of `DeleteWalletTransactions`, based on the work by @CryptoForge in https://github.com/PirateNetwork/pirate/pull/5 (+ some additional commits surrounding the code from https://github.com/PirateNetwork/pirate/pull/14 & https://github.com/PirateNetwork/pirate/pull/20)

Modified for our code, also adding an RPC command `erasewallettransactions` to run the function on demand.
Otherwise, it will run on a PoA block for now (which makes it run in an approximately hourly interval). Open to different ideas about the intervals/defaults.

Added:
```
-deletetx - "Enable Old Transaction Deletion"
-deleteinterval - "Delete transaction every <n> blocks during inital block download"
-keeptxnum - "Keep the last <n> transactions"
-keeptxfornblocks - "Keep transactions for at least <n> blocks"
-debug=deletetx - "Display logs for the function"
```

Defaults:
```
//Default Transaction Retention N-BLOCKS
static const int DEFAULT_TX_DELETE_INTERVAL = 10000;

//Default Transaction Retention N-BLOCKS
static const unsigned int DEFAULT_TX_RETENTION_BLOCKS = 10000;

//Default Retenion Last N-Transactions
static const unsigned int DEFAULT_TX_RETENTION_LASTTX = 200;

//Amount of transactions to delete per run while syncing
static const int MAX_DELETE_TX_SIZE = 50000;
```

Some additional work to follow, but functions well as is.