### PR TITLE
[Upstream] build: Skip i686 build by default in guix and gitian

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,15 +85,6 @@ jobs:
         PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine-binfmt wine64"
         GOAL="install"
         BITCOIN_CONFIG="--enable-reduce-exports"
-# 32-bit + dash
-    - stage: test
-      env: >-
-        HOST=i686-pc-linux-gnu
-        PACKAGES="g++-multilib python3-zmq"
-        DEP_OPTS="NO_QT=1"
-        GOAL="install"
-        BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++"
-        CONFIG_SHELL="/bin/dash"
 # x86_64 Linux (uses qt5 dev package instead of depends Qt to speed up build and avoid timeout)
     - stage: test
       env: >-

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -40,7 +40,7 @@ script: |
   set -e -o pipefail
 
   WRAP_DIR=$HOME/wrapped
-  HOSTS="i686-pc-linux-gnu x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu"
+  HOSTS="x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu"
   CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests"
   FAKETIME_HOST_PROGS="gcc g++"
   FAKETIME_PROGS="date ar ranlib nm"

--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -114,7 +114,7 @@ find output/ -type f -print0 | sort -z | xargs -r0 sha256sum
 * _**HOSTS**_
 
   Override the space-separated list of platform triples for which to perform a
-  bootstrappable build. _(defaults to "i686-linux-gnu x86\_64-linux-gnu
+  bootstrappable build. _(defaults to "x86\_64-linux-gnu
   arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu")_
 
   > Windows and OS X platform triplet support are WIP.

--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -20,7 +20,7 @@ time-machine() {
 }
 
 # Deterministically build PRCYcoin for HOSTs (overriable by environment)
-for host in ${HOSTS=i686-linux-gnu x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu}; do
+for host in ${HOSTS=x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu}; do
 
     # Display proper warning when the user interrupts the build
     trap 'echo "** INT received while building ${host}, you may want to clean up the relevant output and distsrc-* directories before rebuilding"' INT

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -251,7 +251,6 @@ The list of files should be:
 ```
 prcycoin-${VERSION}-aarch64-linux-gnu.tar.gz
 prcycoin-${VERSION}-arm-linux-gnueabihf.tar.gz
-prcycoin-${VERSION}-i686-pc-linux-gnu.tar.gz
 prcycoin-${VERSION}-riscv64-linux-gnu.tar.gz
 prcycoin-${VERSION}-x86_64-linux-gnu.tar.gz
 prcycoin-${VERSION}-osx64.tar.gz


### PR DESCRIPTION
> Closes https://github.com/bitcoin/bitcoin/issues/17504
> 
> Now that we no longer provide downloads for i686 on our website (https://bitcoincore.org/en/download/), there is no need to build them by default.
> 
> i686 can still be built in depends (tested by ci/travis) and in guix/gitian by setting the appropriate `HOSTS`.

from https://github.com/bitcoin/bitcoin/pull/18104