### PR TITLE
[Upstream] build: fix unoptimized libraries in depends

### DIFF
--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -14,7 +14,7 @@ $(package)_config_opts_freebsd=--with-pic
 $(package)_config_opts_netbsd=--with-pic
 $(package)_config_opts_openbsd=--with-pic
 $(package)_cflags+=-Wno-error=implicit-function-declaration
-$(package)_cxxflags=-std=c++17
+$(package)_cxxflags+=-std=c++17
 $(package)_cppflags_mingw32=-DUNICODE -D_UNICODE
 endef
 

--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -13,6 +13,7 @@ $(package)_config_opts_linux=--with-pic
 $(package)_config_opts_freebsd=--with-pic
 $(package)_config_opts_netbsd=--with-pic
 $(package)_config_opts_openbsd=--with-pic
+$(package)_cflags+=-Wno-error=implicit-function-declaration
 $(package)_cxxflags=-std=c++17
 $(package)_cppflags_mingw32=-DUNICODE -D_UNICODE
 endef

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -32,7 +32,7 @@ else
 $(package)_toolset_$(host_os)=gcc
 endif
 $(package)_config_libraries=chrono,filesystem,program_options,system,thread,test
-$(package)_cxxflags=-std=c++17 -fvisibility=hidden
+$(package)_cxxflags+=-std=c++17 -fvisibility=hidden
 $(package)_cxxflags_linux=-fPIC
 $(package)_cxxflags_freebsd=-fPIC
 $(package)_cxxflags_openbsd=-fPIC

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -16,7 +16,7 @@ define $(package)_set_vars
   $(package)_config_opts_netbsd=--with-pic
   $(package)_config_opts_openbsd=--with-pic
   $(package)_config_opts_android=--with-pic
-  $(package)_cxxflags=-std=c++17
+  $(package)_cxxflags+=-std=c++17
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
>We need to append-to rather than set CXXFLAGS, otherwise we loose -O2 & -pipe from our defaults. Currently this results in zeromq being built without optimizations at all (or whatever the compiler would default too, essentially always -O0).

>Bdb is the same, for the CXX portion of its code. C code has been built with -O2. Boost has actually been unaffected because it receives -O3 from it's own build flags.

>Noticed while reworking https://github.com/bitcoin/bitcoin/pull/22380. For bdb & zeromq, I assume (haven't checked) this has been the case since https://github.com/bitcoin/bitcoin/pull/7165.

>You can inspect the effects in bitcoind comparing a function from a unoptimised library, i.e libzmq.

from https://github.com/bitcoin/bitcoin/pull/22840