### PR TITLE
build: use our own FALLBACK_DOWNLOAD_PATH for depends

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -38,7 +38,7 @@ NO_WALLET ?=
 NO_ZMQ ?=
 NO_UPNP ?=
 LTO ?=
-FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources
+FALLBACK_DOWNLOAD_PATH ?= https://bootstrap.prcycoin.com/depends-sources
 
 BUILD = $(shell ./config.guess)
 HOST ?= $(BUILD)


### PR DESCRIPTION
The Qt 5.9.9 archive has been removed from their website and mirrors. Host our own, as well as all current depends packages, and set that as the `FALLBACK_DOWNLOAD_PATH` to fix/prevent this issue in the future.