### PR TITLE
[Upstream] build: Cleanup depends build system

### DIFF
--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -22,5 +22,5 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  rm lib/*.la
+  rm -rf share lib/*.la
 endef

--- a/depends/packages/fontconfig.mk
+++ b/depends/packages/fontconfig.mk
@@ -28,5 +28,5 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  rm lib/*.la
+  rm -rf var lib/*.la
 endef

--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -22,5 +22,5 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  rm lib/*.la
+  rm -rf share/man lib/*.la
 endef

--- a/depends/packages/libXau.mk
+++ b/depends/packages/libXau.mk
@@ -29,5 +29,5 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  rm lib/*.la
+  rm -rf share lib/*.la
 endef

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -235,7 +235,6 @@ endef
 define $(package)_config_cmds
   export PKG_CONFIG_SYSROOT_DIR=/ && \
   export PKG_CONFIG_LIBDIR=$(host_prefix)/lib/pkgconfig && \
-  export PKG_CONFIG_PATH=$(host_prefix)/share/pkgconfig  && \
   ./configure $($(package)_config_opts) && \
   echo "host_build: QT_CONFIG ~= s/system-zlib/zlib" >> mkspecs/qconfig.pri && \
   echo "CONFIG += force_bootstrap" >> mkspecs/qconfig.pri && \


### PR DESCRIPTION
> This PR:
>- removes non-existent share/pkgconfig path from PKG_CONFIG_PATH. This change, actually, make PKG_CONFIG_PATH unused in the depends build system
>- removes doc, man and empty directories from the built packages

from https://github.com/bitcoin/bitcoin/pull/22783