### PR TITLE
[Upstream] build: Improve error message when pkg-config is not installed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ AC_CONFIG_HEADERS([src/config/prcycoin-config.h])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([build-aux/m4])
 
-m4_ifndef([PKG_PROG_PKG_CONFIG], [AC_MSG_ERROR([PKG_PROG_PKG_CONFIG macro not found. Please install pkg-config and re-run autogen.sh])])
+m4_ifndef([PKG_PROG_PKG_CONFIG], [m4_fatal([PKG_PROG_PKG_CONFIG macro not found. Please install pkg-config and re-run autogen.sh])])
 PKG_PROG_PKG_CONFIG
 if test "x$PKG_CONFIG" = x; then
   AC_MSG_ERROR([pkg-config not found])


### PR DESCRIPTION
>Fixes https://github.com/bitcoin/bitcoin/issues/24037.


>With this PR:

```
# ./autogen.sh 
configure.ac:16: error: PKG_PROG_PKG_CONFIG macro not found. Please install pkg-config and re-run autogen.sh
configure.ac:16: the top level
autom4te: /usr/bin/m4 failed with exit status: 1
aclocal: error: /usr/bin/autom4te failed with exit status: 1
autoreconf: aclocal failed with exit status: 1
```

from https://github.com/bitcoin/bitcoin/pull/24048