### PR TITLE
[Upstream] build: Try posix-specific CXX first for mingw32 host

### DIFF
--- a/depends/hosts/mingw32.mk
+++ b/depends/hosts/mingw32.mk
@@ -1,3 +1,7 @@
+ifneq ($(shell which $(host)-g++-posix),)
+mingw32_CXX := $(host)-g++-posix
+endif
+
 mingw32_CFLAGS=-pipe
 mingw32_CXXFLAGS=$(mingw32_CFLAGS)
 

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -81,10 +81,6 @@ The first step is to install the mingw-w64 cross-compilation tool chain:
 
     sudo apt install g++-mingw-w64-x86-64
 
-Ubuntu Bionic 18.04 <sup>[1](#footnote1)</sup>:
-
-    sudo update-alternatives --config x86_64-w64-mingw32-g++ # Set the default mingw32 g++ compiler option to posix.
-
 Once the toolchain is installed the build steps are common:
 
 Note that for WSL the PRCYCoin source path MUST be somewhere in the default mount file system, for
@@ -118,13 +114,3 @@ way. This will install to `c:\workspace\prcycoin`, for example:
 You can also create an installer using:
 
     make deploy
-
-Footnotes
----------
-
-<a name="footnote1">1</a>: Starting from Ubuntu Xenial 16.04, both the 32 and 64 bit Mingw-w64 packages install two different
-compiler options to allow a choice between either posix or win32 threads. The default option is win32 threads which is the more
-efficient since it will result in binary code that links directly with the Windows kernel32.lib. Unfortunately, the headers
-required to support win32 threads conflict with some of the classes in the C++11 standard library, in particular std::mutex.
-It's not possible to build the PRCYCoin code using the win32 version of the Mingw-w64 cross compilers (at least not without
-modifying headers in the PRCYCoin source code).


### PR DESCRIPTION
>On master (https://github.com/bitcoin/bitcoin/commit/1186910b6b7ba7c7e5193c76f33f25825e6cc0b7), when cross-compiling for Windows using our depends build system, we must manually choose the POSIX thread model for the x86_64-w64-mingw32-g++ compiler.

>This PR improves the build system to make this choice automagically.

from https://github.com/bitcoin/bitcoin/pull/22093