### PR TITLE
[Upstream] rpc: Set HTTP Content-Type in prcycoin-cli

### DIFF
--- a/src/prcycoin-cli.cpp
+++ b/src/prcycoin-cli.cpp
@@ -179,6 +179,7 @@ UniValue CallRPC(const std::string& strMethod, const UniValue& params)
     assert(output_headers);
     evhttp_add_header(output_headers, "Host", host.c_str());
     evhttp_add_header(output_headers, "Connection", "close");
+    evhttp_add_header(output_headers, "Content-Type", "application/json");
     evhttp_add_header(output_headers, "Authorization", (std::string("Basic ") + EncodeBase64(strRPCUserColonPass)).c_str());
 
     // Attach request data


### PR DESCRIPTION
>We don't set any `Content-Type` in the client. It is more consistent with our other JSON-RPC use to set it to `application/json`.

>Note that our server doesn't enforce content types, so it doesn't make a difference in practice. But it is fairly strange HTTP behavior to not set it.

>This came up in https://github.com/bitcoin/bitcoin/issues/18950.

from https://github.com/bitcoin/bitcoin/pull/20055