### PR TITLE
[Upstream] [Startup] Decrease the amount of blocks checked for corruption in the startup

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1484,7 +1484,7 @@ bool AppInit2(bool isDaemon)
                     }
 
                     //Must check at level 4
-                    if (!CVerifyDB().VerifyDB(pcoinsdbview, 4, GetArg("-checkblocks", 100))) {
+                    if (!CVerifyDB().VerifyDB(pcoinsdbview, 4, GetArg("-checkblocks", 10))) {
                         strLoadError = _("Corrupted block database detected");
                         fVerifyingBlocks = false;
                         break;


### PR DESCRIPTION
cherry picked from https://github.com/PIVX-Project/PIVX/pull/1217 - related info below:
>Db verification decreased to 10 blocks.
>- Previously our wallet was checking, disconnecting and reconnecting the last 100 blocks in the startup, looking for inconsistencies. That is really too much, if we have any inconsistency, it should appear in the last 10 blocks.

Should speed up startup.