### PR TITLE
[Upstream] depends: Purge libtool archives

### DIFF
--- a/depends/packages.md
+++ b/depends/packages.md
@@ -151,6 +151,18 @@ Most autotools projects can be properly staged using:
 
     $(MAKE) DESTDIR=$($(package)_staging_dir) install
 
+## Build outputs:
+
+In general, the output of a depends package should not contain any libtool
+archives. Instead, the package should output `.pc` (`pkg-config`) files where
+possible.
+
+From the [Gentoo Wiki entry](https://wiki.gentoo.org/wiki/Project:Quality_Assurance/Handling_Libtool_Archives):
+
+>  Libtool pulls in all direct and indirect dependencies into the .la files it
+>  creates. This leads to massive overlinking, which is toxic to the Gentoo
+>  ecosystem, as it leads to a massive number of unnecessary rebuilds.
+
 ## Secondary dependencies:
 
 Secondary dependency packages relative to the bitcoin binaries/libraries (i.e.

--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -20,3 +20,7 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef

--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -5,7 +5,8 @@ $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=17b43c2716d521369f82fc2dc70f359860e90fa440bea65b3b85f0b246ea81f2
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-static --without-docbook
+  $(package)_config_opts=--disable-shared --without-docbook
+  $(package)_config_opts_linux=--with-pic
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/fontconfig.mk
+++ b/depends/packages/fontconfig.mk
@@ -26,3 +26,7 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef

--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -20,3 +20,7 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef

--- a/depends/packages/libXau.mk
+++ b/depends/packages/libXau.mk
@@ -25,3 +25,7 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -35,4 +35,5 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
+  rm lib/*.la
 endef

--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -44,5 +44,5 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  rm -rf share/man share/doc
+  rm -rf share/man share/doc lib/*.la
 endef

--- a/depends/packages/qrencode.mk
+++ b/depends/packages/qrencode.mk
@@ -25,3 +25,7 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -30,5 +30,5 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  rm -rf bin share
+  rm -rf bin share lib/*.la
 endef


### PR DESCRIPTION
>We use pkg-config where we can, which generally replaces libtool at a
higher level and does not have the same downsides as libtool. These
archives sit in our depends tree with no purpose and pollute the final
bitcoin build with massive overlinking.
See [here](https://wiki.gentoo.org/wiki/Project:Quality_Assurance/Handling_Libtool_Archives) for an explanation of the various problems libtool archives can cause.

>Unrelated in every way except in spirit: -D__LIBTOOL_IS_A_FOOL__!!

from https://github.com/bitcoin/bitcoin/pull/15844