### PR TITLE
[Upstream] build: Bump minimum Qt version to 5.5.1

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -101,24 +101,6 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
   if test "x$bitcoin_cv_static_qt" = xyes; then
     _BITCOIN_QT_FIND_STATIC_PLUGINS
     AC_DEFINE(QT_STATICPLUGIN, 1, [Define this symbol if qt plugins are static])
-    AC_CACHE_CHECK(for Qt < 5.4, bitcoin_cv_need_acc_widget,[
-      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-          #include <QtCore/qconfig.h>
-          #ifndef QT_VERSION
-          #  include <QtCore/qglobal.h>
-          #endif
-        ]],
-        [[
-          #if QT_VERSION >= 0x050400
-          choke
-          #endif
-        ]])],
-      [bitcoin_cv_need_acc_widget=yes],
-      [bitcoin_cv_need_acc_widget=no])
-    ])
-    if test "x$bitcoin_cv_need_acc_widget" = xyes; then
-      _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(AccessibleFactory)], [-lqtaccessiblewidgets])
-    fi
     if test "x$TARGET_OS" != xandroid; then
       _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin)],[-lqminimal])
       AC_DEFINE(QT_QPA_PLATFORM_MINIMAL, 1, [Define this symbol if the minimal qt platform exists])

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -41,6 +41,7 @@
 #include <QDoubleValidator>
 #include <QFileDialog>
 #include <QFont>
+#include <QFontDatabase>
 #include <QLineEdit>
 #include <QObject>
 #include <QSettings>
@@ -79,9 +80,7 @@ QString dateTimeStr(qint64 nTime)
 
 QFont bitcoinAddressFont()
 {
-    QFont font("Monospace");
-    font.setStyleHint(QFont::Monospace);
-    return font;
+    return QFontDatabase::systemFont(QFontDatabase::FixedFont);
 }
 
 void setupAddressWidget(QValidatedLineEdit* widget, QWidget* parent)

--- a/src/qt/prcycoin.cpp
+++ b/src/qt/prcycoin.cpp
@@ -67,9 +67,6 @@
 
 #if defined(QT_STATICPLUGIN)
 #include <QtPlugin>
-#if QT_VERSION < 0x050400
-Q_IMPORT_PLUGIN(AccessibleFactory)
-#endif
 #if defined(QT_QPA_PLATFORM_XCB)
 Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
 #elif defined(QT_QPA_PLATFORM_WINDOWS)

--- a/src/qt/prcycoin.cpp
+++ b/src/qt/prcycoin.cpp
@@ -588,10 +588,8 @@ int main(int argc, char* argv[])
     Q_INIT_RESOURCE(prcycoin);
 
     BitcoinApplication app(argc, argv);
-#if QT_VERSION > 0x050100
     // Generate high-dpi pixmaps
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-#endif
 #if QT_VERSION >= 0x050600
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif


### PR DESCRIPTION
Most of this was completed previously, this just adds the parts that were missed.

from https://github.com/bitcoin/bitcoin/pull/14725 and https://github.com/bitcoin/bitcoin/pull/15393