### PR TITLE
[Upstream] build, qt: Fix compiling qt package in depends with GCC 11

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -12,6 +12,7 @@ $(package)_patches=fix_qt_pkgconfig.patch mac-qmake.conf fix_no_printer.patch no
 $(package)_patches+= fix_android_qmake_conf.patch fix_android_jni_static.patch dont_hardcode_pwd.patch
 $(package)_patches+= drop_lrelease_dependency.patch no_sdk_version_check.patch
 $(package)_patches+= fix_qpainter_non_determinism.patch fix_lib_paths.patch
+$(package)_patches+= fix_limits_header.patch
 
 # Update OSX_QT_TRANSLATIONS when this is updated
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
@@ -219,6 +220,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/fix_qpainter_non_determinism.patch && \
   patch -p1 -i $($(package)_patch_dir)/no_sdk_version_check.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_lib_paths.patch && \
+  patch -p1 -i $($(package)_patch_dir)/fix_limits_header.patch && \
   sed -i.old "s|updateqm.commands = \$$$$\$$$$LRELEASE|updateqm.commands = $($(package)_extract_dir)/qttools/bin/lrelease|" qttranslations/translations/translations.pro && \
   mkdir -p qtbase/mkspecs/macx-clang-linux &&\
   cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\

--- a/depends/patches/qt/fix_limits_header.patch
+++ b/depends/patches/qt/fix_limits_header.patch
@@ -1,0 +1,44 @@
+Fix compiling with GCC 11
+
+See: https://bugreports.qt.io/browse/QTBUG-90395.
+
+Upstream commits:
+ - Qt 5.15 -- unavailable as open source
+ - Qt 6.0: b2af6332ea37e45ab230a7a5d2d278f86d961b83
+ - Qt 6.1: 9c56d4da2ff631a8c1c30475bd792f6c86bda53c
+
+--- old/qtbase/src/corelib/global/qendian.h
++++ new/qtbase/src/corelib/global/qendian.h
+@@ -44,6 +44,8 @@
+ #include <QtCore/qfloat16.h>
+ #include <QtCore/qglobal.h>
+ 
++#include <limits>
++
+ // include stdlib.h and hope that it defines __GLIBC__ for glibc-based systems
+ #include <stdlib.h>
+ #include <string.h>
+
+--- old/qtbase/src/corelib/tools/qbytearraymatcher.h
++++ new/qtbase/src/corelib/tools/qbytearraymatcher.h
+@@ -42,6 +42,8 @@
+ 
+ #include <QtCore/qbytearray.h>
+ 
++#include <limits>
++
+ QT_BEGIN_NAMESPACE
+ 
+ 
+
+--- old/qtbase/src/tools/moc/generator.cpp
++++ new/qtbase/src/tools/moc/generator.cpp
+@@ -40,6 +40,8 @@
+ #include <QtCore/qplugin.h>
+ #include <QtCore/qstringview.h>
+ 
++#include <limits>
++
+ #include <math.h>
+ #include <stdio.h>
+ 


### PR DESCRIPTION
> The `qt` package in depends fails to compile with GCC 11 due to the missed `<limits>` headers.
> 
> See: https://bugreports.qt.io/browse/QTBUG-90395
> 
> Affected systems:
> - Ubuntu 21.04 + GCC 11.1.0
> - Fedora 34 + GCC 11.1.1
> 
> Ubuntu 21.04 build log excerpt:
> ```
> Configuring qt...
> Creating qmake...
> gmake[1]: Entering directory '/home/hebasto/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.12.11-1ff5c6c1f55/qtbase/qmake'
> In file included from /home/hebasto/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.12.11-1ff5c6c1f55/qtbase/include/QtCore/qendian.h:1,
>                  from /home/hebasto/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.12.11-1ff5c6c1f55/qtbase/src/corelib/codecs/qutfcodec.cpp:43:
> /home/hebasto/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.12.11-1ff5c6c1f55/qtbase/include/QtCore/../../src/corelib/global/qendian.h: In static member function ‘static constexpr QSpecialInteger<S> QSpecialInteger<S>::max()’:
> /home/hebasto/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.12.11-1ff5c6c1f55/qtbase/include/QtCore/../../src/corelib/global/qendian.h:331:35: error: ‘numeric_limits’ is not a member of ‘std’
>   331 |     { return QSpecialInteger(std::numeric_limits<T>::max()); }
>       |                                   ^~~~~~~~~~~~~~
> /home/hebasto/bitcoin/depends/work/build/x86_64-pc-linux-gnu/qt/5.12.11-1ff5c6c1f55/qtbase/include/QtCore/../../src/corelib/global/qendian.h:331:54: error: ‘::max’ has not been declared; did you mean ‘std::max’?
>   331 |     { return QSpecialInteger(std::numeric_limits<T>::max()); }
>       |                                                      ^~~
>       |                                                      std::max
> ```

from https://github.com/bitcoin/bitcoin/pull/22186