### PR TITLE
[Upstream] depends: don't use OpenGL in Qt on macOS

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -90,6 +90,7 @@ $(package)_config_opts += -no-feature-wizard
 $(package)_config_opts += -no-feature-xml
 
 $(package)_config_opts_darwin = -no-dbus
+$(package)_config_opts_darwin += -no-opengl
 $(package)_config_opts_darwin += -pch
 
 ifneq ($(build_os),darwin)


### PR DESCRIPTION
>Based on https://github.com/bitcoin/bitcoin/pull/17663. OpenGL on macOS was also deprecated in 10.14.

>This also removes the /System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL dylib from bitcoin-qt.

from https://github.com/bitcoin/bitcoin/pull/17676