### PR TITLE
[Upstream] build: Set minimum Automake version to 1.13

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,14 +34,14 @@ dnl faketime breaks configure and is only needed for make. Disable it here.
 unset FAKETIME
 
 dnl Automake init set-up and checks
-AM_INIT_AUTOMAKE([no-define subdir-objects foreign])
+AM_INIT_AUTOMAKE([1.13 no-define subdir-objects foreign])
 
 dnl faketime messes with timestamps and causes configure to be re-run.
 dnl --disable-maintainer-mode can be used to bypass this.
 AM_MAINTAINER_MODE([enable])
 
 dnl make the compilation flags quiet unless V=1 is used
-m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+AM_SILENT_RULES([yes])
 
 dnl Compiler checks (here before libtool).
 if test "x${CXXFLAGS+set}" = "xset"; then


### PR DESCRIPTION
>This PR suggests to set the required minimum Automake version to 1.13 explicitly for the following reasons:

>it guarantees that [CVE-2012-3386](https://lists.gnu.org/archive/html/automake/2012-07/msg00023.html) has been fixed
AC_CONFIG_MACRO_DIR macro support, which we already use; from the [release notes](https://lists.gnu.org/archive/html/automake/2012-12/msg00038.html):
Improvements to aclocal and related rebuilds rules:

>Autoconf-provided macros AC_CONFIG_MACRO_DIR and AC_CONFIG_MACRO_DIRS are now traced by aclocal, and can be used to declare the local m4 include directories. Formerly, one had to specify it with an explicit '-I' option to the 'aclocal' invocation.
AM_SILENT_RULES macro support (since version 1.11)
Automake 1.13 requires Autoconf 2.65 or greater. We already have 2.69 since https://github.com/bitcoin/bitcoin/pull/17769.

>For reference, Automake 1.13 was released in [December of 2012](https://lists.gnu.org/archive/html/automake/2012-12/msg00038.html).

>CentOS 7 uses Automake [1.13.4](https://centos.pkgs.org/7/centos-x86_64/automake-1.13.4-3.el7.noarch.rpm.html)

>See the Automake docs for more info:

[AM_INIT_AUTOMAKE](https://www.gnu.org/software/automake/manual/automake.html#Public-Macros)
[List of Automake options](https://www.gnu.org/software/automake/manual/automake.html#List-of-Automake-options)

from https://github.com/bitcoin/bitcoin/pull/18290