### PR TITLE
[Upstream] rpc: Add WWW-Authenticate header to 401 response

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -21,6 +21,9 @@
 
 #include <boost/algorithm/string.hpp> // boost::trim
 
+/** WWW-Authenticate to present with 401 Unauthorized response */
+static const char* WWW_AUTH_HEADER_DATA = "Basic realm=\"jsonrpc\"";
+
 /** Simple one-shot callback timer to be used by the RPC mechanism to e.g.
  * re-lock the wellet.
  */
@@ -151,6 +154,7 @@ static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string &)
     // Check authorization
     std::pair<bool, std::string> authHeader = req->GetHeader("authorization");
     if (!authHeader.first) {
+        req->WriteHeader("WWW-Authenticate", WWW_AUTH_HEADER_DATA);
         req->WriteReply(HTTP_UNAUTHORIZED);
         return false;
     }
@@ -163,6 +167,7 @@ static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string &)
            shouldn't have their RPC port exposed. */
         MilliSleep(250);
 
+        req->WriteHeader("WWW-Authenticate", WWW_AUTH_HEADER_DATA);
         req->WriteReply(HTTP_UNAUTHORIZED);
         return false;
     }


### PR DESCRIPTION
>A WWW-Authenticate header must be present in the 401 response to make clients know that they can authenticate, and how.

> `WWW-Authenticate: Basic realm="jsonrpc"`

>Fixes https://github.com/bitcoin/bitcoin/issues/7462.

from https://github.com/bitcoin/bitcoin/pull/7472