### PR TITLE
[Upstream] depends: Bump Qt version to 5.12.11

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -1,9 +1,9 @@
 PACKAGE=qt
-$(package)_version=5.12.10
+$(package)_version=5.12.11
 $(package)_download_path=https://download.qt.io/archive/qt/5.12/$($(package)_version)/submodules
 $(package)_suffix=everywhere-src-$($(package)_version).tar.xz
 $(package)_file_name=qtbase-$($(package)_suffix)
-$(package)_sha256_hash=8088f174e6d28e779516c083b6087b6a9e3c8322b4bc161fd1b54195e3c86940
+$(package)_sha256_hash=1c1b4e33137ca77881074c140d54c3c9747e845a31338cfe8680f171f0bc3a39
 $(package)_dependencies=openssl zlib
 $(package)_linux_dependencies=freetype fontconfig libxcb libxkbcommon
 $(package)_build_subdir=qtbase
@@ -15,10 +15,10 @@ $(package)_patches+= fix_qpainter_non_determinism.patch fix_lib_paths.patch
 
 # Update OSX_QT_TRANSLATIONS when this is updated
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
-$(package)_qttranslations_sha256_hash=e1de58ed108b7e0a138815ea60fd46a2c4e1fc31396a707e5630e92de79c53de
+$(package)_qttranslations_sha256_hash=577b0668a777eb2b451c61e8d026d79285371597ce9df06b6dee6c814164b7c3
 
 $(package)_qttools_file_name=qttools-$($(package)_suffix)
-$(package)_qttools_sha256_hash=b0cfa6e7aac41b7c61fc59acc04843d7a98f9e1840370611751bcfc1834a636c
+$(package)_qttools_sha256_hash=98b2aaca230458f65996f3534fd471d2ffd038dd58ac997c0589c06dc2385b4f
 
 $(package)_extra_sources  = $($(package)_qttranslations_file_name)
 $(package)_extra_sources += $($(package)_qttools_file_name)

--- a/depends/patches/qt/fix_android_jni_static.patch
+++ b/depends/patches/qt/fix_android_jni_static.patch
@@ -1,6 +1,6 @@
 --- old/qtbase/src/plugins/platforms/android/androidjnimain.cpp
 +++ new/qtbase/src/plugins/platforms/android/androidjnimain.cpp
-@@ -897,6 +897,14 @@
+@@ -898,6 +898,14 @@
          __android_log_print(ANDROID_LOG_FATAL, "Qt", "registerNatives failed");
          return -1;
      }

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -21,7 +21,7 @@ These are the dependencies currently used by PRCYCoin. You can find instructions
 | PCRE |  |  |  |  | [Yes](https://github.com/prcycoin/prcycoin/blob/master/depends/packages/qt.mk#L66) |
 | Python (tests) |  | [3.6](https://www.python.org/downloads) |  |  |  |
 | qrencode | [3.4.4](https://fukuchi.org/works/qrencode) |  | No |  |  |
-| Qt | [5.9.9](https://download.qt.io/official_releases/qt/) | [5.5.1](https://github.com/bitcoin/bitcoin/issues/13478) | No |  |  |
+| Qt | [5.12.11](https://download.qt.io/official_releases/qt/) | [5.5.1](https://github.com/bitcoin/bitcoin/issues/13478) | No |  |  |
 | XCB |  |  |  |  | [Yes](https://github.com/prcycoin/prcycoin/blob/master/depends/packages/qt.mk#L87) (Linux only) |
 | xkbcommon |  |  |  |  | [Yes](https://github.com/prcycoin/prcycoin/blob/master/depends/packages/qt.mk#L86) (Linux only) |
 | ZeroMQ | [4.3.1](https://github.com/zeromq/libzmq/releases) | 4.0.0 | No |  |  |


### PR DESCRIPTION
> Qt 5.12.11:
> 
> [fixes](https://github.com/qt/qtbase/commit/c5d904639dbd690a36306e2b455610029704d821) macOS related [QTBUG-87014](https://bugreports.qt.io/browse/QTBUG-87014), and the fix_bigsur_drawing.patch (which is our workaround for QTBUG-87014) could be dropped
> [upgrades](https://github.com/qt/qtbase/commit/00326c9dc1ec6c80679347859c2fe01d4837b061) supported macOS SDK to 11.0, and removes related warnings
> fixes tab widget rendering on macOS Big Sur ([here](https://github.com/qt/qtbase/commit/4d6832d03f31b513ff2e3517197691bedddaccdf) and [here](https://github.com/qt/qtbase/commit/28b015342d000b8487c853153f1d93606d3c2add))

from https://github.com/bitcoin/bitcoin/pull/22054

Note: we were able to skip the patch as we bumped versions so quickly.