### PR TITLE
[Upstream] build: Clean remnants of QTBUG-34748 fix

### DIFF
--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -22,7 +22,7 @@ $(package)_config_opts += --disable-xv --disable-xvmc
 endef
 
 define $(package)_preprocess_cmds
-  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub build-aux &&\
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub build-aux && \
   sed "s/pthread-stubs//" -i configure
 endef
 
@@ -39,5 +39,5 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  rm -rf share/man share/doc lib/*.la
+  rm -rf share lib/*.la
 endef

--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -26,13 +26,8 @@ define $(package)_preprocess_cmds
   sed "s/pthread-stubs//" -i configure
 endef
 
-# Don't install xcb headers to the default path in order to work around a qt
-# build issue: https://bugreports.qt.io/browse/QTBUG-34748
-# When using qt's internal libxcb, it may end up finding the real headers in
-# depends staging. Use a non-default path to avoid that.
-
 define $(package)_config_cmds
-  $($(package)_autoconf) --includedir=$(host_prefix)/include/xcb-shared
+  $($(package)_autoconf)
 endef
 
 define $(package)_build_cmds


### PR DESCRIPTION
>Hope, this PR will make https://github.com/bitcoin/bitcoin/pull/21376 to Qt 5.12.10 neater.

>A fix for [QTBUG-34748](https://bugreports.qt.io/browse/QTBUG-34748) was introduced in https://github.com/bitcoin/bitcoin/pull/5915 (v0.11.0, Qt 5.2.1).

>[QTBUG-34748](https://bugreports.qt.io/browse/QTBUG-34748) was [fixed](https://github.com/qt/qtbase/commit/b19b0808940c8c54b102012be134a370b26e348e) in Qt 5.3.0.

>The separated [fix-xcb-include-order.patch](https://github.com/theuni/bitcoin/blob/bb44d9e7546e6118cd91db5bbe471a3ce2ee7fcd/depends/patches/qt/fix-xcb-include-order.patch), provided by https://github.com/bitcoin/bitcoin/pull/5915, was dropped in https://github.com/bitcoin/bitcoin/pull/12971 while bumping Qt to 5.9.4 (5.9.6). But libxcb.mk remained unchanged.

>This PR reverts https://github.com/bitcoin/bitcoin/pull/5915 for `libxcb.mk` as well.

from https://github.com/bitcoin/bitcoin/pull/21382