### PR TITLE
[Upstream] doc: Update macOS cross compilation dependencies for Focal

### DIFF
--- a/.github/workflows/prcy-build-factory-ubuntu20.yml
+++ b/.github/workflows/prcy-build-factory-ubuntu20.yml
@@ -250,7 +250,7 @@ jobs:
     - name: Install Required Packages
       run: |
         sudo apt-get update
-        sudo apt-get install -y python3-setuptools libcap-dev
+        sudo apt-get install -y python3-setuptools libcap-dev libtinfo5
     - name: Get macOS SDK
       run: |
         mkdir -p depends/sdk-sources depends/SDKs

--- a/depends/README.md
+++ b/depends/README.md
@@ -37,7 +37,7 @@ The paths are automatically configured and no other options are needed unless ta
 
 #### For macOS cross compilation
 
-    sudo apt-get install curl bsdmainutils cmake libcap-dev libz-dev libbz2-dev python3-setuptools
+    sudo apt-get install curl bsdmainutils cmake libcap-dev libz-dev libbz2-dev python3-setuptools libtinfo5
 
 Note: You must obtain the macOS SDK before proceeding with a cross-compile.
 Under the depends directory, create a subdirectory named `SDKs`.


### PR DESCRIPTION
>The [`libtinfo5`](https://packages.ubuntu.com/focal/libtinfo5) package is required on Ubuntu Focal for macOS cross compilation.

>Fixes https://github.com/bitcoin/bitcoin/issues/19546.

from https://github.com/bitcoin/bitcoin/pull/19547

As the Ubuntu 18 Actions Runner will be deprecated April 1st, we will be moving to Focal for building on GitHub.