### PR TITLE
rpc: add blockheight to WalletTxToJSON

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -58,6 +58,7 @@ void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
         entry.push_back(Pair("generated", true));
     if (confirms > 0) {
         entry.push_back(Pair("blockhash", wtx.hashBlock.GetHex()));
+        entry.push_back(Pair("blockheight", mapBlockIndex[wtx.hashBlock]->nHeight));
         entry.push_back(Pair("blockindex", wtx.nIndex));
         entry.push_back(Pair("blocktime", mapBlockIndex[wtx.hashBlock]->GetBlockTime()));
     }
@@ -1629,6 +1630,7 @@ UniValue gettransaction(const UniValue& params, bool fHelp)
             "  \"confirmations\" : n,     (numeric) The number of confirmations\n"
             "  \"bcconfirmations\" : n,   (numeric) The number of blockchain confirmations\n"
             "  \"blockhash\" : \"hash\",  (string) The block hash\n"
+            "  \"blockheight\" : n,       (numeric) The block height\n"
             "  \"blockindex\" : xx,       (numeric) The block index\n"
             "  \"blocktime\" : ttt,       (numeric) The time in seconds since epoch (1 Jan 1970 GMT)\n"
             "  \"txid\" : \"transactionid\",   (string) The transaction id.\n"


### PR DESCRIPTION
This pull request implements an enhancement to the existing functionality of the RPCs using `WalletTxToJSON`. It introduces the addition of a `"blockheight"` field, which allows for easy referencing of the height at which a transaction was included in a block. This enhancement can be particularly useful in scenarios such as performing a rescan, where determining the wallet height of the first transaction becomes important.

Will be used in a future Toolkit update.