### PR TITLE
[Upstream] build: fix mutex detection when building bdb on macOS

### DIFF
--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -13,6 +13,7 @@ $(package)_config_opts_linux=--with-pic
 $(package)_config_opts_freebsd=--with-pic
 $(package)_config_opts_netbsd=--with-pic
 $(package)_config_opts_openbsd=--with-pic
+$(package)_cflags+=-Wno-error=implicit-function-declaration
 $(package)_cxxflags=-std=c++17
 $(package)_cppflags_mingw32=-DUNICODE -D_UNICODE
 endef


### PR DESCRIPTION
>Starting with the Apple Clang shipped with Xcode 12, [Apple has enabled -Werror=implicit-function-declaration by default](https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes):

>Clang now reports an error when you use a function without an explicit declaration when building C or Objective-C code for macOS (-Werror=implicit-function-declaration flag is on). This additional error detection unifies Clang’s behavior for iOS/tvOS and macOS 64-bit targets for this diagnostic. (49917738)

>This causes bdbs mutex detection to fail when building on macOS (not cross-compiling):
```
checking for mutexes... UNIX/fcntl
configure: WARNING: NO SHARED LATCH IMPLEMENTATION FOUND FOR THIS PLATFORM.
configure: error: Unable to find a mutex implementation
```
>as previously emitted warnings are being turned into errors. i.e:
```
configure:18704: checking for mutexes
configure:18815: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -mmacosx-version-min=10.12 --sysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -o conftest -pipe -O2  -I/Users/michael/github/fanquake-bitcoin/depends/x86_64-apple-darwin19.6.0/include -L/Users/michael/github/fanquake-bitcoin/depends/x86_64-apple-darwin19.6.0/lib conftest.c  -lpthread >&5
conftest.c:46:1: warning: type specifier missing, defaults to 'int' [-Wimplicit-int]
main() {
^
conftest.c:51:2: error: implicitly declaring library function 'exit' with type 'void (int) __attribute__((noreturn))' [-Werror,-Wimplicit-function-declaration]
        exit (
        ^
conftest.c:51:2: note: include the header <stdlib.h> or explicitly provide a declaration for 'exit'
1 warning and 1 error generated.
```

>Append `-Wno-error=implicit-function-declaration` to `cflags` so that `-Wimplicit-function-declaration` [returns to being a warning](https://clang.llvm.org/docs/UsersManual.html#cmdoption-wno-error), and the configure checks succeed.

>Fixes https://github.com/bitcoin/bitcoin/issues/19411.

Following more updates re: macOS compile with newer tools.
from https://github.com/bitcoin/bitcoin/pull/20195
