### PR TITLE
depends: openssl 1.0.2u

### DIFF
--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -1,35 +1,28 @@
 package=openssl
-$(package)_version=1.0.1k
-$(package)_download_path=https://www.openssl.org/source/old
+$(package)_version=1.0.2u
+$(package)_download_path=https://www.openssl.org/source/old/1.0.2
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c
+$(package)_sha256_hash=ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16
 
 define $(package)_set_vars
 $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"
 $(package)_config_opts=--prefix=$(host_prefix) --openssldir=$(host_prefix)/etc/openssl
-$(package)_config_opts+=no-camellia
 $(package)_config_opts+=no-capieng
-$(package)_config_opts+=no-cast
-$(package)_config_opts+=no-comp
 $(package)_config_opts+=no-dso
 $(package)_config_opts+=no-dtls1
 $(package)_config_opts+=no-ec_nistp_64_gcc_128
 $(package)_config_opts+=no-gost
 $(package)_config_opts+=no-gmp
 $(package)_config_opts+=no-heartbeats
-$(package)_config_opts+=no-idea
 $(package)_config_opts+=no-jpake
 $(package)_config_opts+=no-krb5
 $(package)_config_opts+=no-libunbound
 $(package)_config_opts+=no-md2
-$(package)_config_opts+=no-mdc2
-$(package)_config_opts+=no-rc4
 $(package)_config_opts+=no-rc5
 $(package)_config_opts+=no-rdrand
 $(package)_config_opts+=no-rfc3779
 $(package)_config_opts+=no-rsax
 $(package)_config_opts+=no-sctp
-$(package)_config_opts+=no-seed
 $(package)_config_opts+=no-sha0
 $(package)_config_opts+=no-shared
 $(package)_config_opts+=no-ssl-trace
@@ -39,7 +32,6 @@ $(package)_config_opts+=no-static_engine
 $(package)_config_opts+=no-store
 $(package)_config_opts+=no-unit-test
 $(package)_config_opts+=no-weak-ssl-ciphers
-$(package)_config_opts+=no-whirlpool
 $(package)_config_opts+=no-zlib
 $(package)_config_opts+=no-zlib-dynamic
 $(package)_config_opts+=$($(package)_cflags) $($(package)_cppflags)


### PR DESCRIPTION
This bumps our OpenSSL from 1.0.1k (released 2015-Jan-08 15:04:45) to 1.0.2u (released 2019-Dec-20 13:25:43). This is the latest 1.0.* build available. 1.1.1+ breaks consensus.

Also adjust configure options to fix compile.
