### PR TITLE
[Upstream] depends: expat 2.2.7

### DIFF
--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -1,11 +1,11 @@
 package=expat
-$(package)_version=2.2.6
-$(package)_download_path=https://github.com/libexpat/libexpat/releases/download/R_2_2_6/
+$(package)_version=2.2.7
+$(package)_download_path=https://github.com/libexpat/libexpat/releases/download/R_2_2_7/
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=17b43c2716d521369f82fc2dc70f359860e90fa440bea65b3b85f0b246ea81f2
+$(package)_sha256_hash=cbc9102f4a31a8dafd42d642e9a3aa31e79a0aedaa1f6efd2795ebc83174ec18
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared --without-docbook
+  $(package)_config_opts=--disable-shared --without-docbook --without-tests --without-examples
   $(package)_config_opts_linux=--with-pic
 endef
 

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -9,7 +9,7 @@ These are the dependencies currently used by PRCYCoin. You can find instructions
 | Boost | [1.71.0](https://www.boost.org/users/download/) | [1.57.0](https://github.com/PRCYCoin/PRCYCoin/pull/286) | No |  |  |
 | Clang |  | [3.3+](https://llvm.org/releases/download.html) (C++11 support) |  |  |  |
 | D-Bus | [1.10.18](https://cgit.freedesktop.org/dbus/dbus/tree/NEWS?h=dbus-1.10) |  | No | Yes |  |
-| Expat | [2.2.6](https://libexpat.github.io/) |  | No | Yes |  |
+| Expat | [2.2.7](https://libexpat.github.io/) |  | No | Yes |  |
 | fontconfig | [2.12.1](https://www.freedesktop.org/software/fontconfig/release/) |  | No | Yes |  |
 | FreeType | [2.7.1](https://download.savannah.gnu.org/releases/freetype) |  | No |  |  |
 | GCC |  | [4.8+](https://gcc.gnu.org/) (C++11 support) |  |  |  |


### PR DESCRIPTION
>Major changes in expat 2.2.7:

>- https://github.com/libexpat/libexpat/issues/186 https://github.com/libexpat/libexpat/pull/262 Fix extraction of namespace prefixes from XML names;
XML names with multiple colons could end up in the
wrong namespace, and take a high amount of RAM and CPU
resources while processing, opening the door to use for denial-of-service attacks
>- https://github.com/libexpat/libexpat/pull/227 Autotools: Add --without-examples and --without-tests
Full changelog is available [here](https://github.com/libexpat/libexpat/blob/R_2_2_7/expat/Changes#L5).

from https://github.com/bitcoin/bitcoin/pull/16270