### PR TITLE
[Upstream] build: make macOS HOST in download-osx generic

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -260,7 +260,7 @@ install: check-packages $(host_prefix)/share/config.site
 download-one: check-sources $(all_sources)
 
 download-osx:
-	@$(MAKE) -s HOST=x86_64-apple-darwin14 download-one
+	@$(MAKE) -s HOST=x86_64-apple-darwin download-one
 download-linux:
 	@$(MAKE) -s HOST=x86_64-unknown-linux-gnu download-one
 download-win:


### PR DESCRIPTION
>This was missed in https://github.com/bitcoin/bitcoin/pull/20419, and the update before that, so just make this un-versioned so that we don't have to worry about it. This is fine, because it's just for downloading sources.

from https://github.com/bitcoin/bitcoin/pull/21065