### PR TITLE
[Upstream] build: Drop redundant checks for ranlib and strip tools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,8 +83,6 @@ LT_INIT([pic-only])
 
 dnl Check/return PATH for base programs.
 AC_PATH_TOOL(AR, ar)
-AC_PATH_TOOL(RANLIB, ranlib)
-AC_PATH_TOOL(STRIP, strip)
 AC_PATH_TOOL(GCOV, gcov)
 AC_PATH_PROG(LCOV, lcov)
 dnl Python 3.6 is specified in .python-version and should be used if available, see doc/dependencies.md


### PR DESCRIPTION
> These checks are handled by the `LT_INIT` macro.
> 
> Inspired by [bitcoin-core/secp256k1#1088](https://github.com/bitcoin-core/secp256k1/pull/1088).

from https://github.com/bitcoin/bitcoin/pull/24566