### PR TITLE
[Upstream] build: set minimum required Boost to 1.57.0->1.58.0->1.64.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -931,7 +931,7 @@ fi
 if test x$use_boost = xyes; then
 
 dnl Check for Boost headers
-AX_BOOST_BASE([1.58.0],[],[AC_MSG_ERROR([Boost is not available!])])
+AX_BOOST_BASE([1.64.0],[],[AC_MSG_ERROR([Boost is not available!])])
 if test x$want_boost = xno; then
     AC_MSG_ERROR([[only libbitcoinconsensus can be built without boost]])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -930,11 +930,8 @@ fi
 
 if test x$use_boost = xyes; then
 
-dnl Minimum required Boost version
-define(MINIMUM_REQUIRED_BOOST, 1.58.0)
-
-dnl Check for Boost libs
-AX_BOOST_BASE([MINIMUM_REQUIRED_BOOST])
+dnl Check for Boost headers
+AX_BOOST_BASE([1.58.0],[],[AC_MSG_ERROR([Boost is not available!])])
 if test x$want_boost = xno; then
     AC_MSG_ERROR([[only libbitcoinconsensus can be built without boost]])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -931,9 +931,9 @@ fi
 if test x$use_boost = xyes; then
 
 dnl Minimum required Boost version
-define(MINIMUM_REQUIRED_BOOST, 1.57.0)
+define(MINIMUM_REQUIRED_BOOST, 1.58.0)
 
-dnl Check for boost libs
+dnl Check for Boost libs
 AX_BOOST_BASE([MINIMUM_REQUIRED_BOOST])
 if test x$want_boost = xno; then
     AC_MSG_ERROR([[only libbitcoinconsensus can be built without boost]])

--- a/configure.ac
+++ b/configure.ac
@@ -940,11 +940,6 @@ AX_BOOST_FILESYSTEM
 AX_BOOST_PROGRAM_OPTIONS
 AX_BOOST_THREAD
 AX_BOOST_CHRONO
-
-dnl Boost 1.56 through 1.62 allow using std::atomic instead of its own atomic
-dnl counter implementations. In 1.63 and later the std::atomic approach is default.
-m4_pattern_allow(DBOOST_AC_USE_STD_ATOMIC) dnl otherwise it's treated like a macro
-BOOST_CPPFLAGS="-DBOOST_SP_USE_STD_ATOMIC -DBOOST_AC_USE_STD_ATOMIC $BOOST_CPPFLAGS"
 fi
 
 if test x$use_reduce_exports = xyes; then

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -6,7 +6,7 @@ These are the dependencies currently used by PRCYCoin. You can find instructions
 | Dependency | Version used | Minimum required | CVEs | Shared | [Bundled Qt library](https://doc.qt.io/qt-5/configure-options.html#third-party-libraries) |
 | --- | --- | --- | --- | --- | --- |
 | Berkeley DB | [4.8.30](https://www.oracle.com/technetwork/database/database-technologies/berkeleydb/downloads/index.html) | 4.8.x | No |  |  |
-| Boost | [1.71.0](https://www.boost.org/users/download/) | [1.58.0](https://github.com/PRCYCoin/PRCYCoin/pull/286) | No |  |  |
+| Boost | [1.71.0](https://www.boost.org/users/download/) | [1.64.0](https://github.com/PRCYCoin/PRCYCoin/pull/286) | No |  |  |
 | Clang |  | [3.3+](https://llvm.org/releases/download.html) (C++11 support) |  |  |  |
 | D-Bus | [1.10.18](https://cgit.freedesktop.org/dbus/dbus/tree/NEWS?h=dbus-1.10) |  | No | Yes |  |
 | Fontconfig | [2.12.6](https://www.freedesktop.org/software/fontconfig/release/) |  | No | Yes |  |

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -6,7 +6,7 @@ These are the dependencies currently used by PRCYCoin. You can find instructions
 | Dependency | Version used | Minimum required | CVEs | Shared | [Bundled Qt library](https://doc.qt.io/qt-5/configure-options.html#third-party-libraries) |
 | --- | --- | --- | --- | --- | --- |
 | Berkeley DB | [4.8.30](https://www.oracle.com/technetwork/database/database-technologies/berkeleydb/downloads/index.html) | 4.8.x | No |  |  |
-| Boost | [1.71.0](https://www.boost.org/users/download/) | [1.57.0](https://github.com/PRCYCoin/PRCYCoin/pull/286) | No |  |  |
+| Boost | [1.71.0](https://www.boost.org/users/download/) | [1.58.0](https://github.com/PRCYCoin/PRCYCoin/pull/286) | No |  |  |
 | Clang |  | [3.3+](https://llvm.org/releases/download.html) (C++11 support) |  |  |  |
 | D-Bus | [1.10.18](https://cgit.freedesktop.org/dbus/dbus/tree/NEWS?h=dbus-1.10) |  | No | Yes |  |
 | Fontconfig | [2.12.6](https://www.freedesktop.org/software/fontconfig/release/) |  | No | Yes |  |


### PR DESCRIPTION
Bumps our minimum Boost version to 1.64.0 (we use 1.71 currently) and fails when Boost doesn't exist

based on:
- https://github.com/bitcoin/bitcoin/pull/19667
- https://github.com/bitcoin/bitcoin/pull/21205
- https://github.com/bitcoin/bitcoin/pull/22320
