### PR TITLE
[Upstream] guix: Pin Guix using guix time-machine

### DIFF
--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -62,15 +62,16 @@ Likewise, to perform a bootstrapped build (takes even longer):
 export ADDITIONAL_GUIX_ENVIRONMENT_FLAGS='--bootstrap --no-substitutes'
 ```
 
-### Using the right Guix
+### Using a version of Guix with `guix time-machine` capabilities
 
-Once Guix is installed, deploy our patched version into your current Guix
-profile. The changes there are slowly being upstreamed.
+> Note: This entire section can be skipped if you are already using a version of
+> Guix that has [the `guix time-machine` command][guix/time-machine].
+
+Once Guix is installed, if it doesn't have the `guix time-machine` command, pull
+the latest `guix`.
 
 ```sh
-guix pull --url=https://github.com/dongcarl/guix.git \
-          --commit=82c77e52b8b46e0a3aad2cb12307c2e30547deec \
-          --max-jobs=4 # change accordingly
+guix pull --max-jobs=4 # change number of jobs accordingly
 ```
 
 Make sure that you are using your current profile. (You are prompted to do this
@@ -79,9 +80,6 @@ at the end of the `guix pull`)
 ```bash
 export PATH="${HOME}/.config/guix/current/bin${PATH:+:}$PATH"
 ```
-
-> Note: There is ongoing work to eliminate this entire section using Guix
-> [inferiors][guix/inferiors] and [channels][guix/channels].
 
 ## Usage
 
@@ -224,6 +222,7 @@ repository and will likely put one up soon.
 [guix/substitute-server-auth]: https://www.gnu.org/software/guix/manual/en/html_node/Substitute-Server-Authorization.html
 [guix/inferiors]: https://www.gnu.org/software/guix/manual/en/html_node/Inferiors.html
 [guix/channels]: https://www.gnu.org/software/guix/manual/en/html_node/Channels.html
+[guix/time-machine]: https://guix.gnu.org/manual/en/html_node/Invoking-guix-time_002dmachine.html
 
 [debian/guix-package]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=850644
 [fanquake/guix-docker]: https://github.com/fanquake/core-review/tree/master/guix

--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -13,6 +13,12 @@ make -C "${PWD}/depends" -j"$MAX_JOBS" download ${V:+V=1} ${SOURCES_PATH:+SOURCE
 # Determine the reference time used for determinism (overridable by environment)
 SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log --format=%at -1)}"
 
+time-machine() {
+    guix time-machine --url=https://github.com/dongcarl/guix.git \
+                      --commit=b3a7c72c8b2425f8ddb0fc6e3b1caeed40f86dee \
+                      -- "$@"
+}
+
 # Deterministically build PRCYcoin for HOSTs (overriable by environment)
 for host in ${HOSTS=i686-linux-gnu x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu}; do
 
@@ -22,18 +28,18 @@ for host in ${HOSTS=i686-linux-gnu x86_64-linux-gnu arm-linux-gnueabihf aarch64-
     # Run the build script 'contrib/guix/libexec/build.sh' in the build
     # container specified by 'contrib/guix/manifest.scm'
     # shellcheck disable=SC2086
-    guix environment --manifest="${PWD}/contrib/guix/manifest.scm" \
-                     --container \
-                     --pure \
-                     --no-cwd \
-                     --share="$PWD"=/prcycoin \
-                     ${SOURCES_PATH:+--share="$SOURCES_PATH"} \
-                     ${ADDITIONAL_GUIX_ENVIRONMENT_FLAGS} \
-                     -- env HOST="$host" \
-                            MAX_JOBS="$MAX_JOBS" \
-                            SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:?unable to determine value}" \
-                            ${V:+V=1} \
-                            ${SOURCES_PATH:+SOURCES_PATH="$SOURCES_PATH"} \
-                          bash -c "cd /prcycoin && bash contrib/guix/libexec/build.sh"
+    time-machine environment --manifest="${PWD}/contrib/guix/manifest.scm" \
+                             --container \
+                             --pure \
+                             --no-cwd \
+                             --share="$PWD"=/prcycoin \
+                             ${SOURCES_PATH:+--share="$SOURCES_PATH"} \
+                             ${ADDITIONAL_GUIX_ENVIRONMENT_FLAGS} \
+                             -- env HOST="$host" \
+                                    MAX_JOBS="$MAX_JOBS" \
+                                    SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:?unable to determine value}" \
+                                    ${V:+V=1} \
+                                    ${SOURCES_PATH:+SOURCES_PATH="$SOURCES_PATH"} \
+                                  bash -c "cd /prcycoin && bash contrib/guix/libexec/build.sh"
 
 done


### PR DESCRIPTION
> An alternative to https://github.com/bitcoin/bitcoin/pull/16519, pinning our version of Guix and eliminating a `guix pull` and changing the default Guix profile of builders.
> 
> I think this method might be superior, as it:
> 
> Eliminates the possibility of future changes to the `guix environment` command line interface breaking our builds
> Eliminates the need to set up a separate channel repo
> It is a more general pinning solution than https://github.com/bitcoin/bitcoin/pull/16519.
> 
> The reason why I didn't originally propose this is because `guix time-machine` is a recent addition to Guix, only available since `f675f8dec73d02e319e607559ed2316c299ae8c7`

from https://github.com/bitcoin/bitcoin/pull/17933