### PR TITLE
wallet: DeleteTx updates

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1674,7 +1674,7 @@ bool AppInit2(bool isDaemon)
             //Sort Transactions by block and block index, then reorder
             LOCK2(cs_main, pwalletMain->cs_wallet);
             if (chainActive.Tip()) {
-                LogPrintf("Runnning transaction reorder\n");
+                LogPrintf("Running transaction reorder\n");
                 int64_t maxOrderPos = 0;
                 std::map<std::pair<int,int>, CWalletTx*> mapSorted;
                 pwalletMain->ReorderWalletTransactions(mapSorted, maxOrderPos);

--- a/src/qt/revealtxdialog.cpp
+++ b/src/qt/revealtxdialog.cpp
@@ -185,7 +185,13 @@ void RevealTxDialog::deleteTransaction()
             return;
         }
         // Erase it
-        pwalletMain->EraseFromWallet(hash);
+        if (!pwalletMain->EraseFromWallet(hash)) {
+            GUIUtil::showMessageBox(
+                tr("Unable to delete transaction id"),
+                tr("Unable to delete transaction id."),
+                QMessageBox::Critical);
+            return;
+        }
 
         // Display Success! dialog if not disabled
         QMessageBox msgBox;

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -33,6 +33,7 @@ class CValidationInterface {
 protected:
     virtual void UpdatedBlockTip(const CBlockIndex *pindex) {}
     virtual void SyncTransaction(const CTransaction &tx, const CBlock *pblock) {}
+    virtual bool EraseFromWallet(const uint256 &hash) { return false;}
     virtual void NotifyTransactionLock(const CTransaction &tx) {}
     virtual void SetBestChain(const CBlockLocator &locator) {}
     virtual bool UpdatedTransaction(const uint256 &hash) { return false;}

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3093,11 +3093,23 @@ UniValue erasewallettransactions(const UniValue& params, bool fHelp) {
     EnsureWallet();
     EnsureWalletIsUnlocked();
 
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     CBlockIndex* pindex = chainActive.Tip();
+    int initialCount = (int)pwalletMain->mapWallet.size();
+    int newCount, removedTxes = 0;
 
-    pwalletMain->DeleteWalletTransactions(pindex);
+    pwalletMain->DeleteWalletTransactions(pindex, false);
 
-    return "Done";
+    newCount = (int)pwalletMain->mapWallet.size();
+    removedTxes = initialCount - newCount;
+
+    UniValue ret(UniValue::VOBJ);
+    ret.push_back(Pair("initial_utxo_count", initialCount));
+    ret.push_back(Pair("new_utxo_count", newCount));
+    ret.push_back(Pair("deleted_utxo_count", removedTxes));
+
+    return ret;
 }
 
 UniValue revealmnemonicphrase(const UniValue& params, bool fHelp)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3143,7 +3143,8 @@ UniValue erasefromwallet(const UniValue& params, bool fHelp)
     if (!pwalletMain->mapWallet.count(hash))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id");
 
-    pwalletMain->EraseFromWallet(hash);
+    if (!pwalletMain->mapWallet.count(hash))
+        return "Failed to delete transaction";
 
     return "Done";
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1317,17 +1317,16 @@ void CWallet::SyncTransaction(const CTransaction& tx, const CBlock* pblock)
     }
 }
 
-void CWallet::EraseFromWallet(const uint256& hash)
+bool CWallet::EraseFromWallet(const uint256& hash)
 {
     if (!fFileBacked)
-        return;
+        return false;
     {
         LOCK(cs_wallet);
         if (mapWallet.erase(hash))
-            CWalletDB(strWalletFile).EraseTx(hash);
-        LogPrintf("%s: Erased wtx %s from wallet\n", __func__, hash.GetHex());
+            return CWalletDB(strWalletFile).EraseTx(hash);
     }
-    return;
+    return false;
 }
 
 
@@ -1852,8 +1851,7 @@ void CWallet::DeleteTransactions(std::vector<uint256> &removeTxs)
     CWalletDB walletdb(strWalletFile, "r+", false);
 
     for (int i = 0; i< removeTxs.size(); i++) {
-        if (mapWallet.erase(removeTxs[i])) {
-            walletdb.EraseTx(removeTxs[i]);
+        if (EraseFromWallet(removeTxs[i])) {
             LogPrint(BCLog::DELETETX,"DeleteTx - Deleting tx %s, %i.\n", removeTxs[i].ToString(),i);
         } else {
             LogPrint(BCLog::DELETETX,"DeleteTx - Deleting tx %failed.\n", removeTxs[i].ToString());

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -895,6 +895,17 @@ unsigned int CWallet::GetSpendDepth(const uint256& hash, unsigned int n) const
         if (mit != mapWallet.end() && mit->second.GetDepthInMainChain() >= 0)
             return mit->second.GetDepthInMainChain(); // Spent
     }
+
+    std::string outString = outpoint.hash.GetHex() + std::to_string(outpoint.n);
+    CKeyImage ki = outpointToKeyImages[outString];
+    if (IsSpentKeyImage(ki.GetHex(), UINT256_ZERO)) {
+        std::string kiHex = ki.GetHex();
+        int confirmations = 0;
+        if (CheckKeyImageSpendInMainChain(kiHex, confirmations)) {
+            return confirmations; // Spent
+        }
+    }
+
     return 0;
 }
 
@@ -1793,22 +1804,29 @@ void CWallet::RemoveFromSpends(const uint256& wtxid)
  */
 void CWallet::ReorderWalletTransactions(std::map<std::pair<int,int>, CWalletTx*> &mapSorted, int64_t &maxOrderPos)
 {
-    LOCK2(cs_main, cs_wallet);
+    AssertLockHeld(cs_main);
+    AssertLockHeld(cs_wallet);
 
     int maxSortNumber = chainActive.Tip()->nHeight + 1;
 
     for (std::map<uint256, CWalletTx>::iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
     {
         CWalletTx* pwtx = &(it->second);
-        int confirms = pwtx->GetDepthInMainChain();
         maxOrderPos = std::max(maxOrderPos, pwtx->nOrderPos);
 
-        if (confirms > 0) {
-            int wtxHeight = mapBlockIndex[pwtx->hashBlock]->nHeight;
-            auto key = std::make_pair(wtxHeight, pwtx->nIndex);
-            mapSorted.insert(make_pair(key, pwtx));
-        }
-        else {
+        if (mapBlockIndex.count(pwtx->hashBlock) > 0) {
+            auto blockIndex = mapBlockIndex[pwtx->hashBlock];
+            if (blockIndex) {
+                int wtxHeight = blockIndex->nHeight;
+                auto key = std::make_pair(wtxHeight, pwtx->nIndex);
+                mapSorted.insert(make_pair(key, pwtx));
+            } else {
+                // handle null blockIndex
+                auto key = std::make_pair(maxSortNumber, 0);
+                mapSorted.insert(std::make_pair(key, pwtx));
+                maxSortNumber++;
+            }
+        } else {
             auto key = std::make_pair(maxSortNumber, 0);
             mapSorted.insert(std::make_pair(key, pwtx));
             maxSortNumber++;
@@ -1821,7 +1839,8 @@ void CWallet::ReorderWalletTransactions(std::map<std::pair<int,int>, CWalletTx*>
  */
 void CWallet::UpdateWalletTransactionOrder(std::map<std::pair<int,int>, CWalletTx*> &mapSorted, bool resetOrder)
 {
-    LOCK2(cs_main, cs_wallet);
+    AssertLockHeld(cs_main);
+    AssertLockHeld(cs_wallet);
 
     int64_t previousPosition = 0;
     std::map<const uint256, CWalletTx*> mapUpdatedTxs;
@@ -1857,19 +1876,23 @@ void CWallet::UpdateWalletTransactionOrder(std::map<std::pair<int,int>, CWalletT
     nOrderPosNext = previousPosition++;
     CWalletDB(strWalletFile).WriteOrderPosNext(nOrderPosNext);
     LogPrint(BCLog::DELETETX,"Reorder Tx - Total Transactions Reordered %i, Next Position %i\n", mapUpdatedTxs.size(), nOrderPosNext);
-
 }
 
 /**
  * Delete transactions from the Wallet
  */
-void CWallet::DeleteTransactions(std::vector<uint256> &removeTxs)
+bool CWallet::DeleteTransactions(std::vector<uint256> &removeTxs, bool fRescan)
 {
-    LOCK(cs_wallet);
+    AssertLockHeld(cs_wallet);
+
+    bool removingTransactions = false;
+    if (removeTxs.size() > 0) {
+        removingTransactions = true;
+    }
 
     CWalletDB walletdb(strWalletFile, "r+", false);
 
-    for (int i = 0; i< removeTxs.size(); i++) {
+    for (int i = 0; i < removeTxs.size(); i++) {
         bool fRemoveFromSpends = !(mapWallet.at(removeTxs[i]).IsCoinBase());
         if (EraseFromWallet(removeTxs[i])) {
             if (fRemoveFromSpends) {
@@ -1877,8 +1900,8 @@ void CWallet::DeleteTransactions(std::vector<uint256> &removeTxs)
             }
             LogPrint(BCLog::DELETETX,"DeleteTx - Deleting tx %s, %i.\n", removeTxs[i].ToString(),i);
         } else {
-            LogPrint(BCLog::DELETETX,"DeleteTx - Deleting tx %failed.\n", removeTxs[i].ToString());
-            return;
+            LogPrint(BCLog::DELETETX,"DeleteTx - Deleting tx %s failed.\n", removeTxs[i].ToString());
+            return false;
         }
     }
 
@@ -1886,18 +1909,21 @@ void CWallet::DeleteTransactions(std::vector<uint256> &removeTxs)
     #ifdef __linux__
     malloc_trim(0);
     #endif
+
+    return removingTransactions;
 }
 
-void CWallet::DeleteWalletTransactions(const CBlockIndex* pindex)
+bool CWallet::DeleteWalletTransactions(const CBlockIndex* pindex, bool fRescan)
 {
-    LOCK2(cs_main, cs_wallet);
+    AssertLockHeld(cs_main);
+    AssertLockHeld(cs_wallet);
 
     int nDeleteAfter = (int)fDeleteTransactionsAfterNBlocks;
     bool runCompact = false;
+    bool deletedTransactions = false;
     auto startTime = GetTime();
 
     if (pindex && fTxDeleteEnabled) {
-
         //Check for acentries - exit function if found
         {
             std::list<CAccountingEntry> acentries;
@@ -1905,7 +1931,7 @@ void CWallet::DeleteWalletTransactions(const CBlockIndex* pindex)
             walletdb.ListAccountCreditDebit("*", acentries);
             if (acentries.size() > 0) {
                 LogPrintf("deletetx not compatible to account entries\n");
-                return;
+                return false;
             }
         }
         //delete transactions
@@ -2017,7 +2043,7 @@ void CWallet::DeleteWalletTransactions(const CBlockIndex* pindex)
         LogPrint(BCLog::DELETETX,"DeleteTx - Time to Select %s\n", DateTimeStrFormat("%H:%M:%S", selectTime - reorderTime));
 
         //Delete Transactions from wallet
-        DeleteTransactions(removeTxs);
+        deletedTransactions = DeleteTransactions(removeTxs, fRescan);
 
         auto deleteTime = GetTime();
         LogPrint(BCLog::DELETETX,"DeleteTx - Time to Delete %s\n", DateTimeStrFormat("%H:%M:%S", deleteTime - selectTime));
@@ -2030,6 +2056,8 @@ void CWallet::DeleteWalletTransactions(const CBlockIndex* pindex)
         auto totalTime = GetTime();
         LogPrint(BCLog::DELETETX,"DeleteTx - Time to Run Total Function %s\n", DateTimeStrFormat("%H:%M:%S", totalTime - startTime));
     }
+
+    return deletedTransactions;
 }
 
 /**
@@ -2072,6 +2100,11 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate, b
                 if (AddToWalletIfInvolvingMe(tx, &block, fUpdate))
                     ret++;
             }
+
+            //Delete Transactions
+            if (pindex->nHeight % fDeleteInterval == 0)
+                while(DeleteWalletTransactions(pindex, true)) {}
+
             pindex = chainActive.Next(pindex);
             if (GetTime() >= nNow + 60) {
                 nNow = GetTime();
@@ -2083,6 +2116,8 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate, b
             }
         }
         ShowProgress(_("Rescanning... Please do not interrupt this process as it could lead to a corrupt wallet."), 100); // hide progress dialog in GUI
+        //Delete transactions
+        while(DeleteWalletTransactions(chainActive.Tip(), true)) {}
     }
     return ret;
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -476,7 +476,7 @@ public:
     bool AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet, CWalletDB* pwalletdb);
     void SyncTransaction(const CTransaction& tx, const CBlock* pblock);
     bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate);
-    void EraseFromWallet(const uint256& hash);
+    bool EraseFromWallet(const uint256& hash);
     void ReorderWalletTransactions(std::map<std::pair<int,int>, CWalletTx*> &mapSorted, int64_t &maxOrderPos);
     void UpdateWalletTransactionOrder(std::map<std::pair<int,int>, CWalletTx*> &mapSorted, bool resetOrder);
     void DeleteTransactions(std::vector<uint256> &removeTxs);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -268,6 +268,7 @@ private:
     TxSpends mapTxSpends;
     void AddToSpends(const COutPoint& outpoint, const uint256& wtxid);
     void AddToSpends(const uint256& wtxid);
+    void RemoveFromSpends(const uint256& wtxid);
 
     void SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator>);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -480,8 +480,8 @@ public:
     bool EraseFromWallet(const uint256& hash);
     void ReorderWalletTransactions(std::map<std::pair<int,int>, CWalletTx*> &mapSorted, int64_t &maxOrderPos);
     void UpdateWalletTransactionOrder(std::map<std::pair<int,int>, CWalletTx*> &mapSorted, bool resetOrder);
-    void DeleteTransactions(std::vector<uint256> &removeTxs);
-    void DeleteWalletTransactions(const CBlockIndex* pindex);
+    bool DeleteTransactions(std::vector<uint256> &removeTxs, bool fRescan = false);
+    bool DeleteWalletTransactions(const CBlockIndex* pindex, bool fRescan = false);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false, bool fromStartup = false, int height = -1);
     void ReacceptWalletTransactions();
     void ResendWalletTransactions();


### PR DESCRIPTION
A number of improvements mainly from upstream [Pirate](https://github.com/PirateNetwork/pirate)

- fix GetSpendDepth (this was the cause for Masternode rewards that were spent not being deleted)
- keep running DeleteWalletTransactions until no more can be deleted
- updated thread locks
- update RPC to return initial, new, deleted utxo_count

