### PR TITLE
[Upstream] build: force CRCCheck in Windows installer

### DIFF
--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -54,7 +54,7 @@ Var StartMenuGroup
 # Installer attributes
 OutFile @abs_top_srcdir@/@PACKAGE_TARNAME@-@PACKAGE_VERSION@-win64-setup-unsigned.exe
 InstallDir $PROGRAMFILES64\PRCYcoin
-CRCCheck on
+CRCCheck force
 XPStyle on
 BrandingText " "
 ShowInstDetails show


### PR DESCRIPTION
> Otherwise a user can pass /NCRC on the command line and bypass the
> CRC check, meaning they could use a corrupted installer. I can't think of
> a reason why we'd want to allow the use of corrupted installers.
> 
> [NSIS docs](https://nsis.sourceforge.io/Docs/Chapter4.html#acrccheck):
> 
> >Specifies whether or not the installer will perform a CRC on itself before allowing an install. Note that if the user uses /NCRC on the command line when executing the installer, and you didn't specify 'force', the CRC will not occur, and the user will be allowed to install a (potentially) corrupted installer.

https://github.com/bitcoin/bitcoin/pull/24111