### PR TITLE
[Upstream] build: Suppress -Wdeprecated-copy warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -331,6 +331,7 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   AX_CHECK_COMPILE_FLAG([-Wunused-local-typedef],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-unused-local-typedef"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wdeprecated-register],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-deprecated-register"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-implicit-fallthrough"],,[[$CXXFLAG_WERROR]])
+  AX_CHECK_COMPILE_FLAG([-Wdeprecated-copy],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-deprecated-copy"],,[[$CXXFLAG_WERROR]])
 fi
 
 enable_sse42=no


### PR DESCRIPTION
>Tomorrow, on Apr 23 the Ubuntu 20.04 release is expected. It packaged with Qt 5.12 LTS that has a nasty peculiarity to cause modern compilers, including Clang 10.0 and GCC 9.3, to emit spammy -Wdeprecated-copy warnings (https://github.com/bitcoin/bitcoin/issues/15822, https://github.com/bitcoin/bitcoin/issues/18419).

>This PR suppress such warnings temporarily, until the [upstream is fixed](https://codereview.qt-project.org/c/qt/qtbase/+/272258).

>Here are some affected systems (with system packages):
>- Ubuntu 20.04 LTS + Qt 5.12.8 LTS + { Clang 10.0 | GCC 9.3 }
>- Fedora 32 + Qt 5.13.2 + Clang 10.0
>Reference: [QTBUG-75210](https://bugreports.qt.io/browse/QTBUG-75210)

>Also see fanquake's https://github.com/bitcoin/bitcoin/pull/18738#issuecomment-622956100.

Since we are switching our Actions to Ubuntu 20, better to have less spammy warnings.

from https://github.com/bitcoin/bitcoin/pull/18738