### PR TITLE
[Upstream] build: support LTO in depends

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -37,6 +37,7 @@ NO_QR ?=
 NO_WALLET ?=
 NO_ZMQ ?=
 NO_UPNP ?=
+LTO ?=
 FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources
 
 BUILD = $(shell ./config.guess)
@@ -139,8 +140,8 @@ include packages/packages.mk
 #     2. Before including packages/*.mk (excluding packages/packages.mk), since
 #        they rely on the build_id variables
 #
-build_id:=$(shell env CC='$(build_CC)' CXX='$(build_CXX)' AR='$(build_AR)' RANLIB='$(build_RANLIB)' STRIP='$(build_STRIP)' SHA256SUM='$(build_SHA256SUM)' DEBUG='$(DEBUG)' ./gen_id '$(BUILD_ID_SALT)')
-$(host_arch)_$(host_os)_id:=$(shell env CC='$(host_CC)' CXX='$(host_CXX)' AR='$(host_AR)' RANLIB='$(host_RANLIB)' STRIP='$(host_STRIP)' SHA256SUM='$(build_SHA256SUM)' DEBUG='$(DEBUG)' ./gen_id '$(HOST_ID_SALT)')
+build_id:=$(shell env CC='$(build_CC)' CXX='$(build_CXX)' AR='$(build_AR)' RANLIB='$(build_RANLIB)' STRIP='$(build_STRIP)' SHA256SUM='$(build_SHA256SUM)' DEBUG='$(DEBUG)' LTO='$(LTO)' ./gen_id '$(BUILD_ID_SALT)')
+$(host_arch)_$(host_os)_id:=$(shell env CC='$(host_CC)' CXX='$(host_CXX)' AR='$(host_AR)' RANLIB='$(host_RANLIB)' STRIP='$(host_STRIP)' SHA256SUM='$(build_SHA256SUM)' DEBUG='$(DEBUG)' LTO='$(LTO)' ./gen_id '$(HOST_ID_SALT)')
 
 qrencode_packages_$(NO_QR) = $(qrencode_packages)
 
@@ -225,6 +226,7 @@ $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_
             -e 's|@no_zmq@|$(NO_ZMQ)|' \
             -e 's|@no_wallet@|$(NO_WALLET)|' \
             -e 's|@no_upnp@|$(NO_UPNP)|' \
+            -e 's|@lto@|$(LTO)|' \
             -e 's|@debug@|$(DEBUG)|' \
             $< > $@
 	$(AT)touch $@

--- a/depends/README.md
+++ b/depends/README.md
@@ -102,6 +102,7 @@ The following can be set when running make: `make FOO=bar`
 - `FORCE_USE_SYSTEM_CLANG`: (EXPERTS ONLY) When cross-compiling for macOS, use Clang found in the
   system's `$PATH` rather than the default prebuilt release of Clang
   from llvm.org. Clang 8 or later is required.
+- `LTO`: Use LTO when building packages.
 
 If some packages are not built, for example `make NO_WALLET=1`, the appropriate
 options will be passed to bitcoin's configure. In this case, `--disable-wallet`.

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -67,6 +67,10 @@ if test "x@host_os@" = xdarwin; then
   PORT=no
 fi
 
+if test -z "$enable_lto" && test -n "@lto@"; then
+  enable_lto=yes
+fi
+
 PATH="${depends_prefix}/native/bin:${PATH}"
 PKG_CONFIG="$(which pkg-config) --static"
 

--- a/depends/gen_id
+++ b/depends/gen_id
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Usage: env [ CC=... ] [ CXX=... ] [ AR=... ] [ RANLIB=... ] [ STRIP=... ] \
-#            [ DEBUG=... ] ./build-id [ID_SALT]...
+#            [ DEBUG=... ] [ LTO=... ] ./build-id [ID_SALT]...
 #
 # Prints to stdout a SHA256 hash representing the current toolset, used by
 # depends/Makefile as a build id for caching purposes (detecting when the
@@ -62,6 +62,10 @@
     bash -c "${STRIP} --version"
     env | grep '^STRIP_'
     echo "END STRIP"
+
+    echo "BEGIN LTO"
+    echo "LTO=${LTO}"
+    echo "END LTO"
 
     echo "END ALL"
 ) | if [ -n "$DEBUG" ] && command -v tee > /dev/null 2>&1; then

--- a/depends/hosts/android.mk
+++ b/depends/hosts/android.mk
@@ -9,3 +9,8 @@ android_CXX=$(ANDROID_TOOLCHAIN_BIN)/$(HOST)$(ANDROID_API_LEVEL)-clang++
 android_CC=$(ANDROID_TOOLCHAIN_BIN)/$(HOST)$(ANDROID_API_LEVEL)-clang
 android_RANLIB=$(ANDROID_TOOLCHAIN_BIN)/$(HOST)-ranlib
 endif
+
+ifneq ($(LTO),)
+android_CFLAGS += -flto
+android_LDFLAGS += -flto
+endif

--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -110,6 +110,12 @@ darwin_CXX=env -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH \
                -Xclang -internal-externc-isystem$(OSX_SDK)/usr/include
 
 darwin_CFLAGS=-pipe
+
+ifneq ($(LTO),)
+darwin_CFLAGS += -flto
+darwin_LDFLAGS += -flto
+endif
+
 darwin_CXXFLAGS=$(darwin_CFLAGS)
 
 darwin_release_CFLAGS=-O2

--- a/depends/hosts/freebsd.mk
+++ b/depends/hosts/freebsd.mk
@@ -1,4 +1,10 @@
 freebsd_CFLAGS=-pipe
+
+ifneq ($(LTO),)
+freebsd_CFLAGS += -flto
+freebsd_LDFLAGS += -flto
+endif
+
 freebsd_CXXFLAGS=$(freebsd_CFLAGS)
 
 freebsd_release_CFLAGS=-O2

--- a/depends/hosts/linux.mk
+++ b/depends/hosts/linux.mk
@@ -1,4 +1,10 @@
 linux_CFLAGS=-pipe
+
+ifneq ($(LTO),)
+linux_CFLAGS += -flto
+linux_LDFLAGS += -flto
+endif
+
 linux_CXXFLAGS=$(linux_CFLAGS)
 
 linux_release_CFLAGS=-O2

--- a/depends/hosts/mingw32.mk
+++ b/depends/hosts/mingw32.mk
@@ -3,6 +3,12 @@ mingw32_CXX := $(host)-g++-posix
 endif
 
 mingw32_CFLAGS=-pipe
+
+ifneq ($(LTO),)
+mingw32_CFLAGS += -flto
+mingw32_LDFLAGS += -flto
+endif
+
 mingw32_CXXFLAGS=$(mingw32_CFLAGS)
 
 mingw32_release_CFLAGS=-O2

--- a/depends/hosts/netbsd.mk
+++ b/depends/hosts/netbsd.mk
@@ -1,4 +1,10 @@
 netbsd_CFLAGS=-pipe
+
+ifneq ($(LTO),)
+netbsd_CFLAGS += -flto
+netbsd_LDFLAGS += -flto
+endif
+
 netbsd_CXXFLAGS=$(netbsd_CFLAGS)
 
 netbsd_release_CFLAGS=-O2

--- a/depends/hosts/openbsd.mk
+++ b/depends/hosts/openbsd.mk
@@ -1,4 +1,10 @@
 openbsd_CFLAGS=-pipe
+
+ifneq ($(LTO),)
+openbsd_CFLAGS += -flto
+openbsd_LDFLAGS += -flto
+endif
+
 openbsd_CFLAGS_CXXFLAGS=$(openbsd_CFLAGS)
 
 openbsd_CFLAGS_release_CFLAGS=-O2


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><p dir="auto" style="box-sizing: border-box; margin-top: 0px !important; margin-bottom: 16px; color: rgb(173, 186, 199); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(34, 39, 46); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This adds an<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; padding: 0.2em 0.4em; margin: 0px; white-space: break-spaces; background-color: var(--color-neutral-muted); border-radius: 6px;">LTO</code><span> </span>option to depends, i.e<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; padding: 0.2em 0.4em; margin: 0px; white-space: break-spaces; background-color: var(--color-neutral-muted); border-radius: 6px;">make -C depends LTO=1</code>, which passes<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; padding: 0.2em 0.4em; margin: 0px; white-space: break-spaces; background-color: var(--color-neutral-muted); border-radius: 6px;">-flto</code><span> </span>when building packages (not currently qt), and automatically configures with<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; padding: 0.2em 0.4em; margin: 0px; white-space: break-spaces; background-color: var(--color-neutral-muted); border-radius: 6px;">--enable-lto</code><span> </span>when doing a build using a<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; padding: 0.2em 0.4em; margin: 0px; white-space: break-spaces; background-color: var(--color-neutral-muted); border-radius: 6px;">CONFIG_SITE</code>.</p><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(173, 186, 199); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(34, 39, 46); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The following tables comapres the size (in bytes) of the stripped<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; padding: 0.2em 0.4em; margin: 0px; white-space: break-spaces; background-color: var(--color-neutral-muted); border-radius: 6px;">x86_64</code><span> </span>Linux binaries produced with master and this PR (full depends build):</p>

Binary | stripped master | stripped LTO=1 | saving
-- | -- | -- | --
bitcoin-cli | 1178632 | 469872 | 60%
bitcoin-tx | 2710584 | 1866504 | 31%
bitcoin-util | 952880 | 240104 | 74%
bitcoin-wallet | 7992888 | 5365984 | 32%
bitcoind | 13421336 | 11868592 | 12%
bitcoin-qt | 37680496 | 31640976 | 16%

<!--EndFragment-->
</body>
</html>

from https://github.com/bitcoin/bitcoin/pull/23611