### PR TITLE
[Upstream] build: fix mingw miniupnpc cflags

### DIFF
--- a/depends/packages/miniupnpc.mk
+++ b/depends/packages/miniupnpc.mk
@@ -3,7 +3,7 @@ $(package)_version=2.2.2
 $(package)_download_path=https://miniupnp.tuxfamily.org/files/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=888fb0976ba61518276fe1eda988589c700a3f2a69d71089260d75562afd3687
-$(package)_patches=dont_leak_info.patch
+$(package)_patches=dont_leak_info.patch respect_mingw_cflags.patch
 
 define $(package)_set_vars
 $(package)_build_opts=CC="$($(package)_cc)"
@@ -13,7 +13,8 @@ $(package)_build_env+=CFLAGS="$($(package)_cflags) $($(package)_cppflags)" AR="$
 endef
 
 define $(package)_preprocess_cmds
-  patch -p1 < $($(package)_patch_dir)/dont_leak_info.patch
+  patch -p1 < $($(package)_patch_dir)/dont_leak_info.patch && \
+  patch -p1 < $($(package)_patch_dir)/respect_mingw_cflags.patch
 endef
 
 define $(package)_build_cmds

--- a/depends/packages/miniupnpc.mk
+++ b/depends/packages/miniupnpc.mk
@@ -5,10 +5,12 @@ $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=888fb0976ba61518276fe1eda988589c700a3f2a69d71089260d75562afd3687
 $(package)_patches=dont_leak_info.patch respect_mingw_cflags.patch
 
+# Next time this package is updated, ensure that _WIN32_WINNT is still properly set.
+# See discussion in https://github.com/bitcoin/bitcoin/pull/25964.
 define $(package)_set_vars
 $(package)_build_opts=CC="$($(package)_cc)"
 $(package)_build_opts_darwin=LIBTOOL="$($(package)_libtool)"
-$(package)_build_opts_mingw32=-f Makefile.mingw
+$(package)_build_opts_mingw32=-f Makefile.mingw CFLAGS="$($(package)_cflags) -D_WIN32_WINNT=0x0601"
 $(package)_build_env+=CFLAGS="$($(package)_cflags) $($(package)_cppflags)" AR="$($(package)_ar)"
 endef
 

--- a/depends/patches/miniupnpc/respect_mingw_cflags.patch
+++ b/depends/patches/miniupnpc/respect_mingw_cflags.patch
@@ -1,0 +1,23 @@
+commit fec515a7ac9991a0ee91068fda046b54b191155e
+Author: fanquake <fanquake@gmail.com>
+Date:   Wed Jul 27 15:52:37 2022 +0100
+
+    build: respect CFLAGS in makefile.mingw
+    
+    Similar to the other Makefile.
+
+    Cherry-pick of https://github.com/miniupnp/miniupnp/pull/619.
+
+diff --git a/Makefile.mingw b/Makefile.mingw
+index 2bff7bd..88430d2 100644
+--- a/Makefile.mingw
++++ b/Makefile.mingw
+@@ -19,7 +19,7 @@ else
+ RM = rm -f
+ endif
+ #CFLAGS = -Wall -g -DDEBUG -D_WIN32_WINNT=0X501
+-CFLAGS = -Wall -W -Wstrict-prototypes -Os -DNDEBUG -D_WIN32_WINNT=0X501
++CFLAGS ?= -Wall -W -Wstrict-prototypes -Os -DNDEBUG -D_WIN32_WINNT=0X501
+ LDLIBS = -lws2_32 -liphlpapi
+ # -lwsock32
+ # -liphlpapi is needed for GetBestRoute() and GetIpAddrTable()


### PR DESCRIPTION
> Pulls in a patch I've upstreamed to miniupnpc so that we properly pass our cflags when building it for mingw. See [miniupnp/miniupnp#619](https://github.com/miniupnp/miniupnp/pull/619). Also set `D_WIN32_WINNT` to `0x0601` to match libevent, configure etc. Previously it was being set to `0X501`.
> 
> Guix Build (x86_64 / arm64):
> 
> ```shell
> 39a66c473a45b83ca85500b32ccf8f30d4ae80f965ca064566ee9fd84a51964b  guix-build-859644b3c855/output/aarch64-linux-gnu/SHA256SUMS.part
> 7b0515e422f350cb23f4f0b2f87eaa1b30d1c80389da6f1cbe700794902c88e9  guix-build-859644b3c855/output/aarch64-linux-gnu/bitcoin-859644b3c855-aarch64-linux-gnu-debug.tar.gz
> 192253fb387a2216b6d63d47a18e34bfa284874488d7ebc6ba656ca76a905519  guix-build-859644b3c855/output/aarch64-linux-gnu/bitcoin-859644b3c855-aarch64-linux-gnu.tar.gz
> 0a8b5c77928a46e62dff85cf73ca9e932560533b99ef1ec374be00516f9e1183  guix-build-859644b3c855/output/arm-linux-gnueabihf/SHA256SUMS.part
> d1b01b36d7092d63ab84877e05a973d915d177dbc618fe00eeaff86295032750  guix-build-859644b3c855/output/arm-linux-gnueabihf/bitcoin-859644b3c855-arm-linux-gnueabihf-debug.tar.gz
> 50d9cd81a4a37fbd5c22ee8f1b8398a836879bda1b514a9ed3d0bcd6fd3de41f  guix-build-859644b3c855/output/arm-linux-gnueabihf/bitcoin-859644b3c855-arm-linux-gnueabihf.tar.gz
> e590d6dc6687c744b4067af330a7fe44110da4972c46f0262c39ce03e2aa6ac5  guix-build-859644b3c855/output/arm64-apple-darwin/SHA256SUMS.part
> 6b9b97a1f6ead6d2b70d706ba39b11f36c2929962afc0d52404f2341d412d4e7  guix-build-859644b3c855/output/arm64-apple-darwin/bitcoin-859644b3c855-arm64-apple-darwin-unsigned.dmg
> de6be985a4e1b11c6450c388b54be4fff3dc3a78e528cb628623ee4a8ea249f4  guix-build-859644b3c855/output/arm64-apple-darwin/bitcoin-859644b3c855-arm64-apple-darwin-unsigned.tar.gz
> 940024658b9387040ceb26535dbd1ed7edb3709106f6e25d5d3720ed90bbbb2e  guix-build-859644b3c855/output/arm64-apple-darwin/bitcoin-859644b3c855-arm64-apple-darwin.tar.gz
> 67c8fcdd31dca595e5c6b72e597a135718dd50ce1f062cb18d181520c13d3013  guix-build-859644b3c855/output/dist-archive/bitcoin-859644b3c855.tar.gz
> 4b1954953913d1387589873a8e9dc9765f0f300c125270046da95a23c43aa069  guix-build-859644b3c855/output/powerpc64-linux-gnu/SHA256SUMS.part
> 5b12ab7e3a7fc162912e67e026646ee5d4c92ef804525504f188d9a569af7d67  guix-build-859644b3c855/output/powerpc64-linux-gnu/bitcoin-859644b3c855-powerpc64-linux-gnu-debug.tar.gz
> fa4debb24dbb4c9c515ad3bfa2e5cb9bd686f1062157bd4480d076ef35d7ea9d  guix-build-859644b3c855/output/powerpc64-linux-gnu/bitcoin-859644b3c855-powerpc64-linux-gnu.tar.gz
> bafad2f56aad4edd25e49e4cc658811cf87f32a2a2e013672659d410d7a8cac8  guix-build-859644b3c855/output/powerpc64le-linux-gnu/SHA256SUMS.part
> 96318cac800dc7ee86229754a76047dececd62ecd962362e6dbd1d694bc8c17a  guix-build-859644b3c855/output/powerpc64le-linux-gnu/bitcoin-859644b3c855-powerpc64le-linux-gnu-debug.tar.gz
> 461415ee7bf67e2c59bfce3a09736b3b0ecdc7c81751ce2bed19369237450154  guix-build-859644b3c855/output/powerpc64le-linux-gnu/bitcoin-859644b3c855-powerpc64le-linux-gnu.tar.gz
> 5c9d19f6af5d1fab7de7496bbdcd1cd266abd6c0e2c226b362dab2582c94a33a  guix-build-859644b3c855/output/riscv64-linux-gnu/SHA256SUMS.part
> 04492f5ce121ba09672119cc8861ee30ecdb814b34726c9c5d7971c528209a55  guix-build-859644b3c855/output/riscv64-linux-gnu/bitcoin-859644b3c855-riscv64-linux-gnu-debug.tar.gz
> 5fb28111b49e73fc53db2805500c275a2e6321c3e180695eb813675629dcd64c  guix-build-859644b3c855/output/riscv64-linux-gnu/bitcoin-859644b3c855-riscv64-linux-gnu.tar.gz
> 3f48c1c2ba77d4fda725225f6c9b5ab7f3aae244c8abb354407cc73d6547d983  guix-build-859644b3c855/output/x86_64-apple-darwin/SHA256SUMS.part
> 6dcfb5a4af350466fb7f9319e02fd4bcef66e015116c9eda8aff03b3ac53d109  guix-build-859644b3c855/output/x86_64-apple-darwin/bitcoin-859644b3c855-x86_64-apple-darwin-unsigned.dmg
> 87112cc5f2d02c16614f6d8df41af6f3ea3c765eb6d196d68d2b514b6bd317bc  guix-build-859644b3c855/output/x86_64-apple-darwin/bitcoin-859644b3c855-x86_64-apple-darwin-unsigned.tar.gz
> b245a4d4881a679f2c91e0c7fd5466d6b93313289e609dbce4e1009b7591332e  guix-build-859644b3c855/output/x86_64-apple-darwin/bitcoin-859644b3c855-x86_64-apple-darwin.tar.gz
> a4c3449aa9d8a8e1c8b0532f6e74845c40f90ad4186f480d5bb2750e184efc10  guix-build-859644b3c855/output/x86_64-linux-gnu/SHA256SUMS.part
> 12a32f25d6ef7f60023dd3053b21e31131350b6afa01aeab25e53d1928b1a0f5  guix-build-859644b3c855/output/x86_64-linux-gnu/bitcoin-859644b3c855-x86_64-linux-gnu-debug.tar.gz
> 93d603d89c9251e93992e3c0e176b094d981b020ef1d4bbfbff21806e50b962d  guix-build-859644b3c855/output/x86_64-linux-gnu/bitcoin-859644b3c855-x86_64-linux-gnu.tar.gz
> 79df55f4ca8f972665fd55b43550b2ab9ffafa8fc8de1335b324f4af047c6788  guix-build-859644b3c855/output/x86_64-w64-mingw32/SHA256SUMS.part
> 8d837e96595ab7337736da334d940ffc9d15215141f176804a528fe9e21f490a  guix-build-859644b3c855/output/x86_64-w64-mingw32/bitcoin-859644b3c855-win64-debug.zip
> 6c9541524f1d54eceb3265c6e79d62502fdc0c2e5263719a0ca357988d7ed718  guix-build-859644b3c855/output/x86_64-w64-mingw32/bitcoin-859644b3c855-win64-setup-unsigned.exe
> 7566ab4ee53092e81c3079db955d85c8d574cbde2be21526d45619076ffcd264  guix-build-859644b3c855/output/x86_64-w64-mingw32/bitcoin-859644b3c855-win64-unsigned.tar.gz
> 32164cfa7c06ead63305485653f37d74c6ada82d28b79f58e66faf6e72e130bb  guix-build-859644b3c855/output/x86_64-w64-mingw32/bitcoin-859644b3c855-win64.zip
> ```

from https://github.com/bitcoin/bitcoin/pull/25964
