### PR TITLE
[Upstream] guix: Remove now-unnecessary gcc make flag

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -21,17 +21,6 @@
              (guix profiles)
              (guix utils))
 
-(define (make-ssp-fixed-gcc xgcc)
-  "Given a XGCC package, return a modified package that uses the SSP function
-from glibc instead of from libssp.so. Taken from:
-http://www.linuxfromscratch.org/hlfs/view/development/chapter05/gcc-pass1.html"
-  (package
-   (inherit xgcc)
-   (arguments
-    (substitute-keyword-arguments (package-arguments xgcc)
-      ((#:make-flags flags)
-       `(cons "gcc_cv_libc_provides_ssp=yes" ,flags))))))
-
 (define (make-gcc-rpath-link xgcc)
   "Given a XGCC package, return a modified package that replace each instance of
 -rpath in the default system spec that's inserted by Guix with -rpath-link"
@@ -104,8 +93,7 @@ chain for " target " development."))
                                   (base-gcc-for-libc gcc-5)
                                   (base-kernel-headers linux-libre-headers-4.19)
                                   (base-libc glibc-2.27)
-                                  (base-gcc (make-gcc-rpath-link
-                                             (make-ssp-fixed-gcc gcc-9))))
+                                  (base-gcc (make-gcc-rpath-link gcc-9)))
   "Convienience wrapper around MAKE-CROSS-TOOLCHAIN with default values
 desirable for building PRCYcoin release binaries."
   (make-cross-toolchain target


### PR DESCRIPTION
> Previously, Guix would produce a gcc which did not know to use the SSP
> function from glibc, and required a gcc make flag for it to do so, in my
> attempt to fix it upstream I realized that this is no longer the case.
> 
> This can be verified by performing a Guix build and doing
> 
>   readelf -s ... | grep __stack_chk
> 
> to check that symbols are coming from glibc, and doing
> 
>   readelf -d ... | grep NEEDED | grep ssp
> 
> to see that libssp.so is not being depended on
> 

from https://github.com/bitcoin/bitcoin/pull/18320