### PR TITLE
[Upstream] build, refactor: Improve package version usage

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,7 +1,7 @@
 package=boost
-$(package)_version=1_71_0
-$(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/$(subst _,.,$($(package)_version))/source/
-$(package)_file_name=boost_$($(package)_version).tar.bz2
+$(package)_version=1.71.0
+$(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/$($(package)_version)/source/
+$(package)_file_name=boost_$(subst .,_,$($(package)_version)).tar.bz2
 $(package)_sha256_hash=d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee
 $(package)_dependencies=native_b2
 $(package)_patches=fix_openbsd_test_lib.patch

--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -1,6 +1,6 @@
 package=expat
 $(package)_version=2.4.1
-$(package)_download_path=https://github.com/libexpat/libexpat/releases/download/R_2_4_1/
+$(package)_download_path=https://github.com/libexpat/libexpat/releases/download/R_$(subst .,_,$($(package)_version))/
 $(package)_file_name=$(package)-$($(package)_version).tar.xz
 $(package)_sha256_hash=cf032d0dba9b928636548e32b327a2d66b1aab63c4f4a13dd132c2d1d2f2fb6a
 


### PR DESCRIPTION
>`boost` package:
>- `.` is used as a separator in versions of other depends packages.
>
>`expat` package:
>
>- reuse package version in its download path
>The straightforward way to verify this PR:
>```
>$ cd depends
>$ make clean-all
>$ make boost_fetched
>$ make expat_fetched
>```

from https://github.com/bitcoin/bitcoin/pull/24276