### PR TITLE
[Upstream] Various *BSD Build/Doc Updates

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -39,6 +39,7 @@ The following are developer notes on how to build PRCYCoin on your native platfo
 - [macOS Build Notes](build-osx.md)
 - [Unix Build Notes](build-unix.md)
 - [Windows Build Notes](build-windows.md)
+- [FreeBSD Build Notes](build-freeebsd.md)
 - [OpenBSD Build Notes](build-openbsd.md)
 - [NetBSD Build Notes](build-netbsd.md)
 - [Gitian Building Guide](gitian-building.md)

--- a/doc/README.md
+++ b/doc/README.md
@@ -40,6 +40,7 @@ The following are developer notes on how to build PRCYCoin on your native platfo
 - [Unix Build Notes](build-unix.md)
 - [Windows Build Notes](build-windows.md)
 - [OpenBSD Build Notes](build-openbsd.md)
+- [NetBSD Build Notes](build-netbsd.md)
 - [Gitian Building Guide](gitian-building.md)
 
 Development

--- a/doc/README.md
+++ b/doc/README.md
@@ -39,6 +39,7 @@ The following are developer notes on how to build PRCYCoin on your native platfo
 - [macOS Build Notes](build-osx.md)
 - [Unix Build Notes](build-unix.md)
 - [Windows Build Notes](build-windows.md)
+- [OpenBSD Build Notes](build-openbsd.md)
 - [Gitian Building Guide](gitian-building.md)
 
 Development

--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -14,6 +14,12 @@ You will need the following dependencies, which can be installed as root via pkg
 pkg install autoconf automake boost-libs git gmake libevent libtool openssl pkgconf
 ```
 
+In order to run the test suite (recommended), you will need to have Python 3 installed:
+
+```
+pkg install python3
+```
+
 For the wallet (optional):
 ```
 ./contrib/install_db4.sh `pwd`
@@ -36,9 +42,21 @@ git clone https://github.com/bitcoin/bitcoin
 
 ./configure                  # to build with wallet OR
 ./configure --disable-wallet # to build without wallet
+```
 
+followed by either:
+
+```
 gmake
 ```
+
+to build without testing, or
+
+```
+gmake check
+```
+
+to also run the test suite (recommended, if Python 3 is installed).
 
 *Note on debugging*: The version of `gdb` installed by default is [ancient and considered harmful](https://wiki.freebsd.org/GdbRetirement).
 It is not suitable for debugging a multi-threaded C++ program, not even for getting backtraces. Please install the package `gdb` and

--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -29,7 +29,7 @@ git clone https://github.com/bitcoin/bitcoin
 
 ## Building Bitcoin Core
 
-**Important**: Use `gmake` (the non-GNU `make` will exit with an error).
+**Important**: Use `gmake` (the non-GNU `make` will exit with an error):
 
 ```
 ./autogen.sh

--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -17,7 +17,7 @@ pkg install autoconf automake boost-libs git gmake libevent libtool openssl pkgc
 For the wallet (optional):
 ```
 ./contrib/install_db4.sh `pwd`
-export BDB_PREFIX='$PWD/db4'
+export BDB_PREFIX="$PWD/db4"
 ```
 
 See [dependencies.md](dependencies.md) for a complete overview.

--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -10,15 +10,15 @@ This guide does not contain instructions for building the GUI.
 
 You will need the following dependencies, which can be installed as root via pkg:
 
-```shell
-pkg install autoconf automake boost-libs git gmake libevent libtool openssl pkgconf
+```bash
+pkg install autoconf automake boost-libs git gmake libevent libtool pkgconf
 
 git clone https://github.com/bitcoin/bitcoin.git
 ```
 
 In order to run the test suite (recommended), you will need to have Python 3 installed:
 
-```shell
+```bash
 pkg install python3
 ```
 
@@ -29,32 +29,33 @@ See [dependencies.md](dependencies.md) for a complete overview.
 BerkeleyDB is only necessary for the wallet functionality. To skip this, pass
 `--disable-wallet` to `./configure` and skip to the next section.
 
-```shell
+```bash
 ./contrib/install_db4.sh `pwd`
 export BDB_PREFIX="$PWD/db4"
 ```
 
 ## Building Bitcoin Core
 
-**Important**: Use `gmake` (the non-GNU `make` will exit with an error):
+**Important**: Use `gmake` (the non-GNU `make` will exit with an error).
 
 With wallet:
-```shell
+```bash
 ./autogen.sh
 ./configure --with-gui=no \
     BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
-    BDB_CFLAGS="-I${BDB_PREFIX}/include"
+    BDB_CFLAGS="-I${BDB_PREFIX}/include" \
+    MAKE=gmake
 ```
 
 Without wallet:
-```shell
+```bash
 ./autogen.sh
-./configure --with-gui=no --disable-wallet
+./configure --with-gui=no --disable-wallet MAKE=gmake
 ```
 
 followed by:
 
-```shell
+```bash
 gmake # use -jX here for parallelism
 gmake check # Run tests if Python 3 is available
 ```

--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -1,0 +1,46 @@
+FreeBSD build guide
+======================
+(updated for FreeBSD 11.1)
+
+This guide describes how to build bitcoind and command-line utilities on FreeBSD.
+
+This guide does not contain instructions for building the GUI.
+
+## Preparation
+
+You will need the following dependencies, which can be installed as root via pkg:
+
+```
+pkg install autoconf automake boost-libs git gmake libevent libtool openssl pkgconf
+```
+
+For the wallet (optional):
+```
+./contrib/install_db4.sh `pwd`
+export BDB_PREFIX='$PWD/db4'
+```
+
+See [dependencies.md](dependencies.md) for a complete overview.
+
+Download the source code:
+```
+git clone https://github.com/bitcoin/bitcoin
+```
+
+## Building Bitcoin Core
+
+**Important**: Use `gmake` (the non-GNU `make` will exit with an error).
+
+```
+./autogen.sh
+
+./configure                  # to build with wallet OR
+./configure --disable-wallet # to build without wallet
+
+gmake
+```
+
+*Note on debugging*: The version of `gdb` installed by default is [ancient and considered harmful](https://wiki.freebsd.org/GdbRetirement).
+It is not suitable for debugging a multi-threaded C++ program, not even for getting backtraces. Please install the package `gdb` and
+use the versioned gdb command (e.g. `gdb7111`).
+

--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -1,6 +1,6 @@
 FreeBSD build guide
 ======================
-(updated for FreeBSD 11.1)
+(updated for FreeBSD 12.0)
 
 This guide describes how to build bitcoind and command-line utilities on FreeBSD.
 
@@ -10,55 +10,51 @@ This guide does not contain instructions for building the GUI.
 
 You will need the following dependencies, which can be installed as root via pkg:
 
-```
+```shell
 pkg install autoconf automake boost-libs git gmake libevent libtool openssl pkgconf
+
+git clone https://github.com/bitcoin/bitcoin.git
 ```
 
 In order to run the test suite (recommended), you will need to have Python 3 installed:
 
-```
+```shell
 pkg install python3
-```
-
-For the wallet (optional):
-```
-./contrib/install_db4.sh `pwd`
-export BDB_PREFIX="$PWD/db4"
 ```
 
 See [dependencies.md](dependencies.md) for a complete overview.
 
-Download the source code:
-```
-git clone https://github.com/bitcoin/bitcoin
+### Building BerkeleyDB
+
+BerkeleyDB is only necessary for the wallet functionality. To skip this, pass
+`--disable-wallet` to `./configure` and skip to the next section.
+
+```shell
+./contrib/install_db4.sh `pwd`
+export BDB_PREFIX="$PWD/db4"
 ```
 
 ## Building Bitcoin Core
 
 **Important**: Use `gmake` (the non-GNU `make` will exit with an error):
 
-```
+With wallet:
+```shell
 ./autogen.sh
-
-./configure                  # to build with wallet OR
-./configure --disable-wallet # to build without wallet
+./configure --with-gui=no \
+    BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
+    BDB_CFLAGS="-I${BDB_PREFIX}/include"
 ```
 
-followed by either:
-
-```
-gmake
-```
-
-to build without testing, or
-
-```
-gmake check
+Without wallet:
+```shell
+./autogen.sh
+./configure --with-gui=no --disable-wallet
 ```
 
-to also run the test suite (recommended, if Python 3 is installed).
+followed by:
 
-*Note on debugging*: The version of `gdb` installed by default is [ancient and considered harmful](https://wiki.freebsd.org/GdbRetirement).
-It is not suitable for debugging a multi-threaded C++ program, not even for getting backtraces. Please install the package `gdb` and
-use the versioned gdb command (e.g. `gdb7111`).
-
+```shell
+gmake # use -jX here for parallelism
+gmake check # Run tests if Python 3 is available
+```

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -1,6 +1,6 @@
 NetBSD build guide
 ======================
-(updated for NetBSD 7.0)
+(updated for NetBSD 8.0)
 
 This guide describes how to build bitcoind and command-line utilities on NetBSD.
 
@@ -15,20 +15,37 @@ You will need the following modules, which can be installed via pkgsrc or pkgin:
 autoconf
 automake
 boost
-db4
 git
 gmake
 libevent
 libtool
-python27
-```
+pkg-config
+python37
 
-Download the source code:
-```
-git clone https://github.com/bitcoin/bitcoin
+git clone https://github.com/bitcoin/bitcoin.git
 ```
 
 See [dependencies.md](dependencies.md) for a complete overview.
+
+### Building BerkeleyDB
+
+BerkeleyDB is only necessary for the wallet functionality. To skip this, pass
+`--disable-wallet` to `./configure` and skip to the next section.
+
+It is recommended to use Berkeley DB 4.8. You cannot use the BerkeleyDB library
+from ports, for the same reason as boost above (g++/libstd++ incompatibility).
+If you have to build it yourself, you can use [the installation script included
+in contrib/](/contrib/install_db4.sh) like so:
+
+```shell
+./contrib/install_db4.sh `pwd`
+```
+
+from the root of the repository. Then set `BDB_PREFIX` for the next section:
+
+```shell
+export BDB_PREFIX="$PWD/db4"
+```
 
 ### Building Bitcoin Core
 
@@ -37,13 +54,26 @@ See [dependencies.md](dependencies.md) for a complete overview.
 With wallet:
 ```
 ./autogen.sh
-./configure CPPFLAGS="-I/usr/pkg/include" LDFLAGS="-L/usr/pkg/lib" BOOST_CPPFLAGS="-I/usr/pkg/include" BOOST_LDFLAGS="-L/usr/pkg/lib"
-gmake
+./configure --with-gui=no CPPFLAGS="-I/usr/pkg/include" \
+    LDFLAGS="-L/usr/pkg/lib" \
+    BOOST_CPPFLAGS="-I/usr/pkg/include" \
+    BOOST_LDFLAGS="-L/usr/pkg/lib" \
+    BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
+    BDB_CFLAGS="-I${BDB_PREFIX}/include"
 ```
 
 Without wallet:
 ```
 ./autogen.sh
-./configure --disable-wallet CPPFLAGS="-I/usr/pkg/include" LDFLAGS="-L/usr/pkg/lib" BOOST_CPPFLAGS="-I/usr/pkg/include" BOOST_LDFLAGS="-L/usr/pkg/lib"
-gmake
+./configure --with-gui=no --disable-wallet \
+    CPPFLAGS="-I/usr/pkg/include" \
+    LDFLAGS="-L/usr/pkg/lib" \
+    BOOST_CPPFLAGS="-I/usr/pkg/include" \
+    BOOST_LDFLAGS="-L/usr/pkg/lib"
+```
+
+Build and run the tests:
+```bash
+gmake # use -jX here for parallelism
+gmake check
 ```

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -1,0 +1,49 @@
+NetBSD build guide
+======================
+(updated for NetBSD 7.0)
+
+This guide describes how to build bitcoind and command-line utilities on NetBSD.
+
+This guide does not contain instructions for building the GUI.
+
+Preparation
+-------------
+
+You will need the following modules, which can be installed via pkgsrc or pkgin:
+
+```
+autoconf
+automake
+boost
+db4
+git
+gmake
+libevent
+libtool
+python27
+```
+
+Download the source code:
+```
+git clone https://github.com/bitcoin/bitcoin
+```
+
+See [dependencies.md](dependencies.md) for a complete overview.
+
+### Building Bitcoin Core
+
+**Important**: Use `gmake` (the non-GNU `make` will exit with an error).
+
+With wallet:
+```
+./autogen.sh
+./configure CPPFLAGS="-I/usr/pkg/include" LDFLAGS="-L/usr/pkg/lib" BOOST_CPPFLAGS="-I/usr/pkg/include" BOOST_LDFLAGS="-L/usr/pkg/lib"
+gmake
+```
+
+Without wallet:
+```
+./autogen.sh
+./configure --disable-wallet CPPFLAGS="-I/usr/pkg/include" LDFLAGS="-L/usr/pkg/lib" BOOST_CPPFLAGS="-I/usr/pkg/include" BOOST_LDFLAGS="-L/usr/pkg/lib"
+gmake
+```

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -37,13 +37,13 @@ from ports, for the same reason as boost above (g++/libstd++ incompatibility).
 If you have to build it yourself, you can use [the installation script included
 in contrib/](/contrib/install_db4.sh) like so:
 
-```shell
+```bash
 ./contrib/install_db4.sh `pwd`
 ```
 
 from the root of the repository. Then set `BDB_PREFIX` for the next section:
 
-```shell
+```bash
 export BDB_PREFIX="$PWD/db4"
 ```
 
@@ -52,24 +52,26 @@ export BDB_PREFIX="$PWD/db4"
 **Important**: Use `gmake` (the non-GNU `make` will exit with an error).
 
 With wallet:
-```
+```bash
 ./autogen.sh
 ./configure --with-gui=no CPPFLAGS="-I/usr/pkg/include" \
     LDFLAGS="-L/usr/pkg/lib" \
     BOOST_CPPFLAGS="-I/usr/pkg/include" \
     BOOST_LDFLAGS="-L/usr/pkg/lib" \
     BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
-    BDB_CFLAGS="-I${BDB_PREFIX}/include"
+    BDB_CFLAGS="-I${BDB_PREFIX}/include" \
+    MAKE=gmake
 ```
 
 Without wallet:
-```
+```bash
 ./autogen.sh
 ./configure --with-gui=no --disable-wallet \
     CPPFLAGS="-I/usr/pkg/include" \
     LDFLAGS="-L/usr/pkg/lib" \
     BOOST_CPPFLAGS="-I/usr/pkg/include" \
-    BOOST_LDFLAGS="-L/usr/pkg/lib"
+    BOOST_LDFLAGS="-L/usr/pkg/lib" \
+    MAKE=gmake
 ```
 
 Build and run the tests:

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,6 +1,6 @@
 OpenBSD build guide
 ======================
-(updated for OpenBSD 6.0)
+(updated for OpenBSD 6.1)
 
 This guide describes how to build bitcoind and command-line utilities on OpenBSD.
 
@@ -48,13 +48,13 @@ BOOST_PREFIX="${BITCOIN_ROOT}/boost"
 mkdir -p $BOOST_PREFIX
 
 # Fetch the source and verify that it is not tampered with
-curl -o boost_1_61_0.tar.bz2 http://heanet.dl.sourceforge.net/project/boost/boost/1.61.0/boost_1_61_0.tar.bz2
-echo 'a547bd06c2fd9a71ba1d169d9cf0339da7ebf4753849a8f7d6fdb8feee99b640  boost_1_61_0.tar.bz2' | sha256 -c
-# MUST output: (SHA256) boost_1_61_0.tar.bz2: OK
-tar -xjf boost_1_61_0.tar.bz2
+curl -o boost_1_64_0.tar.bz2 https://netcologne.dl.sourceforge.net/project/boost/boost/1.64.0/boost_1_64_0.tar.bz2
+echo '7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332 boost_1_64_0.tar.bz2' | sha256 -c
+# MUST output: (SHA256) boost_1_64_0.tar.bz2: OK
+tar -xjf boost_1_64_0.tar.bz2
 
-# Boost 1.61 needs one small patch for OpenBSD
-cd boost_1_61_0
+# Boost 1.64 needs one small patch for OpenBSD
+cd boost_1_64_0
 # Also here: https://gist.githubusercontent.com/laanwj/bf359281dc319b8ff2e1/raw/92250de8404b97bb99d72ab898f4a8cb35ae1ea3/patch-boost_test_impl_execution_monitor_ipp.patch
 patch -p0 < /usr/ports/devel/boost/patches/patch-boost_test_impl_execution_monitor_ipp
 

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,0 +1,187 @@
+OpenBSD build guide
+======================
+(updated for OpenBSD 5.7)
+
+This guide describes how to build bitcoind and command-line utilities on OpenBSD.
+
+As OpenBSD is most common as a server OS, we will not bother with the GUI.
+
+Preparation
+-------------
+
+Run the following as root to install the base dependencies for building:
+
+```bash
+pkg_add gmake libtool libevent
+pkg_add autoconf # (select highest version, e.g. 2.69)
+pkg_add automake # (select highest version, e.g. 1.15)
+pkg_add python # (select version 2.7.x, not 3.x)
+ln -sf /usr/local/bin/python2.7 /usr/local/bin/python2
+```
+
+The default C++ compiler that comes with OpenBSD 5.7 is g++ 4.2. This version is old (from 2007), and is not able to compile the current version of Bitcoin Core. It is possible to patch it up to compile, but with the planned transition to C++11 this is a losing battle. So here we will be installing a newer compiler.
+
+GCC
+-------
+
+You can install a newer version of gcc with:
+
+```bash
+pkg_add g++ # (select newest 4.x version, e.g. 4.9.2)
+```
+
+This compiler will not overwrite the system compiler, it will be installed as `egcc` and `eg++` in `/usr/local/bin`.
+
+### Building boost
+
+Do not use `pkg_add boost`! The boost version installed thus is compiled using the `g++` compiler not `eg++`, which will result in a conflict between `/usr/local/lib/libestdc++.so.XX.0` and `/usr/lib/libstdc++.so.XX.0`, resulting in a test crash:
+
+    test_bitcoin:/usr/lib/libstdc++.so.57.0: /usr/local/lib/libestdc++.so.17.0 : WARNING: symbol(_ZN11__gnu_debug17_S_debug_me ssagesE) size mismatch, relink your program
+    ...
+    Segmentation fault (core dumped) 
+
+This makes it necessary to build boost, or at least the parts used by Bitcoin Core, manually:
+
+```
+# Pick some path to install boost to, here we create a directory within the bitcoin directory
+BITCOIN_ROOT=$(pwd)
+BOOST_PREFIX="${BITCOIN_ROOT}/boost"
+mkdir -p $BOOST_PREFIX
+
+# Fetch the source and verify that it is not tampered with
+wget http://heanet.dl.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.bz2
+echo '727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca  boost_1_59_0.tar.bz2' | sha256 -c
+# MUST output: (SHA256) boost_1_59_0.tar.bz2: OK
+tar -xjf boost_1_59_0.tar.bz2
+
+# Boost 1.59 needs two small patches for OpenBSD
+cd boost_1_59_0
+# Also here: https://gist.githubusercontent.com/laanwj/bf359281dc319b8ff2e1/raw/92250de8404b97bb99d72ab898f4a8cb35ae1ea3/patch-boost_test_impl_execution_monitor_ipp.patch
+patch -p0 < /usr/ports/devel/boost/patches/patch-boost_test_impl_execution_monitor_ipp 
+# https://github.com/boostorg/filesystem/commit/90517e459681790a091566dce27ca3acabf9a70c
+sed 's/__OPEN_BSD__/__OpenBSD__/g' < libs/filesystem/src/path.cpp > libs/filesystem/src/path.cpp.tmp
+mv libs/filesystem/src/path.cpp.tmp libs/filesystem/src/path.cpp
+
+# Build w/ minimum configuration necessary for bitcoin
+echo 'using gcc : : eg++ : <cxxflags>"-fvisibility=hidden -fPIC" <linkflags>"" <archiver>"ar" <striper>"strip"  <ranlib>"ranlib" <rc>"" : ;' > user-config.jam
+config_opts="runtime-link=shared threadapi=pthread threading=multi link=static variant=release --layout=tagged --build-type=complete --user-config=user-config.jam -sNO_BZIP2=1"
+./bootstrap.sh --without-icu --with-libraries=chrono,filesystem,program_options,system,thread,test
+./b2 -d2 -j2 -d1 ${config_opts} --prefix=${BOOST_PREFIX} stage
+./b2 -d0 -j4 ${config_opts} --prefix=${BOOST_PREFIX} install
+```
+
+### OpenSSL
+
+OpenBSD uses a replacement of OpenSSL: LibreSSL. This can cause compatibility issues, hence `./configure` will bark if you try to compile with this library:
+
+    Detected LibreSSL: This is NOT supported, and may break consensus compatibility!
+
+To install a 'real' OpenSSL use:
+
+    pkg_add openssl
+   
+Any program linked against this library can only be used after setting the dynamic library path:
+    
+    export LD_LIBRARY_PATH="/usr/local/lib/eopenssl"
+
+(otherwise there will be an error about not being able to find `libcrypto.so.1.0`)
+
+Alternatively, pass `--with-libressl` to `./configure`, however as the warning says, this is NOT supported, and may cause problems syncing the chain, or the node to fork off the network in unexpected circumstances.
+
+### Building BerkeleyDB
+
+BerkeleyDB is only necessary for the wallet functionality. To skip this, pass `--disable-wallet` to `./configure`.
+
+See "Berkeley DB" in [build_unix.md](build_unix.md) for instructions on how to build BerkeleyDB 4.8.
+You cannot use the BerkeleyDB library from ports, for the same reason as boost above (g++/libstd++ incompatibility).
+
+```bash
+# Pick some path to install BDB to, here we create a directory within the bitcoin directory
+BITCOIN_ROOT=$(pwd)
+BDB_PREFIX="${BITCOIN_ROOT}/db4"
+mkdir -p $BDB_PREFIX
+
+# Fetch the source and verify that it is not tampered with
+wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
+echo '12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz' | sha256 -c
+# MUST output: (SHA256) db-4.8.30.NC.tar.gz: OK
+tar -xzf db-4.8.30.NC.tar.gz
+
+# Build the library and install to specified prefix
+cd db-4.8.30.NC/build_unix/
+#  Note: Do a static build so that it can be embedded into the executable, instead of having to find a .so at runtime
+../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX CC=egcc CXX=eg++ CPP=ecpp 
+make install
+```
+
+### Building Bitcoin Core
+
+**Important**: use `gmake`, not `make`. The non-GNU `make` will exit with a horrible error.
+
+Preparation:
+```bash
+export AUTOCONF_VERSION=2.69 # replace this with the autoconf version that you installed
+export AUTOMAKE_VERSION=1.15 # replace this with the automake version that you installed
+./autogen.sh
+```
+
+To configure with wallet:
+```bash
+./configure --with-gui=no --with-boost=$BOOST_PREFIX \
+    CC=egcc CXX=eg++ CPP=ecpp \
+    SSL_CFLAGS="-I/usr/local/include/eopenssl" SSL_LIBS="-L/usr/local/lib/eopenssl -lssl" \
+    CRYPTO_CFLAGS="-I/usr/local/include/eopenssl" CRYPTO_LIBS="-L/usr/local/lib/eopenssl -lcrypto" \
+    LDFLAGS="-L${BDB_PREFIX}/lib/" CPPFLAGS="-I${BDB_PREFIX}/include/"
+```
+
+To configure without wallet:
+```bash
+./configure --disable-wallet --with-gui=no --with-boost=$BOOST_PREFIX \
+    CC=egcc CXX=eg++ CPP=ecpp \
+    SSL_CFLAGS="-I/usr/local/include/eopenssl" SSL_LIBS="-L/usr/local/lib/eopenssl -lssl" \
+    CRYPTO_CFLAGS="-I/usr/local/include/eopenssl" CRYPTO_LIBS="-L/usr/local/lib/eopenssl -lcrypto"
+```
+
+Build and run the tests:
+```bash
+gmake
+export LD_LIBRARY_PATH="/usr/local/lib/eopenssl"
+gmake check
+```
+
+Clang (not currently working)
+------------------------------
+
+Using a newer g++ results in linking the new code to a new libstdc++.
+Libraries built with the old g++, will still import the old library.
+This gives conflicts, necessitating rebuild of all C++ dependencies of the application.
+
+With clang this can - at least theoretically - be avoided because it uses the
+base system's libstdc++.
+
+```bash
+pkg_add llvm boost
+```
+
+```bash
+./configure --disable-wallet --with-gui=no CC=clang CXX=clang++ \
+    SSL_CFLAGS="-I/usr/local/include/eopenssl" SSL_LIBS="-L/usr/local/lib/eopenssl -lssl" \
+    CRYPTO_CFLAGS="-I/usr/local/include/eopenssl" CRYPTO_LIBS="-L/usr/local/lib/eopenssl -lcrypto"
+gmake
+```
+
+However, this does not appear to work. Compilation succeeds, but link fails
+with many 'local symbol discarded' errors:
+
+    local symbol 150: discarded in section `.text._ZN10tinyformat6detail14FormatIterator6finishEv' from libbitcoin_util.a(libbitcoin_util_a-random.o)
+    local symbol 151: discarded in section `.text._ZN10tinyformat6detail14FormatIterator21streamStateFromFormatERSoRjPKcii' from libbitcoin_util.a(libbitcoin_util_a-random.o)
+    local symbol 152: discarded in section `.text._ZN10tinyformat6detail12convertToIntIA13_cLb0EE6invokeERA13_Kc' from libbitcoin_util.a(libbitcoin_util_a-random.o)
+
+According to similar reported errors this is a binutils (ld) issue in 2.15, the
+version installed by OpenBSD 5.7:
+
+- http://openbsd-archive.7691.n7.nabble.com/UPDATE-cppcheck-1-65-td248900.html
+- https://llvm.org/bugs/show_bug.cgi?id=9758
+
+There is no known workaround for this.
+

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,10 +1,10 @@
 OpenBSD build guide
 ======================
-(updated for OpenBSD 6.1)
+(updated for OpenBSD 6.2)
 
 This guide describes how to build bitcoind and command-line utilities on OpenBSD.
 
-As OpenBSD is most common as a server OS, we will not bother with the GUI.
+OpenBSD is most commonly used as a server OS, so this guide does not contain instructions for building the GUI.
 
 Preparation
 -------------
@@ -12,60 +12,28 @@ Preparation
 Run the following as root to install the base dependencies for building:
 
 ```bash
-pkg_add gmake libtool libevent
+pkg_add git gmake libevent libtool
 pkg_add autoconf # (select highest version, e.g. 2.69)
 pkg_add automake # (select highest version, e.g. 1.15)
-pkg_add python # (select highest version, e.g. 3.5)
+pkg_add python # (select highest version, e.g. 3.6)
+pkg_add boost
+
+git clone https://github.com/bitcoin/bitcoin.git
 ```
 
-The default C++ compiler that comes with OpenBSD 5.9 is g++ 4.2. This version is old (from 2007), and is not able to compile the current version of Bitcoin Core, primarily as it has no C++11 support, but even before there were issues. So here we will be installing a newer compiler.
+See [dependencies.md](dependencies.md) for a complete overview.
 
 GCC
 -------
 
-You can install a newer version of gcc with:
+The default C++ compiler that comes with OpenBSD 6.2 is g++ 4.2.1. This version is old (from 2007), and is not able to compile the current version of Bitcoin Core because it has no C++11 support. We'll install a newer version of GCC:
 
 ```bash
-pkg_add g++ # (select newest 4.x version, e.g. 4.9.3)
-```
+ pkg_add g++
+ ```
 
-This compiler will not overwrite the system compiler, it will be installed as `egcc` and `eg++` in `/usr/local/bin`.
-
-### Building boost
-
-Do not use `pkg_add boost`! The boost version installed thus is compiled using the `g++` compiler not `eg++`, which will result in a conflict between `/usr/local/lib/libestdc++.so.XX.0` and `/usr/lib/libstdc++.so.XX.0`, resulting in a test crash:
-
-    test_bitcoin:/usr/lib/libstdc++.so.57.0: /usr/local/lib/libestdc++.so.17.0 : WARNING: symbol(_ZN11__gnu_debug17_S_debug_me ssagesE) size mismatch, relink your program
-    ...
-    Segmentation fault (core dumped)
-
-This makes it necessary to build boost, or at least the parts used by Bitcoin Core, manually:
-
-```
-# Pick some path to install boost to, here we create a directory within the bitcoin directory
-BITCOIN_ROOT=$(pwd)
-BOOST_PREFIX="${BITCOIN_ROOT}/boost"
-mkdir -p $BOOST_PREFIX
-
-# Fetch the source and verify that it is not tampered with
-curl -o boost_1_64_0.tar.bz2 https://netcologne.dl.sourceforge.net/project/boost/boost/1.64.0/boost_1_64_0.tar.bz2
-echo '7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332 boost_1_64_0.tar.bz2' | sha256 -c
-# MUST output: (SHA256) boost_1_64_0.tar.bz2: OK
-tar -xjf boost_1_64_0.tar.bz2
-
-# Boost 1.64 needs one small patch for OpenBSD
-cd boost_1_64_0
-# Also here: https://gist.githubusercontent.com/laanwj/bf359281dc319b8ff2e1/raw/92250de8404b97bb99d72ab898f4a8cb35ae1ea3/patch-boost_test_impl_execution_monitor_ipp.patch
-patch -p0 < /usr/ports/devel/boost/patches/patch-boost_test_impl_execution_monitor_ipp
-
-# Build w/ minimum configuration necessary for bitcoin
-echo 'using gcc : : eg++ : <cxxflags>"-fvisibility=hidden -fPIC" <linkflags>"" <archiver>"ar" <striper>"strip"  <ranlib>"ranlib" <rc>"" : ;' > user-config.jam
-config_opts="runtime-link=shared threadapi=pthread threading=multi link=static variant=release --layout=tagged --build-type=complete --user-config=user-config.jam -sNO_BZIP2=1"
-./bootstrap.sh --without-icu --with-libraries=chrono,filesystem,program_options,system,thread,test
-./b2 -d2 -j2 -d1 ${config_opts} --prefix=${BOOST_PREFIX} stage
-./b2 -d0 -j4 ${config_opts} --prefix=${BOOST_PREFIX} install
-```
-
+ This compiler will not overwrite the system compiler, it will be installed as `egcc` and `eg++` in `/usr/local/bin`.
+ 
 ### OpenSSL
 
 OpenBSD uses a replacement of OpenSSL: LibreSSL. This can cause compatibility issues, hence `./configure` will bark if you try to compile with this library:
@@ -88,7 +56,7 @@ Alternatively, pass `--with-libressl` to `./configure`, however as the warning s
 
 BerkeleyDB is only necessary for the wallet functionality. To skip this, pass `--disable-wallet` to `./configure`.
 
-See "Berkeley DB" in [build_unix.md](build_unix.md) for instructions on how to build BerkeleyDB 4.8.
+See "Berkeley DB" in [build-unix.md](build-unix.md#berkeley-db) for instructions on how to build BerkeleyDB 4.8.
 You cannot use the BerkeleyDB library from ports, for the same reason as boost above (g++/libstd++ incompatibility).
 
 ```bash
@@ -116,8 +84,8 @@ The standard ulimit restrictions in OpenBSD are very strict:
 
     data(kbytes)         1572864
 
-This is, unfortunately, no longer enough to compile some `.cpp` files in the project,
-at least with gcc 4.9.3 (see issue https://github.com/bitcoin/bitcoin/issues/6658).
+This, unfortunately, may no longer be enough to compile some `.cpp` files in the project,
+at least with GCC 4.9.4 (see issue [#6658](https://github.com/bitcoin/bitcoin/issues/6658)).
 If your user is in the `staff` group the limit can be raised with:
 
     ulimit -d 3000000
@@ -136,12 +104,11 @@ export AUTOCONF_VERSION=2.69 # replace this with the autoconf version that you i
 export AUTOMAKE_VERSION=1.15 # replace this with the automake version that you installed
 ./autogen.sh
 ```
-Make sure `BDB_PREFIX` and `BOOST_PREFIX` are set to the appropriate paths from the above steps.
+Make sure `BDB_PREFIX` is set to the appropriate path from the above steps.
 
 To configure with wallet:
 ```bash
-./configure --with-gui=no --with-boost=$BOOST_PREFIX \
-    CC=egcc CXX=eg++ CPP=ecpp \
+./configure --with-gui=no CC=egcc CXX=eg++ CPP=ecpp \
     SSL_CFLAGS="-I/usr/local/include/eopenssl" SSL_LIBS="-L/usr/local/lib/eopenssl -lssl" \
     CRYPTO_CFLAGS="-I/usr/local/include/eopenssl" CRYPTO_LIBS="-L/usr/local/lib/eopenssl -lcrypto" \
     BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"
@@ -149,52 +116,25 @@ To configure with wallet:
 
 To configure without wallet:
 ```bash
-./configure --disable-wallet --with-gui=no --with-boost=$BOOST_PREFIX \
-    CC=egcc CXX=eg++ CPP=ecpp \
+./configure --disable-wallet --with-gui=no CC=egcc CXX=eg++ CPP=ecpp \
     SSL_CFLAGS="-I/usr/local/include/eopenssl" SSL_LIBS="-L/usr/local/lib/eopenssl -lssl" \
     CRYPTO_CFLAGS="-I/usr/local/include/eopenssl" CRYPTO_LIBS="-L/usr/local/lib/eopenssl -lcrypto"
 ```
 
 Build and run the tests:
 ```bash
-gmake # can use -jX here for parallelism
+gmake # use -jX here for parallelism
 gmake check
 ```
 
-Clang (not currently working)
+Clang
 ------------------------------
 
-WARNING: This is outdated, needs to be updated for OpenBSD 6.0 and re-tried.
-
-Using a newer g++ results in linking the new code to a new libstdc++.
-Libraries built with the old g++, will still import the old library.
-This gives conflicts, necessitating rebuild of all C++ dependencies of the application.
-
-With clang this can - at least theoretically - be avoided because it uses the
-base system's libstdc++.
-
 ```bash
-pkg_add llvm boost
-```
-
-```bash
+pkg_add llvm
 ./configure --disable-wallet --with-gui=no CC=clang CXX=clang++ \
     SSL_CFLAGS="-I/usr/local/include/eopenssl" SSL_LIBS="-L/usr/local/lib/eopenssl -lssl" \
     CRYPTO_CFLAGS="-I/usr/local/include/eopenssl" CRYPTO_LIBS="-L/usr/local/lib/eopenssl -lcrypto"
-gmake
+gmake # use -jX here for parallelism
+gmake check
 ```
-
-However, this does not appear to work. Compilation succeeds, but link fails
-with many 'local symbol discarded' errors:
-
-    local symbol 150: discarded in section `.text._ZN10tinyformat6detail14FormatIterator6finishEv' from libbitcoin_util.a(libbitcoin_util_a-random.o)
-    local symbol 151: discarded in section `.text._ZN10tinyformat6detail14FormatIterator21streamStateFromFormatERSoRjPKcii' from libbitcoin_util.a(libbitcoin_util_a-random.o)
-    local symbol 152: discarded in section `.text._ZN10tinyformat6detail12convertToIntIA13_cLb0EE6invokeERA13_Kc' from libbitcoin_util.a(libbitcoin_util_a-random.o)
-
-According to similar reported errors this is a binutils (ld) issue in 2.15, the
-version installed by OpenBSD 5.7:
-
-- http://openbsd-archive.7691.n7.nabble.com/UPDATE-cppcheck-1-65-td248900.html
-- https://llvm.org/bugs/show_bug.cgi?id=9758
-
-There is no known workaround for this.

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,6 +1,6 @@
 OpenBSD build guide
 ======================
-(updated for OpenBSD 6.2)
+(updated for OpenBSD 6.3)
 
 This guide describes how to build bitcoind and command-line utilities on OpenBSD.
 
@@ -12,11 +12,10 @@ Preparation
 Run the following as root to install the base dependencies for building:
 
 ```bash
-pkg_add git gmake libevent libtool
+pkg_add git gmake libevent libtool boost
 pkg_add autoconf # (select highest version, e.g. 2.69)
 pkg_add automake # (select highest version, e.g. 1.15)
 pkg_add python # (select highest version, e.g. 3.6)
-pkg_add boost
 
 git clone https://github.com/bitcoin/bitcoin.git
 ```
@@ -73,8 +72,15 @@ export BDB_PREFIX="$PWD/db4"
 
 Preparation:
 ```bash
-export AUTOCONF_VERSION=2.69 # replace this with the autoconf version that you installed
-export AUTOMAKE_VERSION=1.15 # replace this with the automake version that you installed
+
+# Replace this with the autoconf version that you installed. Include only
+# the major and minor parts of the version: use "2.69" for "autoconf-2.69p2".
+export AUTOCONF_VERSION=2.69
+
+# Replace this with the automake version that you installed. Include only
+# the major and minor parts of the version: use "1.15" for "automake-1.15.1".
+export AUTOMAKE_VERSION=1.15
+
 ./autogen.sh
 ```
 Make sure `BDB_PREFIX` is set to the appropriate path from the above steps.

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,6 +1,6 @@
 OpenBSD build guide
 ======================
-(updated for OpenBSD 6.3)
+(updated for OpenBSD 6.4)
 
 This guide describes how to build bitcoind and command-line utilities on OpenBSD.
 
@@ -14,7 +14,7 @@ Run the following as root to install the base dependencies for building:
 ```bash
 pkg_add git gmake libevent libtool boost
 pkg_add autoconf # (select highest version, e.g. 2.69)
-pkg_add automake # (select highest version, e.g. 1.15)
+pkg_add automake # (select highest version, e.g. 1.16)
 pkg_add python # (select highest version, e.g. 3.6)
 
 git clone https://github.com/bitcoin/bitcoin.git
@@ -78,8 +78,8 @@ Preparation:
 export AUTOCONF_VERSION=2.69
 
 # Replace this with the automake version that you installed. Include only
-# the major and minor parts of the version: use "1.15" for "automake-1.15.1".
-export AUTOMAKE_VERSION=1.15
+# the major and minor parts of the version: use "1.16" for "automake-1.16.1".
+export AUTOMAKE_VERSION=1.16
 
 ./autogen.sh
 ```

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,6 +1,6 @@
 OpenBSD build guide
 ======================
-(updated for OpenBSD 5.7)
+(updated for OpenBSD 5.9)
 
 This guide describes how to build bitcoind and command-line utilities on OpenBSD.
 
@@ -15,11 +15,10 @@ Run the following as root to install the base dependencies for building:
 pkg_add gmake libtool libevent
 pkg_add autoconf # (select highest version, e.g. 2.69)
 pkg_add automake # (select highest version, e.g. 1.15)
-pkg_add python # (select version 2.7.x, not 3.x)
-ln -sf /usr/local/bin/python2.7 /usr/local/bin/python2
+pkg_add python # (select highest version, e.g. 3.5)
 ```
 
-The default C++ compiler that comes with OpenBSD 5.7 is g++ 4.2. This version is old (from 2007), and is not able to compile the current version of Bitcoin Core. It is possible to patch it up to compile, but with the planned transition to C++11 this is a losing battle. So here we will be installing a newer compiler.
+The default C++ compiler that comes with OpenBSD 5.9 is g++ 4.2. This version is old (from 2007), and is not able to compile the current version of Bitcoin Core, primarily as it has no C++11 support, but even before there were issues. So here we will be installing a newer compiler.
 
 GCC
 -------
@@ -27,7 +26,7 @@ GCC
 You can install a newer version of gcc with:
 
 ```bash
-pkg_add g++ # (select newest 4.x version, e.g. 4.9.2)
+pkg_add g++ # (select newest 4.x version, e.g. 4.9.3)
 ```
 
 This compiler will not overwrite the system compiler, it will be installed as `egcc` and `eg++` in `/usr/local/bin`.
@@ -38,7 +37,7 @@ Do not use `pkg_add boost`! The boost version installed thus is compiled using t
 
     test_bitcoin:/usr/lib/libstdc++.so.57.0: /usr/local/lib/libestdc++.so.17.0 : WARNING: symbol(_ZN11__gnu_debug17_S_debug_me ssagesE) size mismatch, relink your program
     ...
-    Segmentation fault (core dumped) 
+    Segmentation fault (core dumped)
 
 This makes it necessary to build boost, or at least the parts used by Bitcoin Core, manually:
 
@@ -49,18 +48,15 @@ BOOST_PREFIX="${BITCOIN_ROOT}/boost"
 mkdir -p $BOOST_PREFIX
 
 # Fetch the source and verify that it is not tampered with
-wget http://heanet.dl.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.bz2
-echo '727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca  boost_1_59_0.tar.bz2' | sha256 -c
-# MUST output: (SHA256) boost_1_59_0.tar.bz2: OK
-tar -xjf boost_1_59_0.tar.bz2
+curl -o boost_1_61_0.tar.bz2 http://heanet.dl.sourceforge.net/project/boost/boost/1.61.0/boost_1_61_0.tar.bz2
+echo 'a547bd06c2fd9a71ba1d169d9cf0339da7ebf4753849a8f7d6fdb8feee99b640  boost_1_61_0.tar.bz2' | sha256 -c
+# MUST output: (SHA256) boost_1_61_0.tar.bz2: OK
+tar -xjf boost_1_61_0.tar.bz2
 
-# Boost 1.59 needs two small patches for OpenBSD
-cd boost_1_59_0
+# Boost 1.61 needs one small patch for OpenBSD
+cd boost_1_61_0
 # Also here: https://gist.githubusercontent.com/laanwj/bf359281dc319b8ff2e1/raw/92250de8404b97bb99d72ab898f4a8cb35ae1ea3/patch-boost_test_impl_execution_monitor_ipp.patch
-patch -p0 < /usr/ports/devel/boost/patches/patch-boost_test_impl_execution_monitor_ipp 
-# https://github.com/boostorg/filesystem/commit/90517e459681790a091566dce27ca3acabf9a70c
-sed 's/__OPEN_BSD__/__OpenBSD__/g' < libs/filesystem/src/path.cpp > libs/filesystem/src/path.cpp.tmp
-mv libs/filesystem/src/path.cpp.tmp libs/filesystem/src/path.cpp
+patch -p0 < /usr/ports/devel/boost/patches/patch-boost_test_impl_execution_monitor_ipp
 
 # Build w/ minimum configuration necessary for bitcoin
 echo 'using gcc : : eg++ : <cxxflags>"-fvisibility=hidden -fPIC" <linkflags>"" <archiver>"ar" <striper>"strip"  <ranlib>"ranlib" <rc>"" : ;' > user-config.jam
@@ -102,7 +98,7 @@ BDB_PREFIX="${BITCOIN_ROOT}/db4"
 mkdir -p $BDB_PREFIX
 
 # Fetch the source and verify that it is not tampered with
-wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
+curl -o db-4.8.30.NC.tar.gz 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
 echo '12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz' | sha256 -c
 # MUST output: (SHA256) db-4.8.30.NC.tar.gz: OK
 tar -xzf db-4.8.30.NC.tar.gz
@@ -110,9 +106,25 @@ tar -xzf db-4.8.30.NC.tar.gz
 # Build the library and install to specified prefix
 cd db-4.8.30.NC/build_unix/
 #  Note: Do a static build so that it can be embedded into the executable, instead of having to find a .so at runtime
-../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX CC=egcc CXX=eg++ CPP=ecpp 
-make install
+../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX CC=egcc CXX=eg++ CPP=ecpp
+make install # do NOT use -jX, this is broken
 ```
+
+### Resource limits
+
+The standard ulimit restrictions in OpenBSD are very strict:
+
+    data(kbytes)         1572864
+
+This is, unfortunately, no longer enough to compile some `.cpp` files in the project,
+at least with gcc 4.9.3 (see issue https://github.com/bitcoin/bitcoin/issues/6658).
+If your user is in the `staff` group the limit can be raised with:
+
+    ulimit -d 3000000
+
+The change will only affect the current shell and processes spawned by it. To
+make the change system-wide, change `datasize-cur` and `datasize-max` in
+`/etc/login.conf`, and reboot.
 
 ### Building Bitcoin Core
 
@@ -124,6 +136,7 @@ export AUTOCONF_VERSION=2.69 # replace this with the autoconf version that you i
 export AUTOMAKE_VERSION=1.15 # replace this with the automake version that you installed
 ./autogen.sh
 ```
+Make sure `BDB_PREFIX` and `BOOST_PREFIX` are set to the appropriate paths from the above steps.
 
 To configure with wallet:
 ```bash
@@ -144,8 +157,7 @@ To configure without wallet:
 
 Build and run the tests:
 ```bash
-gmake
-export LD_LIBRARY_PATH="/usr/local/lib/eopenssl"
+gmake # can use -jX here for parallelism
 gmake check
 ```
 
@@ -184,4 +196,3 @@ version installed by OpenBSD 5.7:
 - https://llvm.org/bugs/show_bug.cgi?id=9758
 
 There is no known workaround for this.
-

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -54,7 +54,7 @@ BerkeleyDB is only necessary for the wallet functionality. To skip this, pass
 It is recommended to use Berkeley DB 4.8. You cannot use the BerkeleyDB library
 from ports, for the same reason as boost above (g++/libstd++ incompatibility).
 If you have to build it yourself, you can use [the installation script included
-in contrib/](/contrib/install_db4.sh) like so
+in contrib/](/contrib/install_db4.sh) like so:
 
 ```shell
 ./contrib/install_db4.sh `pwd` CC=cc CXX=c++
@@ -116,7 +116,7 @@ The standard ulimit restrictions in OpenBSD are very strict:
 
     data(kbytes)         1572864
 
-This, unfortunately, in some cases not enough to compile some `.cpp` files in the project,
+This is, unfortunately, in some cases not enough to compile some `.cpp` files in the project,
 (see issue [#6658](https://github.com/bitcoin/bitcoin/issues/6658)).
 If your user is in the `staff` group the limit can be raised with:
 

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -23,17 +23,12 @@ git clone https://github.com/bitcoin/bitcoin.git
 
 See [dependencies.md](dependencies.md) for a complete overview.
 
-GCC
--------
+**Important**: From OpenBSD 6.2 onwards a C++11-supporting clang compiler is
+part of the base image, and while building it is necessary to make sure that this
+compiler is used and not ancient g++ 4.2.1. This is done by appending
+`CC=cc CXX=c++` to configuration commands. Mixing different compilers
+within the same executable will result in linker errors.
 
-The default C++ compiler that comes with OpenBSD 6.2 is g++ 4.2.1. This version is old (from 2007), and is not able to compile the current version of Bitcoin Core because it has no C++11 support. We'll install a newer version of GCC:
-
-```bash
- pkg_add g++
- ```
-
- This compiler will not overwrite the system compiler, it will be installed as `egcc` and `eg++` in `/usr/local/bin`.
- 
 ### OpenSSL
 
 OpenBSD uses a replacement of OpenSSL: LibreSSL. This can cause compatibility issues, hence `./configure` will bark if you try to compile with this library:
@@ -54,45 +49,23 @@ Alternatively, pass `--with-libressl` to `./configure`, however as the warning s
 
 ### Building BerkeleyDB
 
-BerkeleyDB is only necessary for the wallet functionality. To skip this, pass `--disable-wallet` to `./configure`.
+BerkeleyDB is only necessary for the wallet functionality. To skip this, pass
+`--disable-wallet` to `./configure` and skip to the next section.
 
-See "Berkeley DB" in [build-unix.md](build-unix.md#berkeley-db) for instructions on how to build BerkeleyDB 4.8.
-You cannot use the BerkeleyDB library from ports, for the same reason as boost above (g++/libstd++ incompatibility).
+It is recommended to use Berkeley DB 4.8. You cannot use the BerkeleyDB library
+from ports, for the same reason as boost above (g++/libstd++ incompatibility).
+If you have to build it yourself, you can use [the installation script included
+in contrib/](/contrib/install_db4.sh) like so
 
-```bash
-# Pick some path to install BDB to, here we create a directory within the bitcoin directory
-BITCOIN_ROOT=$(pwd)
-BDB_PREFIX="${BITCOIN_ROOT}/db4"
-mkdir -p $BDB_PREFIX
-
-# Fetch the source and verify that it is not tampered with
-curl -o db-4.8.30.NC.tar.gz 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
-echo '12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz' | sha256 -c
-# MUST output: (SHA256) db-4.8.30.NC.tar.gz: OK
-tar -xzf db-4.8.30.NC.tar.gz
-
-# Build the library and install to specified prefix
-cd db-4.8.30.NC/build_unix/
-#  Note: Do a static build so that it can be embedded into the executable, instead of having to find a .so at runtime
-../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX CC=egcc CXX=eg++ CPP=ecpp
-make install # do NOT use -jX, this is broken
+```shell
+./contrib/install_db4.sh `pwd` CC=cc CXX=c++
 ```
 
-### Resource limits
+from the root of the repository. Then set `BDB_PREFIX` for the next section:
 
-The standard ulimit restrictions in OpenBSD are very strict:
-
-    data(kbytes)         1572864
-
-This, unfortunately, may no longer be enough to compile some `.cpp` files in the project,
-at least with GCC 4.9.4 (see issue [#6658](https://github.com/bitcoin/bitcoin/issues/6658)).
-If your user is in the `staff` group the limit can be raised with:
-
-    ulimit -d 3000000
-
-The change will only affect the current shell and processes spawned by it. To
-make the change system-wide, change `datasize-cur` and `datasize-max` in
-`/etc/login.conf`, and reboot.
+```shell
+export BDB_PREFIX="$PWD/db4"
+```
 
 ### Building Bitcoin Core
 
@@ -108,7 +81,7 @@ Make sure `BDB_PREFIX` is set to the appropriate path from the above steps.
 
 To configure with wallet:
 ```bash
-./configure --with-gui=no CC=egcc CXX=eg++ CPP=ecpp \
+./configure --with-gui=no CC=cc CXX=c++ \
     SSL_CFLAGS="-I/usr/local/include/eopenssl" SSL_LIBS="-L/usr/local/lib/eopenssl -lssl" \
     CRYPTO_CFLAGS="-I/usr/local/include/eopenssl" CRYPTO_LIBS="-L/usr/local/lib/eopenssl -lcrypto" \
     BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"
@@ -116,7 +89,7 @@ To configure with wallet:
 
 To configure without wallet:
 ```bash
-./configure --disable-wallet --with-gui=no CC=egcc CXX=eg++ CPP=ecpp \
+./configure --disable-wallet --with-gui=no CC=cc CXX=c++ \
     SSL_CFLAGS="-I/usr/local/include/eopenssl" SSL_LIBS="-L/usr/local/lib/eopenssl -lssl" \
     CRYPTO_CFLAGS="-I/usr/local/include/eopenssl" CRYPTO_LIBS="-L/usr/local/lib/eopenssl -lcrypto"
 ```
@@ -127,14 +100,22 @@ gmake # use -jX here for parallelism
 gmake check
 ```
 
-Clang
-------------------------------
+Resource limits
+-------------------
 
-```bash
-pkg_add llvm
-./configure --disable-wallet --with-gui=no CC=clang CXX=clang++ \
-    SSL_CFLAGS="-I/usr/local/include/eopenssl" SSL_LIBS="-L/usr/local/lib/eopenssl -lssl" \
-    CRYPTO_CFLAGS="-I/usr/local/include/eopenssl" CRYPTO_LIBS="-L/usr/local/lib/eopenssl -lcrypto"
-gmake # use -jX here for parallelism
-gmake check
-```
+If the build runs into out-of-memory errors, the instructions in this section
+might help.
+
+The standard ulimit restrictions in OpenBSD are very strict:
+
+    data(kbytes)         1572864
+
+This, unfortunately, in some cases not enough to compile some `.cpp` files in the project,
+(see issue [#6658](https://github.com/bitcoin/bitcoin/issues/6658)).
+If your user is in the `staff` group the limit can be raised with:
+
+    ulimit -d 3000000
+
+The change will only affect the current shell and processes spawned by it. To
+make the change system-wide, change `datasize-cur` and `datasize-max` in
+`/etc/login.conf`, and reboot.

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,6 +1,6 @@
 OpenBSD build guide
 ======================
-(updated for OpenBSD 6.4)
+(updated for OpenBSD 6.7)
 
 This guide describes how to build bitcoind and command-line utilities on OpenBSD.
 
@@ -15,7 +15,7 @@ Run the following as root to install the base dependencies for building:
 pkg_add git gmake libevent libtool boost
 pkg_add autoconf # (select highest version, e.g. 2.69)
 pkg_add automake # (select highest version, e.g. 1.16)
-pkg_add python # (select highest version, e.g. 3.6)
+pkg_add python # (select highest version, e.g. 3.8)
 
 git clone https://github.com/bitcoin/bitcoin.git
 ```
@@ -23,10 +23,10 @@ git clone https://github.com/bitcoin/bitcoin.git
 See [dependencies.md](dependencies.md) for a complete overview.
 
 **Important**: From OpenBSD 6.2 onwards a C++11-supporting clang compiler is
-part of the base image, and while building it is necessary to make sure that this
-compiler is used and not ancient g++ 4.2.1. This is done by appending
-`CC=cc CXX=c++` to configuration commands. Mixing different compilers
-within the same executable will result in linker errors.
+part of the base image, and while building it is necessary to make sure that
+this compiler is used and not ancient g++ 4.2.1. This is done by appending
+`CC=cc CC_FOR_BUILD=cc CXX=c++` to configuration commands. Mixing different
+compilers within the same executable will result in errors.
 
 ### OpenSSL
 
@@ -97,7 +97,7 @@ To configure with wallet:
 
 To configure without wallet:
 ```bash
-./configure --disable-wallet --with-gui=no CC=cc CXX=c++ \
+./configure --disable-wallet --with-gui=no CC=cc CC_FOR_BUILD=cc CXX=c++ \
     SSL_CFLAGS="-I/usr/local/include/eopenssl" SSL_LIBS="-L/usr/local/lib/eopenssl -lssl" \
     CRYPTO_CFLAGS="-I/usr/local/include/eopenssl" CRYPTO_LIBS="-L/usr/local/lib/eopenssl -lcrypto" \
     MAKE=gmake

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,6 +1,6 @@
 OpenBSD build guide
 ======================
-(updated for OpenBSD 5.9)
+(updated for OpenBSD 6.0)
 
 This guide describes how to build bitcoind and command-line utilities on OpenBSD.
 
@@ -144,7 +144,7 @@ To configure with wallet:
     CC=egcc CXX=eg++ CPP=ecpp \
     SSL_CFLAGS="-I/usr/local/include/eopenssl" SSL_LIBS="-L/usr/local/lib/eopenssl -lssl" \
     CRYPTO_CFLAGS="-I/usr/local/include/eopenssl" CRYPTO_LIBS="-L/usr/local/lib/eopenssl -lcrypto" \
-    LDFLAGS="-L${BDB_PREFIX}/lib/" CPPFLAGS="-I${BDB_PREFIX}/include/"
+    BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"
 ```
 
 To configure without wallet:
@@ -163,6 +163,8 @@ gmake check
 
 Clang (not currently working)
 ------------------------------
+
+WARNING: This is outdated, needs to be updated for OpenBSD 6.0 and re-tried.
 
 Using a newer g++ results in linking the new code to a new libstdc++.
 Libraries built with the old g++, will still import the old library.

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -56,19 +56,19 @@ from ports, for the same reason as boost above (g++/libstd++ incompatibility).
 If you have to build it yourself, you can use [the installation script included
 in contrib/](/contrib/install_db4.sh) like so:
 
-```shell
+```bash
 ./contrib/install_db4.sh `pwd` CC=cc CXX=c++
 ```
 
 from the root of the repository. Then set `BDB_PREFIX` for the next section:
 
-```shell
+```bash
 export BDB_PREFIX="$PWD/db4"
 ```
 
 ### Building Bitcoin Core
 
-**Important**: use `gmake`, not `make`. The non-GNU `make` will exit with a horrible error.
+**Important**: Use `gmake` (the non-GNU `make` will exit with an error).
 
 Preparation:
 ```bash
@@ -90,14 +90,17 @@ To configure with wallet:
 ./configure --with-gui=no CC=cc CXX=c++ \
     SSL_CFLAGS="-I/usr/local/include/eopenssl" SSL_LIBS="-L/usr/local/lib/eopenssl -lssl" \
     CRYPTO_CFLAGS="-I/usr/local/include/eopenssl" CRYPTO_LIBS="-L/usr/local/lib/eopenssl -lcrypto" \
-    BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"
+    BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
+    BDB_CFLAGS="-I${BDB_PREFIX}/include" \
+    MAKE=gmake
 ```
 
 To configure without wallet:
 ```bash
 ./configure --disable-wallet --with-gui=no CC=cc CXX=c++ \
     SSL_CFLAGS="-I/usr/local/include/eopenssl" SSL_LIBS="-L/usr/local/lib/eopenssl -lssl" \
-    CRYPTO_CFLAGS="-I/usr/local/include/eopenssl" CRYPTO_LIBS="-L/usr/local/lib/eopenssl -lcrypto"
+    CRYPTO_CFLAGS="-I/usr/local/include/eopenssl" CRYPTO_LIBS="-L/usr/local/lib/eopenssl -lcrypto" \
+    MAKE=gmake
 ```
 
 Build and run the tests:

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -2,8 +2,7 @@ UNIX BUILD NOTES
 ====================
 Some notes on how to build PRCYCoin in Unix.
 
-(For BSD specific instructions, see [build-openbsd.md](build-openbsd.md) and/or
-[build-netbsd.md](build-netbsd.md))
+(For BSD specific instructions, see `build-*bsd.md` in this directory.)
 
 Note
 ---------------------
@@ -284,31 +283,3 @@ To build executables for ARM:
 
 
 For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.
-
-Building on FreeBSD
---------------------
-
-(Updated as of FreeBSD 11.0)
-
-Clang is installed by default as `cc` compiler, this makes it easier to get
-started than on [OpenBSD](build-openbsd.md). Installing dependencies:
-
-    pkg install autoconf automake libtool pkgconf
-    pkg install boost-libs openssl libevent2
-
-(`libressl` instead of `openssl` will also work)
-
-For the wallet (optional):
-
-    ./contrib/install_db4.sh `pwd`
-    setenv BDB_PREFIX $PWD/db4
-
-Then build using:
-
-    ./autogen.sh
-    ./configure BDB_CFLAGS="-I${BDB_PREFIX}/include" BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx"
-    make
-
-*Note on debugging*: The version of `gdb` installed by default is [ancient and considered harmful](https://wiki.freebsd.org/GdbRetirement).
-It is not suitable for debugging a multi-threaded C++ program, not even for getting backtraces. Please install the package `gdb` and
-use the versioned gdb command e.g. `gdb7111`.

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -283,3 +283,35 @@ To build executables for ARM:
 
 
 For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.
+
+Building on FreeBSD
+--------------------
+
+(Updated as of FreeBSD 10.3)
+
+Clang is installed by default as `cc` compiler, this makes it easier to get
+started than on [OpenBSD](build-openbsd.md). Installing dependencies:
+
+    pkg install autoconf automake libtool pkgconf
+    pkg install boost-libs openssl libevent2
+
+(`libressl` instead of `openssl` will also work)
+
+For the wallet (optional):
+
+    pkg install db5
+
+This will give a warning "configure: WARNING: Found Berkeley DB other
+than 4.8; wallets opened by this build will not be portable!", but as FreeBSD never
+had a binary release, this may not matter. If backwards compatibility
+with 4.8-built Bitcoin Core is needed follow the steps under "Berkeley DB" above.
+
+Then build using:
+
+    ./autogen.sh
+    ./configure --with-incompatible-bdb CPPFLAGS=-I/usr/local/include/db5 LDFLAGS=-L/usr/local/lib/db5
+    make
+
+*Note on debugging*: The version of `gdb` installed by default is [ancient and considered harmful](https://wiki.freebsd.org/GdbRetirement).
+It is not suitable for debugging a multi-threaded C++ program, not even for getting backtraces. Please install the package `gdb` and
+use the versioned gdb command e.g. `gdb7111`.

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -2,6 +2,8 @@ UNIX BUILD NOTES
 ====================
 Some notes on how to build PRCYCoin in Unix.
 
+(for OpenBSD specific instructions, see [build-openbsd.md](build-openbsd.md))
+
 Note
 ---------------------
 Always use absolute paths to configure and compile PRCYCoin and the dependencies,

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -2,7 +2,8 @@ UNIX BUILD NOTES
 ====================
 Some notes on how to build PRCYCoin in Unix.
 
-(for OpenBSD specific instructions, see [build-openbsd.md](build-openbsd.md))
+(For BSD specific instructions, see [build-openbsd.md](build-openbsd.md) and/or
+[build-netbsd.md](build-netbsd.md))
 
 Note
 ---------------------

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -299,17 +299,13 @@ started than on [OpenBSD](build-openbsd.md). Installing dependencies:
 
 For the wallet (optional):
 
-    pkg install db5
-
-This will give a warning "configure: WARNING: Found Berkeley DB other
-than 4.8; wallets opened by this build will not be portable!", but as FreeBSD never
-had a binary release, this may not matter. If backwards compatibility
-with 4.8-built Bitcoin Core is needed follow the steps under "Berkeley DB" above.
+    ./contrib/install_db4.sh `pwd`
+    setenv BDB_PREFIX $PWD/db4
 
 Then build using:
 
     ./autogen.sh
-    ./configure --with-incompatible-bdb BDB_CFLAGS="-I/usr/local/include/db5" BDB_LIBS="-L/usr/local/lib -ldb_cxx-5"
+    ./configure BDB_CFLAGS="-I${BDB_PREFIX}/include" BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx"
     make
 
 *Note on debugging*: The version of `gdb` installed by default is [ancient and considered harmful](https://wiki.freebsd.org/GdbRetirement).

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -287,7 +287,7 @@ For further documentation on the depends system see [README.md](../depends/READM
 Building on FreeBSD
 --------------------
 
-(Updated as of FreeBSD 10.3)
+(Updated as of FreeBSD 11.0)
 
 Clang is installed by default as `cc` compiler, this makes it easier to get
 started than on [OpenBSD](build-openbsd.md). Installing dependencies:
@@ -309,7 +309,7 @@ with 4.8-built Bitcoin Core is needed follow the steps under "Berkeley DB" above
 Then build using:
 
     ./autogen.sh
-    ./configure --with-incompatible-bdb CPPFLAGS=-I/usr/local/include/db5 LDFLAGS=-L/usr/local/lib/db5
+    ./configure --with-incompatible-bdb BDB_CFLAGS="-I/usr/local/include/db5" BDB_LIBS="-L/usr/local/lib -ldb_cxx-5"
     make
 
 *Note on debugging*: The version of `gdb` installed by default is [ancient and considered harmful](https://wiki.freebsd.org/GdbRetirement).


### PR DESCRIPTION
A large collection of Upstream Build/Doc Updates for FreeBSD, NetBSD, and OpenBSD up to the point before upstream updated Qt to 5.12 (lots of changes required for us to get there still)

This will at least get users on those OSs started if they wish to compile their own.