### PR TITLE
Remove Height for Version Block

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -453,7 +453,7 @@ bool CNode::DisconnectOldProtocol(int nVersionRequired, std::string strLastComma
 
 bool CNode::DisconnectOldVersion(std::string strSubVer, int nHeight, std::string strLastCommand) {
     fDisconnect = false;
-    if (nHeight >= Params().FixChecks()) {
+    //if (nHeight >= Params().FixChecks()) {
         if (strSubVer == "/PRCY:1.0.0.2/" || strSubVer == "/PRCY:1.0.0.3/" ||
                 strSubVer == "/PRCY:1.0.0.4/" || strSubVer == "/PRCY:1.0.0.5/" ||
                 strSubVer == "/PRCY:1.0.0.6/" || strSubVer == "/PRCY:1.0.0.7/" ||
@@ -466,7 +466,7 @@ bool CNode::DisconnectOldVersion(std::string strSubVer, int nHeight, std::string
                         strprintf("Using unsupported version %i; disconnecting\n", strSubVer));
             fDisconnect = true;
         }
-    }
+    //}
     return fDisconnect;
 }
 


### PR DESCRIPTION
Since the version block is already in place, no need to check for the heights here.