### PR TITLE
[Upstream] build: fix copypasta in OpenBSD C{XX} flags

### DIFF
--- a/depends/hosts/openbsd.mk
+++ b/depends/hosts/openbsd.mk
@@ -1,17 +1,16 @@
 openbsd_CFLAGS=-pipe
+openbsd_CXXFLAGS=$(openbsd_CFLAGS)
 
 ifneq ($(LTO),)
 openbsd_CFLAGS += -flto
 openbsd_LDFLAGS += -flto
 endif
 
-openbsd_CFLAGS_CXXFLAGS=$(openbsd_CFLAGS)
+openbsd_release_CFLAGS=-O2
+openbsd_release_CXXFLAGS=$(openbsd_release_CFLAGS)
 
-openbsd_CFLAGS_release_CFLAGS=-O2
-openbsd_CFLAGS_release_CXXFLAGS=$(openbsd_release_CFLAGS)
-
-openbsd_CFLAGS_debug_CFLAGS=-O1
-openbsd_CFLAGS_debug_CXXFLAGS=$(openbsd_debug_CFLAGS)
+openbsd_debug_CFLAGS=-O1
+openbsd_debug_CXXFLAGS=$(openbsd_debug_CFLAGS)
 
 ifeq (86,$(findstring 86,$(build_arch)))
 i686_openbsd_CC=clang -m32


### PR DESCRIPTION
Introduced when adding OpenBSD depends.

from https://github.com/bitcoin/bitcoin/pull/24604