### PR TITLE
[Upstream] build: set Unicode true for NSIS installer

### DIFF
--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -3,6 +3,7 @@ Name "@PACKAGE_NAME@ (64-bit)"
 RequestExecutionLevel highest
 SetCompressor /SOLID lzma
 SetDateSave off
+Unicode true
 
 # Uncomment these lines when investigating reproducibility errors
 #SetCompress off


### PR DESCRIPTION
> Now that we are using Focal for gitian builds, and have [NSIS 3.0+ available](https://packages.ubuntu.com/focal/nsis) (also in Guix), we can create installers that [support unicode](https://nsis.sourceforge.io/Docs/Chapter4.html#aunicodetarget).
> 
> Unicode is only becoming the NSIS default [beginning with the 3.07 release](https://nsis.sourceforge.io/Docs/AppendixF.html#v3.07-cl), so we need to set this attribute to get support.
> 
> Should close: https://github.com/bitcoin/bitcoin/issues/13817

from https://github.com/bitcoin/bitcoin/pull/21333