### PR TITLE
[Upstream] build: disable D-Bus on Android by default

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -72,9 +72,18 @@ AC_DEFUN([BITCOIN_QT_INIT],[
 
   AC_ARG_WITH([qtdbus],
     [AS_HELP_STRING([--with-qtdbus],
-    [enable DBus support (default is yes if qt is enabled and QtDBus is found)])],
+    [enable DBus support (default is yes if qt is enabled and QtDBus is found, except on Android)])],
     [use_dbus=$withval],
     [use_dbus=auto])
+
+ dnl Android doesn't support D-Bus and certainly doesn't use it for notifications
+ case $host in
+   *android*)
+     if test "x$use_dbus" != xyes; then
+       use_dbus=no
+     fi
+   ;;
+ esac
 
   AC_SUBST(QT_TRANSLATION_DIR,$qt_translation_path)
 ])


### PR DESCRIPTION
Android uses a different notification system and doesn't support D-Bus

https://github.com/bitcoin/bitcoin/pull/17396/commits/cf0681133ae7301ead7091eaee55c945da5cdfcc from https://github.com/bitcoin/bitcoin/pull/17396

(getting our bitcoin_qt.m4 inline with upstream)