### PR TITLE
[Upstream] RPC: Added additional config option for multiple RPC users.

### DIFF
--- a/share/rpcuser/README.md
+++ b/share/rpcuser/README.md
@@ -1,0 +1,11 @@
+RPC Tools
+---------------------
+
+### [RPCUser](/share/rpcuser) ###
+
+Create an RPC user login credential.
+
+Usage:
+
+./rpcuser.py <username>
+

--- a/share/rpcuser/rpcuser.py
+++ b/share/rpcuser/rpcuser.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python2 
+# Copyright (c) 2015 The Bitcoin Core developers 
+# Distributed under the MIT software license, see the accompanying 
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import hashlib
+import sys
+import os
+from random import SystemRandom
+import base64
+import hmac
+
+if len(sys.argv) < 2:
+    sys.stderr.write('Please include username as an argument.\n')
+    sys.exit(0)
+
+username = sys.argv[1]
+
+#This uses os.urandom() underneath
+cryptogen = SystemRandom()
+
+#Create 16 byte hex salt
+salt_sequence = [cryptogen.randrange(256) for i in range(16)]
+hexseq = list(map(hex, salt_sequence))
+salt = "".join([x[2:] for x in hexseq])
+
+#Create 32 byte b64 password
+password = base64.urlsafe_b64encode(os.urandom(32))
+
+digestmod = hashlib.sha256
+
+if sys.version_info.major >= 3:
+    password = password.decode('utf-8')
+    digestmod = 'SHA256'
+ 
+m = hmac.new(bytearray(salt, 'utf-8'), bytearray(password, 'utf-8'), digestmod)
+result = m.hexdigest()
+
+print("String to be appended to bitcoin.conf:")
+print("rpcauth="+username+":"+salt+"$"+result)
+print("Your password:\n"+password)

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -16,6 +16,8 @@
 #include "util.h"
 #include "utilstrencodings.h"
 #include "guiinterface.h"
+#include "crypto/hmac_sha256.h"
+#include <stdio.h>
 
 #include <boost/algorithm/string.hpp> // boost::trim
 
@@ -78,6 +80,50 @@ static void JSONErrorReply(HTTPRequest* req, const UniValue& objError, const Uni
     req->WriteReply(nStatus, strReply);
 }
 
+//This function checks username and password against -rpcauth
+//entries from config file.
+static bool multiUserAuthorized(std::string strUserPass)
+{    
+    if (strUserPass.find(":") == std::string::npos) {
+        return false;
+    }
+    std::string strUser = strUserPass.substr(0, strUserPass.find(":"));
+    std::string strPass = strUserPass.substr(strUserPass.find(":") + 1);
+
+    if (mapMultiArgs.count("-rpcauth") > 0) {
+        //Search for multi-user login/pass "rpcauth" from config
+        for (std::string strRPCAuth : mapMultiArgs["-rpcauth"])
+        {
+            std::vector<std::string> vFields;
+            boost::split(vFields, strRPCAuth, boost::is_any_of(":$"));
+            if (vFields.size() != 3) {
+                //Incorrect formatting in config file
+                continue;
+            }
+
+            std::string strName = vFields[0];
+            if (!TimingResistantEqual(strName, strUser)) {
+                continue;
+            }
+
+            std::string strSalt = vFields[1];
+            std::string strHash = vFields[2];
+
+            unsigned int KEY_SIZE = 32;
+            unsigned char *out = new unsigned char[KEY_SIZE]; 
+
+            CHMAC_SHA256(reinterpret_cast<const unsigned char*>(strSalt.c_str()), strSalt.size()).Write(reinterpret_cast<const unsigned char*>(strPass.c_str()), strPass.size()).Finalize(out);
+            std::vector<unsigned char> hexvec(out, out+KEY_SIZE);
+            std::string strHashFromPass = HexStr(hexvec);
+
+            if (TimingResistantEqual(strHashFromPass, strHash)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 static bool RPCAuthorized(const std::string& strAuth)
 {
     if (strRPCUserColonPass.empty()) // Belt-and-suspenders measure if InitRPCAuthentication was not called
@@ -87,7 +133,12 @@ static bool RPCAuthorized(const std::string& strAuth)
     std::string strUserPass64 = strAuth.substr(6);
     boost::trim(strUserPass64);
     std::string strUserPass = DecodeBase64(strUserPass64);
-    return TimingResistantEqual(strUserPass, strRPCUserColonPass);
+
+    //Check if authorized under single-user field
+    if (TimingResistantEqual(strUserPass, strRPCUserColonPass)) {
+        return true;
+    }
+    return multiUserAuthorized(strUserPass);
 }
 
 static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string &)
@@ -163,6 +214,7 @@ static bool InitRPCAuthentication()
             return false;
         }
     } else {
+        LogPrintf("Config options rpcuser and rpcpassword will soon be deprecated. Locally-run instances may remove rpcuser to use cookie-based auth, or may be replaced with rpcauth. Please see share/rpcuser for rpcauth auth generation.");
         strRPCUserColonPass = mapArgs["-rpcuser"] + ":" + mapArgs["-rpcpassword"];
     }
     return true;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -554,6 +554,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-rpcbind=<addr>", _("Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6. This option can be specified multiple times (default: bind to all interfaces)"));
     strUsage += HelpMessageOpt("-rpcuser=<user>", _("Username for JSON-RPC connections"));
     strUsage += HelpMessageOpt("-rpcpassword=<pw>", _("Password for JSON-RPC connections"));
+    strUsage += HelpMessageOpt("-rpcauth=<userpw>", _("Username and hashed password for JSON-RPC connections. The field <userpw> comes in the format: <USERNAME>:<SALT>$<HASH>. A canonical python script is included in share/rpcuser. This option can be specified multiple times"));
     strUsage += HelpMessageOpt("-rpcport=<port>", strprintf(_("Listen for JSON-RPC connections on <port> (default: %u or testnet: %u)"), 59683, 59685));
     strUsage += HelpMessageOpt("-rpcallowip=<ip>", _("Allow JSON-RPC connections from specified source. Valid for <ip> are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times"));
     strUsage += HelpMessageOpt("-rpcthreads=<n>", strprintf(_("Set the number of threads to service RPC calls (default: %d)"), DEFAULT_HTTP_THREADS));


### PR DESCRIPTION
>This pull adds an additional config option, "rpcauth" to allow multiple different users to use different credentials for login.

>Motivation:
In business settings there are often multiple users accessing a particular core instance, using wallet functionality. Instead of all users sharing the same login name and password, it is desired to have each user generate their own secret password, and have a hashed and salted version added to bitcoin.conf by the admin. Currently there is only one name and password, and it is stored in plaintext. This pull attempts to do just this and will be followed by an additional audit logging pull to enable admins to assign blame to spends and other irreversible actions.

>The config option comes in the format:
>`rpcauth=USERNAME:SALT$HASH`

>Where:
>1. USERNAME is the desired username. Name does not have to be unique.
>2. SALT is the salt for the HMAC_SHA256 function
>3. HASH is a hex string that is the result of the HMAC_SHA256 function on the user's secret password plus the SALT as the key.

>A "canonical" password generating python script has been supplied in share/rpcuser. From the client-side, one connects using the standard -rpcuser/-rpcpassword options.

from https://github.com/bitcoin/bitcoin/pull/7044