### PR TITLE
[Upstream] build: Require C++17 compiler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,18 +66,8 @@ case $host in
   ;;
 esac
 
-AC_ARG_ENABLE([c++17],
-  [AS_HELP_STRING([--enable-c++17],
-  [enable compilation in c++17 mode (disabled by default)])],
-  [use_cxx17=$enableval],
-  [use_cxx17=no])
-
-dnl Require C++14 or C++17 compiler (no GNU extensions)
-if test "x$use_cxx17" = xyes; then
-  AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
-else
-  AX_CXX_COMPILE_STDCXX([14], [noext], [mandatory])
-fi
+dnl Require C++17 compiler (no GNU extensions)
+AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
 
 dnl Check if -latomic is required for <std::atomic>
 CHECK_ATOMIC

--- a/src/util.h
+++ b/src/util.h
@@ -189,4 +189,11 @@ void TraceThread(const char* name, Callable func)
 fs::path AbsPathForConfigVal(const boost::filesystem::path& path, bool net_specific = true);
 bool PointHashingSuccessively(const CPubKey& pk, const unsigned char* tweak, unsigned char* out);
 
+//! Substitute for C++14 std::make_unique.
+template <typename T, typename... Args>
+std::unique_ptr<T> MakeUnique(Args&&... args)
+{
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
 #endif // BITCOIN_UTIL_H

--- a/src/util.h
+++ b/src/util.h
@@ -190,10 +190,11 @@ fs::path AbsPathForConfigVal(const boost::filesystem::path& path, bool net_speci
 bool PointHashingSuccessively(const CPubKey& pk, const unsigned char* tweak, unsigned char* out);
 
 //! Substitute for C++14 std::make_unique.
+//! DEPRECATED use std::make_unique in new code.
 template <typename T, typename... Args>
 std::unique_ptr<T> MakeUnique(Args&&... args)
 {
-    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+    return std::make_unique<T>(std::forward<Args>(args)...);
 }
 
 #endif // BITCOIN_UTIL_H


### PR DESCRIPTION
>Developers have been compiling with C++17 for a few months now (fuzz tests and the msvc build have it even enabled by default). According to https://github.com/bitcoin/bitcoin/issues/16684, the 22.0 release shall be compiled with C++17 enabled.

>
>This only sets the build flag, any other changes need more discussion and can be done later.

from https://github.com/bitcoin/bitcoin/pull/20413
8116b5e27e8319307b238c4a0a435de38cb9090b is cherry picked from https://github.com/bitcoin/bitcoin/pull/11043