### PR TITLE
[Upstream] guix: Enable building for `x86_64-w64-mingw32` target

### DIFF
--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -220,8 +220,6 @@ repository and will likely put one up soon.
 [guix/env-setup]: https://www.gnu.org/software/guix/manual/en/html_node/Build-Environment-Setup.html
 [guix/substitutes]: https://www.gnu.org/software/guix/manual/en/html_node/Substitutes.html
 [guix/substitute-server-auth]: https://www.gnu.org/software/guix/manual/en/html_node/Substitute-Server-Authorization.html
-[guix/inferiors]: https://www.gnu.org/software/guix/manual/en/html_node/Inferiors.html
-[guix/channels]: https://www.gnu.org/software/guix/manual/en/html_node/Channels.html
 [guix/time-machine]: https://guix.gnu.org/manual/en/html_node/Invoking-guix-time_002dmachine.html
 
 [debian/guix-package]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=850644

--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -17,7 +17,7 @@ SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log --format=%at -1)}"
 # across time.
 time-machine() {
     guix time-machine --url=https://github.com/dongcarl/guix.git \
-                      --commit=b3a7c72c8b2425f8ddb0fc6e3b1caeed40f86dee \
+                      --commit=cf347affd642c709f7e423f7111794ffdb09f5a6 \
                       -- "$@"
 }
 

--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -17,7 +17,7 @@ SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log --format=%at -1)}"
 # across time.
 time-machine() {
     guix time-machine --url=https://github.com/dongcarl/guix.git \
-                      --commit=cf347affd642c709f7e423f7111794ffdb09f5a6 \
+                      --commit=b066c25026f21fb57677aa34692a5034338e7ee3 \
                       -- "$@"
 }
 

--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -20,26 +20,32 @@ time-machine() {
 }
 
 # Deterministically build PRCYcoin for HOSTs (overriable by environment)
-for host in ${HOSTS=x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu}; do
+for host in ${HOSTS=x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu x86_64-w64-mingw32}; do
 
     # Display proper warning when the user interrupts the build
     trap 'echo "** INT received while building ${host}, you may want to clean up the relevant output and distsrc-* directories before rebuilding"' INT
 
-    # Run the build script 'contrib/guix/libexec/build.sh' in the build
-    # container specified by 'contrib/guix/manifest.scm'
-    # shellcheck disable=SC2086
-    time-machine environment --manifest="${PWD}/contrib/guix/manifest.scm" \
-                             --container \
-                             --pure \
-                             --no-cwd \
-                             --share="$PWD"=/prcycoin \
-                             ${SOURCES_PATH:+--share="$SOURCES_PATH"} \
-                             ${ADDITIONAL_GUIX_ENVIRONMENT_FLAGS} \
-                             -- env HOST="$host" \
-                                    MAX_JOBS="$MAX_JOBS" \
-                                    SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:?unable to determine value}" \
-                                    ${V:+V=1} \
-                                    ${SOURCES_PATH:+SOURCES_PATH="$SOURCES_PATH"} \
-                                  bash -c "cd /prcycoin && bash contrib/guix/libexec/build.sh"
+    (
+        # Required for 'contrib/guix/manifest.scm' to output the right manifest
+        # for the particular $HOST we're building for
+        export HOST="$host"
+
+        # Run the build script 'contrib/guix/libexec/build.sh' in the build
+        # container specified by 'contrib/guix/manifest.scm'.
+        # shellcheck disable=SC2086
+        time-machine environment --manifest="${PWD}/contrib/guix/manifest.scm" \
+                                 --container \
+                                 --pure \
+                                 --no-cwd \
+                                 --share="$PWD"=/prcycoin \
+                                 ${SOURCES_PATH:+--share="$SOURCES_PATH"} \
+                                 ${ADDITIONAL_GUIX_ENVIRONMENT_FLAGS} \
+                                 -- env HOST="$host" \
+                                        MAX_JOBS="$MAX_JOBS" \
+                                        SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:?unable to determine value}" \
+                                        ${V:+V=1} \
+                                        ${SOURCES_PATH:+SOURCES_PATH="$SOURCES_PATH"} \
+                                      bash -c "cd /prcycoin && bash contrib/guix/libexec/build.sh"
+    )
 
 done

--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -13,6 +13,8 @@ make -C "${PWD}/depends" -j"$MAX_JOBS" download ${V:+V=1} ${SOURCES_PATH:+SOURCE
 # Determine the reference time used for determinism (overridable by environment)
 SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log --format=%at -1)}"
 
+# Execute "$@" in a pinned, possibly older version of Guix, for reproducibility
+# across time.
 time-machine() {
     guix time-machine --url=https://github.com/dongcarl/guix.git \
                       --commit=b3a7c72c8b2425f8ddb0fc6e3b1caeed40f86dee \
@@ -32,6 +34,53 @@ for host in ${HOSTS=x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv
 
         # Run the build script 'contrib/guix/libexec/build.sh' in the build
         # container specified by 'contrib/guix/manifest.scm'.
+        #
+        # Explanation of `guix environment` flags:
+        #
+        #   --container        run command within an isolated container
+        #
+        #     Running in an isolated container minimizes build-time differences
+        #     between machines and improves reproducibility
+        #
+        #   --pure             unset existing environment variables
+        #
+        #     Same rationale as --container
+        #
+        #   --no-cwd           do not share current working directory with an
+        #                      isolated container
+        #
+        #     When --container is specified, the default behavior is to share
+        #     the current working directory with the isolated container at the
+        #     same exact path (e.g. mapping '/home/satoshi/prcycoin/' to
+        #     '/home/satoshi/prcycoin/'). This means that the $PWD inside the
+        #     container becomes a source of irreproducibility. --no-cwd disables
+        #     this behaviour.
+        #
+        #   --share=SPEC       for containers, share writable host file system
+        #                      according to SPEC
+        #
+        #   --share="$PWD"=/prcycoin
+        #
+        #                     maps our current working directory to /prcycoin
+        #                     inside the isolated container, which we later cd
+        #                     into.
+        #
+        #     While we don't want to map our current working directory to the
+        #     same exact path (as this introduces irrepreducibility), we do want
+        #     it to be at a _fixed_ path _somewhere_ inside the isolated
+        #     container so that we have something to build. '/prcycoin' was
+        #     chosen arbitrarily.
+        #
+        #   ${SOURCES_PATH:+--share="$SOURCES_PATH"}
+        #
+        #                     make the downloaded depends sources path available
+        #                     inside the isolated container
+        #
+        #     The isolated container has no network access as it's in a
+        #     different network namespace from the main machine, so we have to
+        #     make the downloaded depends sources available to it. The sources
+        #     should have been downloaded prior to this invocation.
+        #
         # shellcheck disable=SC2086
         time-machine environment --manifest="${PWD}/contrib/guix/manifest.scm" \
                                  --container \

--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -21,12 +21,26 @@ time-machine() {
                       -- "$@"
 }
 
+# Function to be called when building for host ${1} and the user interrupts the
+# build
+int_trap() {
+cat << EOF
+** INT received while building ${1}, you may want to clean up the relevant
+   output, deploy, and distsrc-* directories before rebuilding
+Hint: To blow everything away, you may want to use:
+  $ git clean -xdff --exclude='/depends/SDKs/*'
+Specifically, this will remove all files without an entry in the index,
+excluding the SDK directory. Practically speaking, this means that all ignored
+and untracked files and directories will be wiped, allowing you to start anew.
+EOF
+}
+
 # Deterministically build PRCYcoin for HOSTs (overridable by environment)
 # shellcheck disable=SC2153
 for host in ${HOSTS=x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu x86_64-w64-mingw32}; do
 
     # Display proper warning when the user interrupts the build
-    trap 'echo "** INT received while building ${host}, you may want to clean up the relevant output and distsrc-* directories before rebuilding"' INT
+    trap 'int_trap ${host}' INT
 
     (
         # Required for 'contrib/guix/manifest.scm' to output the right manifest

--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -21,7 +21,7 @@ time-machine() {
                       -- "$@"
 }
 
-# Deterministically build PRCYcoin for HOSTs (overriable by environment)
+# Deterministically build PRCYcoin for HOSTs (overridable by environment)
 # shellcheck disable=SC2153
 for host in ${HOSTS=x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu x86_64-w64-mingw32}; do
 
@@ -67,7 +67,7 @@ for host in ${HOSTS=x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv
         #                     into.
         #
         #     While we don't want to map our current working directory to the
-        #     same exact path (as this introduces irrepreducibility), we do want
+        #     same exact path (as this introduces irreproducibility), we do want
         #     it to be at a _fixed_ path _somewhere_ inside the isolated
         #     container so that we have something to build. '/prcycoin' was
         #     chosen arbitrarily.

--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -22,6 +22,7 @@ time-machine() {
 }
 
 # Deterministically build PRCYcoin for HOSTs (overriable by environment)
+# shellcheck disable=SC2153
 for host in ${HOSTS=x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu x86_64-w64-mingw32}; do
 
     # Display proper warning when the user interrupts the build

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -211,7 +211,7 @@ export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
     make -C src --jobs=1 check-security ${V:+V=1}
 
     case "$HOST" in
-        *linux*)
+        *linux*|*mingw*)
             # Check that executables only contain allowed gcc, glibc and libstdc++
             # version symbols for Linux distro back-compatibility.
             make -C src --jobs=1 check-symbols  ${V:+V=1}

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -178,6 +178,7 @@ HOST_CXXFLAGS="$HOST_CFLAGS"
 # LDFLAGS
 case "$HOST" in
     *linux*)  HOST_LDFLAGS="-Wl,--as-needed -Wl,--dynamic-linker=$glibc_dynamic_linker -static-libstdc++" ;;
+    *mingw*)  HOST_LDFLAGS="-Wl,--no-insert-timestamp" ;;
 esac
 
 # Make $HOST-specific native binaries from depends available in $PATH
@@ -271,10 +272,14 @@ export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
         # for release
         case "$HOST" in
             *mingw*)
+                find "${DISTNAME}" -not -name "*.dbg" -print0 \
+                    | xargs -0r touch --no-dereference --date="@${SOURCE_DATE_EPOCH}"
                 find "${DISTNAME}" -not -name "*.dbg" \
                     | sort \
                     | zip -X@ "${OUTDIR}/${DISTNAME}-${HOST//x86_64-w64-mingw32/win64}.zip" \
                     || ( rm -f "${OUTDIR}/${DISTNAME}-${HOST//x86_64-w64-mingw32/win64}.zip" && exit 1 )
+                find "${DISTNAME}" -name "*.dbg" -print0 \
+                    | xargs -0r touch --no-dereference --date="@${SOURCE_DATE_EPOCH}"
                 find "${DISTNAME}" -name "*.dbg" \
                     | sort \
                     | zip -X@ "${OUTDIR}/${DISTNAME}-${HOST//x86_64-w64-mingw32/win64}-debug.zip" \

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -55,10 +55,10 @@ case "$HOST" in
         export CROSS_LIBRARY_PATH="${CROSS_GCC}/lib:${CROSS_GCC}/${HOST}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib"
         ;;
     *linux*)
-        CROSS_GLIBC="$(store_path glibc-cross-${HOST})"
-        CROSS_GLIBC_STATIC="$(store_path glibc-cross-${HOST} static)"
-        CROSS_KERNEL="$(store_path linux-libre-headers-cross-${HOST})"
-        CROSS_GCC="$(store_path gcc-cross-${HOST})"
+        CROSS_GLIBC="$(store_path "glibc-cross-${HOST}")"
+        CROSS_GLIBC_STATIC="$(store_path "glibc-cross-${HOST}" static)"
+        CROSS_KERNEL="$(store_path "linux-libre-headers-cross-${HOST}")"
+        CROSS_GCC="$(store_path "gcc-cross-${HOST}")"
         CROSS_GCC_LIBS=( "${CROSS_GCC}/lib/gcc/${HOST}"/* ) # This expands to an array of directories...
         CROSS_GCC_LIB="${CROSS_GCC_LIBS[0]}" # ...we just want the first one (there should only be one)
 

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+export TZ=UTC
 export LC_ALL=C
 set -e -o pipefail
 

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-export TZ=UTC
 export LC_ALL=C
 set -e -o pipefail
+export TZ=UTC
 
 # Check that environment variables assumed to be set by the environment are set
 echo "Building for platform triple ${HOST:?not set} with reference timestamp ${SOURCE_DATE_EPOCH:?not set}..."

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -134,8 +134,7 @@ make -C depends --jobs="$MAX_JOBS" HOST="$HOST" \
                                    x86_64_linux_RANLIB=x86_64-linux-gnu-ranlib \
                                    x86_64_linux_NM=x86_64-linux-gnu-nm \
                                    x86_64_linux_STRIP=x86_64-linux-gnu-strip \
-                                   qt_config_opts_i686_linux='-platform linux-g++ -xplatform bitcoin-linux-g++' \
-                                   mingw32_CFLAGS='-DMINGW_HAS_SECURE_API=1 -pipe'
+                                   qt_config_opts_i686_linux='-platform linux-g++ -xplatform bitcoin-linux-g++'
 
 
 ###########################

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -36,23 +36,41 @@ store_path() {
               --expression='s|"[[:space:]]*$||'
 }
 
-# Determine output paths to use in CROSS_* environment variables
-CROSS_GLIBC="$(store_path glibc-cross-${HOST})"
-CROSS_GLIBC_STATIC="$(store_path glibc-cross-${HOST} static)"
-CROSS_KERNEL="$(store_path linux-libre-headers-cross-${HOST})"
-CROSS_GCC="$(store_path gcc-cross-${HOST})"
-CROSS_GCC_LIBS=( "${CROSS_GCC}/lib/gcc/${HOST}"/* ) # This expands to an array of directories...
-CROSS_GCC_LIB="${CROSS_GCC_LIBS[0]}" # ...we just want the first one (there should only be one)
-
 # Set environment variables to point Guix's cross-toolchain to the right
 # includes/libs for $HOST
-#
-# NOTE: CROSS_C_INCLUDE_PATH is missing ${CROSS_GCC_LIB}/include-fixed, because
-# the limits.h in it is missing a '#include_next <limits.h>'
-#
-export CROSS_C_INCLUDE_PATH="${CROSS_GCC_LIB}/include:${CROSS_GLIBC}/include:${CROSS_KERNEL}/include"
-export CROSS_CPLUS_INCLUDE_PATH="${CROSS_GCC}/include/c++:${CROSS_GCC}/include/c++/${HOST}:${CROSS_GCC}/include/c++/backward:${CROSS_C_INCLUDE_PATH}"
-export CROSS_LIBRARY_PATH="${CROSS_GCC}/lib:${CROSS_GCC}/${HOST}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib:${CROSS_GLIBC_STATIC}/lib"
+case "$HOST" in
+    *mingw*)
+        # Determine output paths to use in CROSS_* environment variables
+        CROSS_GLIBC="$(store_path "mingw-w64-x86_64-winpthreads")"
+        CROSS_GCC="$(store_path "gcc-cross-${HOST}")"
+        CROSS_GCC_LIBS=( "${CROSS_GCC}/lib/gcc/${HOST}"/* ) # This expands to an array of directories...
+        CROSS_GCC_LIB="${CROSS_GCC_LIBS[0]}" # ...we just want the first one (there should only be one)
+
+        NATIVE_GCC="$(store_path gcc-glibc-2.27-toolchain)"
+        export LIBRARY_PATH="${NATIVE_GCC}/lib:${NATIVE_GCC}/lib64"
+        export CPATH="${NATIVE_GCC}/include"
+
+        export CROSS_C_INCLUDE_PATH="${CROSS_GCC_LIB}/include:${CROSS_GCC_LIB}/include-fixed:${CROSS_GLIBC}/include"
+        export CROSS_CPLUS_INCLUDE_PATH="${CROSS_GCC}/include/c++:${CROSS_GCC}/include/c++/${HOST}:${CROSS_GCC}/include/c++/backward:${CROSS_C_INCLUDE_PATH}"
+        export CROSS_LIBRARY_PATH="${CROSS_GCC}/lib:${CROSS_GCC}/${HOST}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib"
+        ;;
+    *linux*)
+        CROSS_GLIBC="$(store_path glibc-cross-${HOST})"
+        CROSS_GLIBC_STATIC="$(store_path glibc-cross-${HOST} static)"
+        CROSS_KERNEL="$(store_path linux-libre-headers-cross-${HOST})"
+        CROSS_GCC="$(store_path gcc-cross-${HOST})"
+        CROSS_GCC_LIBS=( "${CROSS_GCC}/lib/gcc/${HOST}"/* ) # This expands to an array of directories...
+        CROSS_GCC_LIB="${CROSS_GCC_LIBS[0]}" # ...we just want the first one (there should only be one)
+
+        # NOTE: CROSS_C_INCLUDE_PATH is missing ${CROSS_GCC_LIB}/include-fixed, because
+        # the limits.h in it is missing a '#include_next <limits.h>'
+        export CROSS_C_INCLUDE_PATH="${CROSS_GCC_LIB}/include:${CROSS_GLIBC}/include:${CROSS_KERNEL}/include"
+        export CROSS_CPLUS_INCLUDE_PATH="${CROSS_GCC}/include/c++:${CROSS_GCC}/include/c++/${HOST}:${CROSS_GCC}/include/c++/backward:${CROSS_C_INCLUDE_PATH}"
+        export CROSS_LIBRARY_PATH="${CROSS_GCC}/lib:${CROSS_GCC}/${HOST}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib:${CROSS_GLIBC_STATIC}/lib"
+        ;;
+    *)
+        exit 1 ;;
+esac
 
 # Sanity check CROSS_*_PATH directories
 IFS=':' read -ra PATHS <<< "${CROSS_C_INCLUDE_PATH}:${CROSS_CPLUS_INCLUDE_PATH}:${CROSS_LIBRARY_PATH}"
@@ -74,16 +92,20 @@ export GUIX_LD_WRAPPER_DISABLE_RPATH=yes
 [ -e /usr/bin/env ]  || ln -s --no-dereference "$(command -v env)"  /usr/bin/env
 
 # Determine the correct value for -Wl,--dynamic-linker for the current $HOST
-glibc_dynamic_linker=$(
-    case "$HOST" in
-        i686-linux-gnu)      echo /lib/ld-linux.so.2 ;;
-        x86_64-linux-gnu)    echo /lib64/ld-linux-x86-64.so.2 ;;
-        arm-linux-gnueabihf) echo /lib/ld-linux-armhf.so.3 ;;
-        aarch64-linux-gnu)   echo /lib/ld-linux-aarch64.so.1 ;;
-        riscv64-linux-gnu)   echo /lib/ld-linux-riscv64-lp64d.so.1 ;;
-        *)                   exit 1 ;;
-    esac
-)
+case "$HOST" in
+    *linux*)
+        glibc_dynamic_linker=$(
+            case "$HOST" in
+                i686-linux-gnu)      echo /lib/ld-linux.so.2 ;;
+                x86_64-linux-gnu)    echo /lib64/ld-linux-x86-64.so.2 ;;
+                arm-linux-gnueabihf) echo /lib/ld-linux-armhf.so.3 ;;
+                aarch64-linux-gnu)   echo /lib/ld-linux-aarch64.so.1 ;;
+                riscv64-linux-gnu)   echo /lib/ld-linux-riscv64-lp64d.so.1 ;;
+                *)                   exit 1 ;;
+            esac
+        )
+        ;;
+esac
 
 # Environment variables for determinism
 export QT_RCC_TEST=1
@@ -111,7 +133,8 @@ make -C depends --jobs="$MAX_JOBS" HOST="$HOST" \
                                    x86_64_linux_RANLIB=x86_64-linux-gnu-ranlib \
                                    x86_64_linux_NM=x86_64-linux-gnu-nm \
                                    x86_64_linux_STRIP=x86_64-linux-gnu-strip \
-                                   qt_config_opts_i686_linux='-platform linux-g++ -xplatform bitcoin-linux-g++'
+                                   qt_config_opts_i686_linux='-platform linux-g++ -xplatform bitcoin-linux-g++' \
+                                   mingw32_CFLAGS='-DMINGW_HAS_SECURE_API=1 -pipe'
 
 
 ###########################
@@ -136,11 +159,26 @@ DISTNAME="$(basename "$SOURCEDIST" '.tar.gz')"
 # Binary Tarball Building #
 ###########################
 
-# Similar flags to Gitian
-CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests"
-HOST_CFLAGS="-O2 -g -ffile-prefix-map=${PWD}=."
-HOST_CXXFLAGS="-O2 -g -ffile-prefix-map=${PWD}=."
-HOST_LDFLAGS="-Wl,--as-needed -Wl,--dynamic-linker=$glibc_dynamic_linker -static-libstdc++"
+# CONFIGFLAGS
+CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests"
+case "$HOST" in
+    *linux*) CONFIGFLAGS+=" --enable-glibc-back-compat" ;;
+esac
+
+# CFLAGS
+HOST_CFLAGS="-O2 -g"
+case "$HOST" in
+    *linux*)  HOST_CFLAGS+=" -ffile-prefix-map=${PWD}=." ;;
+    *mingw*)  HOST_CFLAGS+=" -fno-ident" ;;
+esac
+
+# CXXFLAGS
+HOST_CXXFLAGS="$HOST_CFLAGS"
+
+# LDFLAGS
+case "$HOST" in
+    *linux*)  HOST_LDFLAGS="-Wl,--as-needed -Wl,--dynamic-linker=$glibc_dynamic_linker -static-libstdc++" ;;
+esac
 
 # Make $HOST-specific native binaries from depends available in $PATH
 export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
@@ -160,7 +198,7 @@ export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
                     ${CONFIGFLAGS} \
                     CFLAGS="${HOST_CFLAGS}" \
                     CXXFLAGS="${HOST_CXXFLAGS}" \
-                    LDFLAGS="${HOST_LDFLAGS}"
+                    ${HOST_LDFLAGS:+LDFLAGS="${HOST_LDFLAGS}"}
 
     sed -i.old 's/-lstdc++ //g' config.status libtool src/univalue/config.status src/univalue/libtool
 
@@ -169,9 +207,21 @@ export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
 
     # Perform basic ELF security checks on a series of executables.
     make -C src --jobs=1 check-security ${V:+V=1}
-    # Check that executables only contain allowed gcc, glibc and libstdc++
-    # version symbols for Linux distro back-compatibility.
-    make -C src --jobs=1 check-symbols  ${V:+V=1}
+
+    case "$HOST" in
+        *linux*)
+            # Check that executables only contain allowed gcc, glibc and libstdc++
+            # version symbols for Linux distro back-compatibility.
+            make -C src --jobs=1 check-symbols  ${V:+V=1}
+            ;;
+    esac
+
+    # Make the os-specific installers
+    case "$HOST" in
+        *mingw*)
+            make deploy ${V:+V=1}
+            ;;
+    esac
 
     # Setup the directory where our PRCYcoin build for HOST will be
     # installed. This directory will also later serve as the input for our
@@ -180,8 +230,20 @@ export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
     mkdir -p "${INSTALLPATH}"
     # Install built PRCYcoin to $INSTALLPATH
     make install DESTDIR="${INSTALLPATH}" ${V:+V=1}
+
+    case "$HOST" in
+        *mingw*)
+            cp -f --target-directory="$OUTDIR" ./*-setup-unsigned.exe
+            ;;
+    esac
     (
         cd installed
+
+        case "$HOST" in
+            *mingw*)
+                mv --target-directory="$DISTNAME"/lib/ "$DISTNAME"/bin/*.dll
+                ;;
+        esac
 
         # Prune libtool and object archives
         find . -name "lib*.la" -delete
@@ -196,19 +258,56 @@ export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
             find "${DISTNAME}/lib" -type f -print0
         } | xargs -0 -n1 -P"$MAX_JOBS" -I{} "${DISTSRC}/contrib/devtools/split-debug.sh" {} {} {}.dbg
 
-        cp "${DISTSRC}/doc/README.md" "${DISTNAME}/"
+        case "$HOST" in
+            *mingw*)
+                cp "${DISTSRC}/doc/README_windows.txt" "${DISTNAME}/readme.txt"
+                ;;
+            *linux*)
+                cp "${DISTSRC}/doc/README.md" "${DISTNAME}/"
+                ;;
+        esac
 
         # Finally, deterministically produce {non-,}debug binary tarballs ready
         # for release
-        find "${DISTNAME}" -not -name "*.dbg" -print0 \
-            | sort --zero-terminated \
-            | tar --create --no-recursion --mode='u+rw,go+r-w,a+X' --null --files-from=- \
-            | gzip -9n > "${OUTDIR}/${DISTNAME}-${HOST}.tar.gz" \
-            || ( rm -f "${OUTDIR}/${DISTNAME}-${HOST}.tar.gz" && exit 1 )
-        find "${DISTNAME}" -name "*.dbg" -print0 \
-            | sort --zero-terminated \
-            | tar --create --no-recursion --mode='u+rw,go+r-w,a+X' --null --files-from=- \
-            | gzip -9n > "${OUTDIR}/${DISTNAME}-${HOST}-debug.tar.gz" \
-            || ( rm -f "${OUTDIR}/${DISTNAME}-${HOST}-debug.tar.gz" && exit 1 )
+        case "$HOST" in
+            *mingw*)
+                find "${DISTNAME}" -not -name "*.dbg" \
+                    | sort \
+                    | zip -X@ "${OUTDIR}/${DISTNAME}-${HOST//x86_64-w64-mingw32/win64}.zip" \
+                    || ( rm -f "${OUTDIR}/${DISTNAME}-${HOST//x86_64-w64-mingw32/win64}.zip" && exit 1 )
+                find "${DISTNAME}" -name "*.dbg" \
+                    | sort \
+                    | zip -X@ "${OUTDIR}/${DISTNAME}-${HOST//x86_64-w64-mingw32/win64}-debug.zip" \
+                    || ( rm -f "${OUTDIR}/${DISTNAME}-${HOST//x86_64-w64-mingw32/win64}-debug.zip" && exit 1 )
+                ;;
+            *linux*)
+                find "${DISTNAME}" -not -name "*.dbg" -print0 \
+                    | sort --zero-terminated \
+                    | tar --create --no-recursion --mode='u+rw,go+r-w,a+X' --null --files-from=- \
+                    | gzip -9n > "${OUTDIR}/${DISTNAME}-${HOST}.tar.gz" \
+                    || ( rm -f "${OUTDIR}/${DISTNAME}-${HOST}.tar.gz" && exit 1 )
+                find "${DISTNAME}" -name "*.dbg" -print0 \
+                    | sort --zero-terminated \
+                    | tar --create --no-recursion --mode='u+rw,go+r-w,a+X' --null --files-from=- \
+                    | gzip -9n > "${OUTDIR}/${DISTNAME}-${HOST}-debug.tar.gz" \
+                    || ( rm -f "${OUTDIR}/${DISTNAME}-${HOST}-debug.tar.gz" && exit 1 )
+                ;;
+        esac
     )
 )
+
+case "$HOST" in
+    *mingw*)
+        cp -rf --target-directory=. contrib/windeploy
+        (
+            cd ./windeploy
+            mkdir unsigned
+            cp --target-directory=unsigned/ "$OUTDIR"/prcycoin-*-setup-unsigned.exe
+            find . -print0 \
+                | sort --zero-terminated \
+                | tar --create --no-recursion --mode='u+rw,go+r-w,a+X' --null --files-from=- \
+                | gzip -9n > "${OUTDIR}/${DISTNAME}-win-unsigned.tar.gz" \
+                || ( rm -f "${OUTDIR}/${DISTNAME}-win-unsigned.tar.gz" && exit 1 )
+        )
+        ;;
+esac

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -24,6 +24,17 @@
              (guix profiles)
              (guix utils))
 
+(define (make-ssp-fixed-gcc xgcc)
+  "Given a XGCC package, return a modified package that uses the SSP function
+from glibc instead of from libssp.so. Taken from:
+http://www.linuxfromscratch.org/hlfs/view/development/chapter05/gcc-pass1.html"
+  (package
+   (inherit xgcc)
+   (arguments
+    (substitute-keyword-arguments (package-arguments xgcc)
+      ((#:make-flags flags)
+       `(cons "gcc_cv_libc_provides_ssp=yes" ,flags))))))
+
 (define (make-gcc-rpath-link xgcc)
   "Given a XGCC package, return a modified package that replace each instance of
 -rpath in the default system spec that's inserted by Guix with -rpath-link"

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -26,7 +26,10 @@
 
 (define (make-ssp-fixed-gcc xgcc)
   "Given a XGCC package, return a modified package that uses the SSP function
-from glibc instead of from libssp.so. Taken from:
+from glibc instead of from libssp.so. Our `symbol-check' script will complain if
+we link against libssp.so, and thus will ensure that this works properly.
+
+Taken from:
 http://www.linuxfromscratch.org/hlfs/view/development/chapter05/gcc-pass1.html"
   (package
    (inherit xgcc)

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -10,11 +10,14 @@
              (gnu packages file)
              (gnu packages gawk)
              (gnu packages gcc)
+             (gnu packages installers)
              (gnu packages linux)
+             (gnu packages mingw)
              (gnu packages perl)
              (gnu packages pkg-config)
              (gnu packages python)
              (gnu packages shells)
+             (guix build-system gnu)
              (guix build-system trivial)
              (guix gexp)
              (guix packages)
@@ -94,7 +97,7 @@ chain for " target " development."))
                                   (base-kernel-headers linux-libre-headers-4.19)
                                   (base-libc glibc-2.27)
                                   (base-gcc (make-gcc-rpath-link gcc-9)))
-  "Convienience wrapper around MAKE-CROSS-TOOLCHAIN with default values
+  "Convenience wrapper around MAKE-CROSS-TOOLCHAIN with default values
 desirable for building PRCYcoin release binaries."
   (make-cross-toolchain target
                    base-gcc-for-libc
@@ -102,45 +105,77 @@ desirable for building PRCYcoin release binaries."
                    base-libc
                    base-gcc))
 
+(define (make-gcc-with-pthreads gcc)
+  (package-with-extra-configure-variable gcc "--enable-threads" "posix"))
+
+(define (make-mingw-pthreads-cross-toolchain target)
+  "Create a cross-compilation toolchain package for TARGET"
+  (let* ((xbinutils (cross-binutils target))
+         (pthreads-xlibc mingw-w64-x86_64-winpthreads)
+         (pthreads-xgcc (make-gcc-with-pthreads
+                         (cross-gcc target
+                                    #:xgcc (make-ssp-fixed-gcc gcc)
+                                    #:xbinutils xbinutils
+                                    #:libc pthreads-xlibc))))
+    ;; Define a meta-package that propagates the resulting XBINUTILS, XLIBC, and
+    ;; XGCC
+    (package
+      (name (string-append target "-posix-toolchain"))
+      (version (package-version pthreads-xgcc))
+      (source #f)
+      (build-system trivial-build-system)
+      (arguments '(#:builder (begin (mkdir %output) #t)))
+      (propagated-inputs
+       `(("binutils" ,xbinutils)
+         ("libc" ,pthreads-xlibc)
+         ("gcc" ,pthreads-xgcc)))
+      (synopsis (string-append "Complete GCC tool chain for " target))
+      (description (string-append "This package provides a complete GCC tool
+chain for " target " development."))
+      (home-page (package-home-page pthreads-xgcc))
+      (license (package-license pthreads-xgcc)))))
+
+
 (packages->manifest
- (list ;; The Basics
-       bash-minimal
-       which
-       coreutils
-       util-linux
-       ;; File(system) inspection
-       file
-       grep
-       diffutils
-       findutils
-       ;; File transformation
-       patch
-       gawk
-       sed
-       ;; Compression and archiving
-       tar
-       bzip2
-       gzip
-       xz
-       zlib
-       ;; Build tools
-       gnu-make
-       libtool
-       autoconf
-       automake
-       pkg-config
-       ;; Scripting
-       perl
-       python-3.7
-       ;; Native gcc 9 toolchain targeting glibc 2.27
-       (make-gcc-toolchain gcc-9 glibc-2.27)
-       ;; Cross gcc 9 toolchains targeting glibc 2.27
-       (make-prcycoin-cross-toolchain "i686-linux-gnu")
-       (make-prcycoin-cross-toolchain "x86_64-linux-gnu")
-       (make-prcycoin-cross-toolchain "aarch64-linux-gnu")
-       (make-prcycoin-cross-toolchain "arm-linux-gnueabihf")
-       ;; The glibc 2.27 for riscv64 needs gcc 7 to successfully build (see:
-       ;; https://www.gnu.org/software/gcc/gcc-7/changes.html#riscv). The final
-       ;; toolchain is still a gcc 9 toolchain targeting glibc 2.27.
-       (make-prcycoin-cross-toolchain "riscv64-linux-gnu"
-                                     #:base-gcc-for-libc gcc-7)))
+ (append
+  (list ;; The Basics
+        bash-minimal
+        which
+        coreutils
+        util-linux
+        ;; File(system) inspection
+        file
+        grep
+        diffutils
+        findutils
+        ;; File transformation
+        patch
+        gawk
+        sed
+        ;; Compression and archiving
+        tar
+        bzip2
+        gzip
+        xz
+        zlib
+        ;; Build tools
+        gnu-make
+        libtool
+        autoconf
+        automake
+        pkg-config
+        ;; Scripting
+        perl
+        python-3.7
+        ;; Native gcc 9 toolchain targeting glibc 2.27
+        (make-gcc-toolchain gcc-9 glibc-2.27))
+  (let ((target (getenv "HOST")))
+    (cond ((string-suffix? "-mingw32" target)
+           ;; Windows
+           (list zip (make-mingw-pthreads-cross-toolchain "x86_64-w64-mingw32") nsis-x86_64))
+          ((string-contains target "riscv64-linux-")
+           (list (make-prcycoin-cross-toolchain "riscv64-linux-gnu"
+                                               #:base-gcc-for-libc gcc-7)))
+          ((string-contains target "-linux-")
+           (list (make-prcycoin-cross-toolchain target)))
+          (else '())))))

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -114,7 +114,7 @@ desirable for building PRCYcoin release binaries."
          (pthreads-xlibc mingw-w64-x86_64-winpthreads)
          (pthreads-xgcc (make-gcc-with-pthreads
                          (cross-gcc target
-                                    #:xgcc (make-ssp-fixed-gcc gcc)
+                                    #:xgcc (make-ssp-fixed-gcc gcc-8)
                                     #:xbinutils xbinutils
                                     #:libc pthreads-xlibc))))
     ;; Define a meta-package that propagates the resulting XBINUTILS, XLIBC, and

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -128,7 +128,7 @@ desirable for building PRCYcoin release binaries."
          (pthreads-xlibc mingw-w64-x86_64-winpthreads)
          (pthreads-xgcc (make-gcc-with-pthreads
                          (cross-gcc target
-                                    #:xgcc (make-ssp-fixed-gcc gcc-8)
+                                    #:xgcc (make-ssp-fixed-gcc gcc-9)
                                     #:xbinutils xbinutils
                                     #:libc pthreads-xlibc))))
     ;; Define a meta-package that propagates the resulting XBINUTILS, XLIBC, and

--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -2,6 +2,11 @@ Name "@PACKAGE_NAME@ (64-bit)"
 
 RequestExecutionLevel highest
 SetCompressor /SOLID lzma
+SetDateSave off
+
+# Uncomment these lines when investigating reproducibility errors
+#SetCompress off
+#SetDatablockOptimize off
 
 # General Symbol Definitions
 !define REGKEY "SOFTWARE\$(^Name)"


### PR DESCRIPTION
> Based on: https://github.com/bitcoin/bitcoin/pull/17933 (Time Machines are... shall we say... superior 😁)
> 
> This PR allows us to perform Guix builds for the x86_64-w64-mingw32 target. We do this without splitting up the build script like we do in Gitian by using this newfangled alien technology called case statements. (This is WIP and might be changed to if statements soon)

from https://github.com/bitcoin/bitcoin/pull/17595