### PR TITLE
[Upstream] build: Make dependency package archive timestamps deterministic

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -211,7 +211,9 @@ $($(1)_postprocessed): | $($(1)_staged)
 	touch $$@
 $($(1)_cached): | $($(1)_dependencies) $($(1)_postprocessed)
 	echo Caching $(1)...
-	cd $$($(1)_staging_dir)/$(host_prefix); find . | sort | $(build_TAR) --no-recursion -czf $$($(1)_staging_dir)/$$(@F) -T -
+	cd $$($(1)_staging_dir)/$(host_prefix); \
+	  find . ! -name '.stamp_postprocessed' -print0 | TZ=UTC xargs -0r touch -h -m -t 200001011200; \
+	  find . ! -name '.stamp_postprocessed' | LC_ALL=C sort | $(build_TAR) --numeric-owner --no-recursion -czf $$($(1)_staging_dir)/$$(@F) -T -
 	mkdir -p $$(@D)
 	rm -rf $$(@D) && mkdir -p $$(@D)
 	mv $$($(1)_staging_dir)/$$(@F) $$(@)


### PR DESCRIPTION
> This PR makes testing changes like #20641, #21593, #22142, #24279, #24285 as easy as comparing hashes.
> 
> With this PR:
> 
> ```
> $ make -C depends clean
> $ make -C depends HOST=x86_64-w64-mingw32
> $ find depends/built/x86_64-w64-mingw32 -name '*.hash' | sort | xargs cat
> 1f685a61cbf205f81977ecf88cba91fa1ccdfbe77ab4ec3405dcd33ceb778af4  bdb-4.8.30-ca950bd6d13.tar.gz
> 08a9acde276e6e5e5c8913e3ad07eeecda184a996882ae226b3ed056c7ec1b01  boost-1.80.0-b537c466dcb.tar.gz
> 144c6d92e4108fcc90740bee27007db58a88336a97be6367f9c8ba4cc208af27  libevent-2.1.12-stable-e13b2bdd8b8.tar.gz
> e3c9c9609bf32bfd460432c6ab99a64e9f8750ed775a193925ff4f5aed363e4c  libnatpmp-07004b97cf691774efebe70404cf22201e4d330d-82255b84667.tar.gz
> 62c6a089a4b24a413eccd2f389bf4c8b0716423b0ace5e87e984069635da9f83  miniupnpc-2.2.2-c43fc4cf2f6.tar.gz
> 78762700066273e597698a78479a506b33532ea565d18ef561614b9fc3820cf5  qrencode-3.4.4-663de0dc628.tar.gz
> 5e2183faf91838510a48e6dbb4b65ae74a7d48ba1abc070b82767c4076582360  qt-5.15.5-986926343e2.tar.gz
> 9f8459f8d27fc3af9146712be6ba6577f15741429936504a950cc51c17da1ba8  sqlite-3380500-bec6a4d3299.tar.gz
> 0eca5d01d427de50be4bd57c8bb100ab69b017792c32b8733e2b20443f4c9c28  zeromq-4.3.4-8ae81bab6f4.tar.gz
> ```
> 
> As an example, here is an evidence that #24279 is a strict refactoring change:
> 
> ```
> $ git fetch origin pull/24279/head
> $ git cherry-pick 706026838d917a3d853e03e83db040f1fd4aeb74
> $ git cherry-pick 3f90ddea8a6a2061cfb347a1d77df2c0a6fa238c
> $ make -C depends clean
> $ make -C depends HOST=x86_64-w64-mingw32
> $ find depends/built/x86_64-w64-mingw32 -name '*.hash' | sort | xargs cat
> 1f685a61cbf205f81977ecf88cba91fa1ccdfbe77ab4ec3405dcd33ceb778af4  bdb-4.8.30-c7faf31d5ca.tar.gz
> 08a9acde276e6e5e5c8913e3ad07eeecda184a996882ae226b3ed056c7ec1b01  boost-1.80.0-1af3dd1d99e.tar.gz
> 144c6d92e4108fcc90740bee27007db58a88336a97be6367f9c8ba4cc208af27  libevent-2.1.12-stable-6228a9f8534.tar.gz
> e3c9c9609bf32bfd460432c6ab99a64e9f8750ed775a193925ff4f5aed363e4c  libnatpmp-07004b97cf691774efebe70404cf22201e4d330d-41aa6194ecc.tar.gz
> 62c6a089a4b24a413eccd2f389bf4c8b0716423b0ace5e87e984069635da9f83  miniupnpc-2.2.2-6a93027769c.tar.gz
> 78762700066273e597698a78479a506b33532ea565d18ef561614b9fc3820cf5  qrencode-3.4.4-d40cb2d45c9.tar.gz
> 5e2183faf91838510a48e6dbb4b65ae74a7d48ba1abc070b82767c4076582360  qt-5.15.5-120c3cb745d.tar.gz
> 9f8459f8d27fc3af9146712be6ba6577f15741429936504a950cc51c17da1ba8  sqlite-3380500-bbd4d813c69.tar.gz
> 0eca5d01d427de50be4bd57c8bb100ab69b017792c32b8733e2b20443f4c9c28  zeromq-4.3.4-df0858a19d2.tar.gz
> ```

from https://github.com/bitcoin/bitcoin/pull/21995