### PR TITLE
wallet: Improve Efficiency in Transaction Creation and Loop Calls

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -380,11 +380,12 @@ void SendCoinsDialog::sendTx() {
         pwalletMain->ComputeStealthPublicAddress("masteraccount", myAddress);
         bool showCheckBox = false;
         int indexOut = -1;
+        const CAmount collateralAmount = Params().MNCollateralAmt();
         if (sendAddress == myAddress) {
             for (int i=0; i < (int)resultTx.vout.size(); i++) {
                 CTxOut& out = resultTx.vout[i];
                 CAmount value = pwalletMain->getCTxOutValue(resultTx, out);
-                if (value == Params().MNCollateralAmt()) {
+                if (value == collateralAmount) {
                     showCheckBox = true;
                     indexOut = i;
                 }

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -530,11 +530,12 @@ UniValue createmasternode(const UniValue& params, bool fHelp)
 
     UniValue ret(UniValue::VARR);
     int indexOut = -1;
+    const CAmount collateralAmount = Params().MNCollateralAmt();
     for (int i=0; i < (int)wtx.vout.size(); i++) {
         UniValue obj(UniValue::VOBJ);
         CTxOut& out = wtx.vout[i];
         CAmount value = pwalletMain->getCTxOutValue(wtx, out);
-        if (value == Params().MNCollateralAmt()) {
+        if (value == collateralAmount) {
             indexOut = i;
 
             // Lock collateral output

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3182,7 +3182,7 @@ bool CWallet::CreateTransactionBulletProof(const CKey& txPrivDes, const CPubKey&
                     CPubKey sharedSec;
                     ECDHInfo::ComputeSharedSec(txPrivDes, recipientViewKey, sharedSec);
                     EncodeTxOutAmount(txout, txout.nValue, sharedSec.begin());
-                    txNew.vout.push_back(txout);
+                    txNew.vout.emplace_back(txout);
                     nBytes += ::GetSerializeSize(*(CTxOut*)&txout, SER_NETWORK, PROTOCOL_VERSION);
                 }
 
@@ -3365,7 +3365,7 @@ bool CWallet::CreateTransaction(const std::vector<std::pair<CScript, CAmount> >&
                             strFailReason = _("Transaction amount too small");
                             return false;
                         }
-                        txNew.vout.push_back(txout);
+                        txNew.vout.emplace_back(txout);
                     }
                 } else //UTXO Splitter Transaction
                 {
@@ -5350,7 +5350,7 @@ bool CWallet::SendAll(std::string des, CWalletTx& wtxNew, bool inclLocked)
                                 CPubKey sharedSec;
                                 ECDHInfo::ComputeSharedSec(wtxNew.txPrivM, pubViewKey, sharedSec);
                                 EncodeTxOutAmount(txout, txout.nValue, sharedSec.begin());
-                                txNew.vout.push_back(txout);
+                                txNew.vout.emplace_back(txout);
                                 txNew.nTxFee = nFeeNeeded;
 
                                 //Fill vin
@@ -5611,7 +5611,7 @@ bool CWallet::CreateSweepingTransaction(CAmount target, CAmount threshold, uint3
                                 CPubKey sharedSec;
                                 ECDHInfo::ComputeSharedSec(wtxNew.txPrivM, pubViewKey, sharedSec);
                                 EncodeTxOutAmount(txout, txout.nValue, sharedSec.begin());
-                                txNew.vout.push_back(txout);
+                                txNew.vout.emplace_back(txout);
                                 //nBytes += ::GetSerializeSize(*(CTxOut*)&txout, SER_NETWORK, PROTOCOL_VERSION);
 
                                 txNew.nTxFee = nFeeNeeded;


### PR DESCRIPTION
This pull request includes two optimizations in the Wallet:

- The Params() calls are moved outside of the loops where possible, potentially improving performance.
- The push_back function in transaction creation is replaced with emplace_back, which can provide better performance due to in-place construction of the object.
The second commit is a very condensed version of a larger upstream PR.