### PR TITLE
[Upstream] build: use zeromq 4.3.4 in depends & fix NetBSD 10 build

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -1,8 +1,8 @@
 package=zeromq
-$(package)_version=4.3.1
+$(package)_version=4.3.4
 $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d835cd21eb
+$(package)_sha256_hash=c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5
 $(package)_patches=remove_libstd_link.patch
 
 define $(package)_set_vars

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -3,7 +3,7 @@ $(package)_version=4.3.4
 $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5
-$(package)_patches=remove_libstd_link.patch
+$(package)_patches=remove_libstd_link.patch netbsd_kevent_void.patch
 
 define $(package)_set_vars
   $(package)_config_opts=--without-docs --disable-shared --disable-curve --disable-curve-keygen --disable-perf --disable-Werror --disable-drafts
@@ -18,10 +18,12 @@ endef
 
 define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/remove_libstd_link.patch && \
+  patch -p1 < $($(package)_patch_dir)/netbsd_kevent_void.patch && \
   cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub config
 endef
 
 define $(package)_config_cmds
+  ./autogen.sh && \
   $($(package)_autoconf)
 endef
 

--- a/depends/patches/zeromq/netbsd_kevent_void.patch
+++ b/depends/patches/zeromq/netbsd_kevent_void.patch
@@ -1,0 +1,57 @@
+commit 129137d5182967dbfcfec66bad843df2a992a78f
+Author: fanquake <fanquake@gmail.com>
+Date:   Mon Jan 3 20:13:33 2022 +0800
+
+    problem: kevent udata is now void* on NetBSD Current (10)
+    
+    solution: check for the intptr_t variant in configure.
+
+diff --git a/configure.ac b/configure.ac
+index 1a571291..402f8b86 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -308,6 +308,27 @@ case "${host_os}" in
+         if test "x$libzmq_netbsd_has_atomic" = "xno"; then
+             AC_DEFINE(ZMQ_FORCE_MUTEXES, 1, [Force to use mutexes])
+         fi
++        # NetBSD Current (to become 10) has changed the type of udata in it's
++        # kevent struct from intptr_t to void * to align with darwin and other
++        # BSDs, see upstream commit:
++        # https://github.com/NetBSD/src/commit/e5ead823eb916b56589d2c6c560dbcfe4a2d0afc
++        AC_MSG_CHECKING([whether kevent udata type is intptr_t])
++        AC_LANG_PUSH([C++])
++        AC_LINK_IFELSE([AC_LANG_PROGRAM(
++            [[#include <sys/types.h>
++              #include <sys/event.h>
++              #include <sys/time.h>]],
++            [[struct kevent ev;
++              intptr_t udata;
++              EV_SET(&ev, 0, 0, EV_ADD, 0, 0, udata);
++              return 0;]])],
++            [libzmq_netbsd_kevent_udata_intptr_t=yes],
++            [libzmq_netbsd_kevent_udata_intptr_t=no])
++        AC_LANG_POP([C++])
++        AC_MSG_RESULT([$libzmq_netbsd_kevent_udata_intptr_t])
++        if test "x$libzmq_netbsd_kevent_udata_intptr_t" = "xyes"; then
++            AC_DEFINE(ZMQ_NETBSD_KEVENT_UDATA_INTPTR_T, 1, [kevent udata type is intptr_t])
++        fi
+         ;;
+     *openbsd*|*bitrig*)
+         # Define on OpenBSD to enable all library features
+diff --git a/src/kqueue.cpp b/src/kqueue.cpp
+index 53d82ac4..a6a7a7f2 100644
+--- a/src/kqueue.cpp
++++ b/src/kqueue.cpp
+@@ -46,9 +46,9 @@
+ #include "i_poll_events.hpp"
+ #include "likely.hpp"
+ 
+-//  NetBSD defines (struct kevent).udata as intptr_t, everyone else
+-//  as void *.
+-#if defined ZMQ_HAVE_NETBSD
++// NetBSD up to version 9 defines (struct kevent).udata as intptr_t,
++// everyone else as void *.
++#if defined ZMQ_HAVE_NETBSD && defined(ZMQ_NETBSD_KEVENT_UDATA_INTPTR_T)
+ #define kevent_udata_t intptr_t
+ #else
+ #define kevent_udata_t void *


### PR DESCRIPTION
>This is a prerequisite for https://github.com/bitcoin/bitcoin/pull/23955. It updates zeromq to the latest available version, and adds a patch, https://github.com/zeromq/libzmq/pull/4326, to fix building on NetBSD Current (10).

from https://github.com/bitcoin/bitcoin/pull/23956