### PR TITLE
[Upstream] qt: Set AA_EnableHighDpiScaling attribute early

### DIFF
--- a/src/qt/prcycoin.cpp
+++ b/src/qt/prcycoin.cpp
@@ -585,15 +585,16 @@ int main(int argc, char* argv[])
     Q_INIT_RESOURCE(prcycoin_locale);
     Q_INIT_RESOURCE(prcycoin);
 
-    BitcoinApplication app(argc, argv);
     // Generate high-dpi pixmaps
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #if QT_VERSION >= 0x050600
-    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
 #ifdef Q_OS_MAC
     QApplication::setAttribute(Qt::AA_DontShowIconsInMenus);
 #endif
+
+    BitcoinApplication app(argc, argv);
 
     // Register meta types used for QMetaObject::invokeMethod
     qRegisterMetaType<bool*>();


### PR DESCRIPTION
> Running bitcoin-qt compiled against Qt 5.12.4 causes a warning:
> 
```
 hebasto@bionic-qt:~/bitcoin$ src/qt/bitcoin-qt 
 Attribute Qt::AA_EnableHighDpiScaling must be set before QCoreApplication is created.
 ```
> 
>This PR fixes this issue.
> 
> From Qt docs:
> 
> - [Qt::AA_EnableHighDpiScaling](https://doc.qt.io/qt-5/qt.html#ApplicationAttribute-enum):
> >Enables high-DPI scaling in Qt on supported platforms (see also High DPI Displays). Supported platforms are X11, Windows and Android. Enabling makes Qt scale the main (device independent) coordinate system according to display scale factors provided by the operating system. This corresponds to setting the QT_AUTO_SCREEN​_SCALE_FACTOR environment variable to 1. This attribute must be set before QGuiApplication is constructed. This value was added in Qt 5.6.
> 
- [QCoreApplication::setAttribute()](https://doc.qt.io/qt-5/qcoreapplication.html#setAttribute)

from https://github.com/bitcoin/bitcoin/pull/16254