### PR TITLE
build, qt: add libcurl 8.0.1, use for price fetch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1000,6 +1000,11 @@ if test "x$use_qr" != xno; then
   BITCOIN_QT_CHECK([PKG_CHECK_MODULES([QR], [libqrencode], [have_qrencode=yes], [have_qrencode=no])])
 fi
 
+dnl curl check
+PKG_CHECK_MODULES([CURL], [libcurl],, [AC_MSG_ERROR([libcurl not found.])])
+AC_CHECK_HEADER([curl/curl.h],, [AC_MSG_ERROR([libcurl header not found.])])
+AC_CHECK_LIB([curl],         [main],CURL_LIBS=-lcurl, AC_MSG_ERROR(libcurl missing))
+
 save_CXXFLAGS="${CXXFLAGS}"
 CXXFLAGS="${CXXFLAGS} ${CRYPTO_CFLAGS} ${SSL_CFLAGS}"
 AC_CHECK_DECLS([EVP_MD_CTX_new],,,[AC_INCLUDES_DEFAULT
@@ -1271,6 +1276,8 @@ AC_SUBST(MINIUPNPC_CPPFLAGS)
 AC_SUBST(MINIUPNPC_LIBS)
 AC_SUBST(CRYPTO_LIBS)
 AC_SUBST(SSL_LIBS)
+AC_SUBST(CURL_CFLAGS)
+AC_SUBST(CURL_LIBS)
 AC_SUBST(USE_NUM_OPENSSL)
 AC_SUBST(HAVE_FDATASYNC)
 AC_SUBST(HAVE_FULLFSYNC)

--- a/contrib/prcycoin-qt.pro
+++ b/contrib/prcycoin-qt.pro
@@ -86,6 +86,7 @@ HEADERS += src/activemasternode.h \
            src/compressor.h \
            src/core_io.h \
            src/cuckoocache.h \
+           src/curl_json.h \
            src/crypter.h \
            src/eccryptoverify.h \
            src/ecdhutil.h \
@@ -412,6 +413,7 @@ SOURCES += src/activemasternode.cpp \
            src/compressor.cpp \
            src/core_read.cpp \
            src/core_write.cpp \
+           src/curl_json.cpp \
            src/crypter.cpp \
            src/prcycoin-cli.cpp \
            src/prcycoin-tx.cpp \

--- a/depends/packages/libcurl.mk
+++ b/depends/packages/libcurl.mk
@@ -1,0 +1,36 @@
+package=libcurl
+$(package)_version=8.0.1
+$(package)_dependencies=openssl
+$(package)_download_path=https://curl.haxx.se/download
+$(package)_file_name=curl-$($(package)_version).tar.xz
+$(package)_sha256_hash=0a381cd82f4d00a9a334438b8ca239afea5bfefcfa9a1025f2bf118e79e0b5f0
+$(package)_config_opts=--disable-shared --enable-static --prefix=$(host_prefix) --host=$(HOST) --with-openssl
+$(package)_config_opts+=--disable-manual --disable-ntlm-wb --with-random=/dev/urandom
+$(package)_config_opts+=--disable-curldebug --disable-libcurl-option --disable-ldap --disable-ldaps
+$(package)_config_opts+=--disable-dependency-tracking --enable-option-checking
+$(package)_config_opts+=CFLAGS="$($(package)_cflags) -fPIC"
+$(package)_conf_tool=./configure
+
+define $(package)_set_vars
+  $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"
+endef
+
+define $(package)_config_cmds
+  echo '=== config for $(package):' && \
+  echo '$($(package)_config_env) $($(package)_conf_tool) $($(package)_config_opts)' && \
+  echo '=== ' && \
+  $($(package)_config_env) $($(package)_conf_tool) $($(package)_config_opts)
+endef
+
+define $(package)_build_cmds
+  $(MAKE)
+endef
+
+define $(package)_stage_cmds
+  echo 'Staging dir: $($(package)_staging_dir)$(host_prefix)' && \
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+endef
+
+define $(package)_postprocess_cmds
+  rm -rf share/man lib/*.la
+endef

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,4 +1,4 @@
-packages:=boost openssl libevent
+packages:=boost openssl libevent libcurl
 
 qt_packages = qrencode zlib
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,7 +22,7 @@ else
 LIBUNIVALUE = $(UNIVALUE_LIBS)
 endif
 
-BITCOIN_INCLUDES=-I$(builddir) $(BDB_CPPFLAGS) $(BOOST_CPPFLAGS) $(LEVELDB_CPPFLAGS) $(CRYPTO_CFLAGS) $(SSL_CFLAGS)
+BITCOIN_INCLUDES=-I$(builddir) $(BDB_CPPFLAGS) $(BOOST_CPPFLAGS) $(LEVELDB_CPPFLAGS) $(CRYPTO_CFLAGS) $(SSL_CFLAGS) $(CURL_CFLAGS) 
 
 BITCOIN_INCLUDES += -I$(srcdir)/secp256k1/include
 BITCOIN_INCLUDES += -I$(srcdir)/secp256k1-mw/include
@@ -121,6 +121,7 @@ BITCOIN_CORE_H = \
   core_io.h \
   cuckoocache.h \
   crypter.h \
+  curl_json.h \
   wallet/db.h \
   fs.h \
   eccryptoverify.h \
@@ -211,7 +212,7 @@ obj/build.h: FORCE
 libbitcoin_util_a-clientversion.$(OBJEXT): obj/build.h
 
 # server: shared between prcycoind and prcycoin-qt
-libbitcoin_server_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(MINIUPNPC_CPPFLAGS) $(EVENT_CFLAGS) $(EVENT_PTHREADS_CFLAGS)
+libbitcoin_server_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(MINIUPNPC_CPPFLAGS) $(EVENT_CFLAGS) $(EVENT_PTHREADS_CFLAGS) $(CURL_CFLAGS) 
 libbitcoin_server_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_server_a_SOURCES = \
   addrman.cpp \
@@ -220,6 +221,7 @@ libbitcoin_server_a_SOURCES = \
   chain.cpp \
   checkpoints.cpp \
   consensus/tx_verify.cpp \
+  curl_json.cpp \
   httprpc.cpp \
   httpserver.cpp \
   init.cpp \
@@ -452,7 +454,7 @@ prcycoind_LDADD = \
   $(LIBSECP256K1) \
   $(LIBSECP256K1_2)
 
-prcycoind_LDADD += $(BOOST_LIBS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS) $(ZMQ_LIBS)
+prcycoind_LDADD += $(BOOST_LIBS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS) $(ZMQ_LIBS) $(CURL_LIBS) 
 
 # prcycoin-cli binary #
 prcycoin_cli_SOURCES = prcycoin-cli.cpp

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -389,7 +389,7 @@ BITCOIN_QT_INCLUDES = -I$(builddir)/qt -I$(srcdir)/qt -I$(srcdir)/qt/forms \
   -I$(builddir)/qt/forms -DQT_NO_KEYWORDS
 
 qt_libbitcoinqt_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BITCOIN_QT_INCLUDES) \
-  $(QT_INCLUDES) $(QT_DBUS_INCLUDES) $(QR_CFLAGS)
+  $(QT_INCLUDES) $(QT_DBUS_INCLUDES) $(QR_CFLAGS) $(CURL_CFLAGS)
 qt_libbitcoinqt_a_CXXFLAGS = $(AM_CXXFLAGS) $(QT_PIE_FLAGS)
 qt_libbitcoinqt_a_OBJCXXFLAGS = $(AM_OBJCXXFLAGS) $(QT_PIE_FLAGS)
 
@@ -408,7 +408,7 @@ $(qt_libbitcoinqt_a_OBJECTS) $(qt_prcycoin_qt_OBJECTS) : | $(QT_MOC)
 
 # prcycoin-qt binary #
 qt_prcycoin_qt_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BITCOIN_QT_INCLUDES) \
-  $(QT_INCLUDES) $(QR_CFLAGS)
+  $(QT_INCLUDES) $(QR_CFLAGS) $(CURL_CFLAGS)
 qt_prcycoin_qt_CXXFLAGS = $(AM_CXXFLAGS) $(QT_PIE_FLAGS)
 
 qt_prcycoin_qt_SOURCES = qt/prcycoin.cpp
@@ -418,7 +418,7 @@ endif
 if TARGET_WINDOWS
   qt_prcycoin_qt_SOURCES += $(BITCOIN_RC)
 endif
-qt_prcycoin_qt_LDADD = qt/libbitcoinqt.a $(LIBBITCOIN_SERVER) $(LIBSECP256K1) $(LIBSECP256K1_2)
+qt_prcycoin_qt_LDADD = qt/libbitcoinqt.a $(LIBBITCOIN_SERVER) $(LIBSECP256K1) $(LIBSECP256K1_2) $(CURL_LIBS)
 if ENABLE_WALLET
 qt_prcycoin_qt_LDADD += $(LIBBITCOIN_UTIL) $(LIBBITCOIN_WALLET) $(LIBBITCOIN_ZXCVBN)
 endif
@@ -428,7 +428,7 @@ endif
 
 qt_prcycoin_qt_LDADD += $(LIBBITCOIN_CLI) $(LIBBITCOIN_COMMON) $(LIBBITCOIN_UTIL) $(LIBBITCOIN_CRYPTO) $(LIBUNIVALUE) $(LIBLEVELDB) $(LIBLEVELDB_SSE42) $(LIBMEMENV) \
   $(BOOST_LIBS) $(QT_LIBS) $(QT_DBUS_LIBS) $(QR_LIBS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(LIBSECP256K1) \
-  $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS) -lqrencode
+  $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS) -lqrencode $(CURL_LIBS)
 qt_prcycoin_qt_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(QT_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 qt_prcycoin_qt_LIBTOOLFLAGS = $(AM_LIBTOOLFLAGS) --tag CXX
 

--- a/src/curl_json.cpp
+++ b/src/curl_json.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "curl_json.h"
+#include "util.h"
+
+#include <openssl/evp.h>
+
+JsonDownload downloadedJSON;
+
+static size_t writer(char *in, size_t size, size_t nmemb, std::string *out)
+{
+      out->append((char*)in, size * nmemb);
+      return size * nmemb;
+}
+
+void getHttpsJson(std::string url)
+{
+    {
+        JsonDownload newDownload;
+        downloadedJSON = newDownload;
+    }
+
+    downloadedJSON.failed = false;
+    downloadedJSON.complete = false;
+    downloadedJSON.URL = url;
+    std::string response_string;
+
+    curl_global_init(CURL_GLOBAL_ALL);
+    CURL *curl;
+    CURLcode res;
+
+    struct curl_slist *headers=NULL; // init to NULL is important
+
+    headers = curl_slist_append(headers, "Accept: application/json");
+    headers = curl_slist_append(headers, "Content-Type: application/json");
+    headers = curl_slist_append(headers, "charset: utf-8");
+
+    curl = curl_easy_init();
+    if(curl) {
+
+        curl_easy_setopt(curl, CURLOPT_URL, downloadedJSON.URL.c_str());
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+        curl_easy_setopt(curl, CURLOPT_HTTPGET, 1);
+        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writer);
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_string);
+        res = curl_easy_perform(curl);
+
+        if(CURLE_OK == res) {
+            char *ct;
+            /* ask for the content-type */
+            res = curl_easy_getinfo(curl, CURLINFO_CONTENT_TYPE, &ct);
+            if((CURLE_OK == res) && ct) {
+                downloadedJSON.response = response_string;
+                downloadedJSON.failed = false;
+                downloadedJSON.complete = true;
+            }
+        } else {
+          downloadedJSON.response = "";
+          downloadedJSON.failed = false;
+          downloadedJSON.complete = false;
+        }
+    }
+    /* always cleanup */
+    curl_easy_cleanup(curl);
+    curl_slist_free_all(headers);
+    curl_global_cleanup();
+
+}

--- a/src/curl_json.h
+++ b/src/curl_json.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PRCYCOIN_CURLJSON_H
+#define PRCYCOIN_CURLJSON_H
+
+#include <curl/curl.h>
+
+#include <string>
+
+#define TIME_IN_US 1
+#define TIMETYPE curl_off_t
+#define TIMEOPT CURLINFO_TOTAL_TIME_T
+#define MINIMAL_PROGRESS_FUNCTIONALITY_INTERVAL     3000000
+
+struct CurlProgress {
+  TIMETYPE lastruntime; /* type depends on version, see above */
+  CURL *curl;
+};
+
+struct JsonDownload {
+    std::string URL = "";
+    std::string response = "";
+    bool failed = false;
+    bool complete = false;
+    CURL *curl;
+    CurlProgress prog;
+};
+
+extern JsonDownload downloadedJSON;
+
+static size_t writer(char *in, size_t size, size_t nmemb, std::string *out);
+extern void getHttpsJson(std::string url);
+
+#endif

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -92,10 +92,10 @@ private:
     QRect getCircleGeometry(QWidget* parent, float ratioToParent);
 
     // Check Currency Value via CoinGecko.com API
+    QTimer* updateJSONtimer;
+    QTimer* updateGUItimer;
     QNetworkAccessManager* manager;
     QNetworkReply* reply;
-    QTimer* getCurrencyValueInterval;
-    bool isRuninngQuery = false;
 
 private Q_SLOTS:
     void updateDisplayUnit();
@@ -106,7 +106,7 @@ private Q_SLOTS:
     void updateLockStatus(int status);
     // Check Currency Value via CoinGecko.com API
     void getCurrencyValue();
-    void setCurrencyValue(QNetworkReply* reply);
+    void setCurrencyValue();
 };
 
 #endif // BITCOIN_QT_OVERVIEWPAGE_H


### PR DESCRIPTION
This introduces libcurl as a dependency in the build system in the first commits.

e6a0681705a95ca87fa1888e1cf232e10fe771f8: Based on initial implementation by @CryptoForge in commits such as: https://github.com/PirateNetwork/pirate/commit/8034da7fc1b90df3bee608d7af7f580b17fc3644, while still retaining our options to select different currencies.

This now opens up a few new potential options, although all may not be implemented:
- Price fetch RPC: (`getprice`)
- Check for Updates will be updated to use libcurl:
  - Using GitHub API, we can retrieve the latest release as it posted, preventing false Update notices while `master` branch was building before upload
  - Much simpler code
  - RPC: (`checkforupdates`) **[only checks, does not do an auto-update]**
- Download and install Bootstrap (this also requires libarchive)
- Make libcurl optional (since the functions are optional/more "nice to haves")?