### PR TITLE
[Upstream] build, refactor: Drop useless `call` Make function

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -168,40 +168,40 @@ $($(1)_fetched):
 	mkdir -p $$(@D) $(SOURCES_PATH)
 	rm -f $$@
 	touch $$@
-	cd $$(@D); $(call $(1)_fetch_cmds,$(1))
+	cd $$(@D); $($(1)_fetch_cmds)
 	cd $($(1)_source_dir); $(foreach source,$($(1)_all_sources),$(build_SHA256SUM) $(source) >> $$(@);)
 	touch $$@
 $($(1)_extracted): | $($(1)_fetched)
 	echo Extracting $(1)...
 	mkdir -p $$(@D)
-	cd $$(@D); $(call $(1)_extract_cmds,$(1))
+	cd $$(@D); $($(1)_extract_cmds)
 	touch $$@
 $($(1)_preprocessed): | $($(1)_extracted)
 	echo Preprocessing $(1)...
 	mkdir -p $$(@D) $($(1)_patch_dir)
 	$(foreach patch,$($(1)_patches),cd $(PATCHES_PATH)/$(1); cp $(patch) $($(1)_patch_dir) ;)
-	cd $$(@D); $(call $(1)_preprocess_cmds, $(1))
+	cd $$(@D); $($(1)_preprocess_cmds)
 	touch $$@
 $($(1)_configured): | $($(1)_dependencies) $($(1)_preprocessed)
 	echo Configuring $(1)...
 	rm -rf $(host_prefix); mkdir -p $(host_prefix)/lib; cd $(host_prefix); $(foreach package,$($(1)_all_dependencies), $(build_TAR) --no-same-owner -xf $($(package)_cached); )
 	mkdir -p $$(@D)
-	+cd $$(@D); $($(1)_config_env) $(call $(1)_config_cmds, $(1))
+	+cd $$(@D); $($(1)_config_env) $($(1)_config_cmds)
 	touch $$@
 $($(1)_built): | $($(1)_configured)
 	echo Building $(1)...
 	mkdir -p $$(@D)
-	+cd $$(@D); $($(1)_build_env) $(call $(1)_build_cmds, $(1))
+	+cd $$(@D); $($(1)_build_env) $($(1)_build_cmds)
 	touch $$@
 $($(1)_staged): | $($(1)_built)
 	echo Staging $(1)...
 	mkdir -p $($(1)_staging_dir)/$(host_prefix)
-	cd $($(1)_build_dir); $($(1)_stage_env) $(call $(1)_stage_cmds, $(1))
+	cd $($(1)_build_dir); $($(1)_stage_env) $($(1)_stage_cmds)
 	rm -rf $($(1)_extract_dir)
 	touch $$@
 $($(1)_postprocessed): | $($(1)_staged)
 	echo Postprocessing $(1)...
-	cd $($(1)_staging_prefix_dir); $(call $(1)_postprocess_cmds)
+	cd $($(1)_staging_prefix_dir); $($(1)_postprocess_cmds)
 	touch $$@
 $($(1)_cached): | $($(1)_dependencies) $($(1)_postprocessed)
 	echo Caching $(1)...


### PR DESCRIPTION
>Using the [`call`](https://www.gnu.org/software/make/manual/html_node/Call-Function.html) function with `$(package)_*_cmds` is effectively noop because the latter, which could be found in `<package>.mk` files, do not use temporary `$(1)` variable at all.

>This PR removes useless calls of the `call` function, and makes code more readable and easier to reason about.

>No change in resulted dependency binaries could be easy verified with bitcoin/bitcoin/https://github.com/bitcoin/bitcoin/pull/21995.

from https://github.com/bitcoin/bitcoin/pull/24285