### PR TITLE
[Upstream] build: Use XLIFF file to provide more context to Transifex translators

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -212,6 +212,7 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
   BITCOIN_QT_PATH_PROGS([RCC], [rcc-qt5 rcc5 rcc], $qt_bin_path)
   BITCOIN_QT_PATH_PROGS([LRELEASE], [lrelease-qt5 lrelease5 lrelease], $qt_bin_path)
   BITCOIN_QT_PATH_PROGS([LUPDATE], [lupdate-qt5 lupdate5 lupdate],$qt_bin_path, yes)
+  BITCOIN_QT_PATH_PROGS([LCONVERT], [lconvert-qt5 lconvert5 lconvert], $qt_bin_path, yes)
 
   MOC_DEFS='-DHAVE_CONFIG_H -I$(srcdir)'
   case $host in
@@ -245,7 +246,10 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
       AC_MSG_ERROR([libQtDBus not found. Install libQtDBus or remove --with-qtdbus.])
     fi
     if test "x$LUPDATE" = x; then
-      AC_MSG_WARN([lupdate is required to update qt translations])
+      AC_MSG_WARN([lupdate tool is required to update Qt translations.])
+    fi
+    if test "x$LCONVERT" = x; then
+      AC_MSG_WARN([lconvert tool is required to update Qt translations.])
     fi
   ],[
     bitcoin_enable_qt=no

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -249,7 +249,8 @@ define $(package)_config_cmds
   qtbase/bin/qmake -o qttranslations/Makefile qttranslations/qttranslations.pro && \
   qtbase/bin/qmake -o qttranslations/translations/Makefile qttranslations/translations/translations.pro && \
   qtbase/bin/qmake -o qttools/src/linguist/lrelease/Makefile qttools/src/linguist/lrelease/lrelease.pro && \
-  qtbase/bin/qmake -o qttools/src/linguist/lupdate/Makefile qttools/src/linguist/lupdate/lupdate.pro
+  qtbase/bin/qmake -o qttools/src/linguist/lupdate/Makefile qttools/src/linguist/lupdate/lupdate.pro && \
+  qtbase/bin/qmake -o qttools/src/linguist/lconvert/Makefile qttools/src/linguist/lconvert/lconvert.pro
 endef
 
 define $(package)_build_cmds
@@ -257,6 +258,7 @@ define $(package)_build_cmds
   $(MAKE) -C qtbase/src $(addprefix sub-,$($(package)_qt_libs)) && \
   $(MAKE) -C qttools/src/linguist/lrelease && \
   $(MAKE) -C qttools/src/linguist/lupdate && \
+  $(MAKE) -C qttools/src/linguist/lconvert && \
   $(MAKE) -C qttranslations
 endef
 
@@ -264,6 +266,7 @@ define $(package)_stage_cmds
   $(MAKE) -C qtbase/src INSTALL_ROOT=$($(package)_staging_dir) $(addsuffix -install_subtargets,$(addprefix sub-,$($(package)_qt_libs))) && \
   $(MAKE) -C qttools/src/linguist/lrelease INSTALL_ROOT=$($(package)_staging_dir) install_target && \
   $(MAKE) -C qttools/src/linguist/lupdate INSTALL_ROOT=$($(package)_staging_dir) install_target && \
+  $(MAKE) -C qttools/src/linguist/lconvert INSTALL_ROOT=$($(package)_staging_dir) install_target && \
   $(MAKE) -C qttranslations INSTALL_ROOT=$($(package)_staging_dir) install_subtargets
 endef
 

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -444,6 +444,8 @@ $(srcdir)/qt/prcycoinstrings.cpp: $(libbitcoin_server_a_SOURCES) $(libbitcoin_wa
 translate: $(srcdir)/qt/prcycoinstrings.cpp $(QT_FORMS_UI) $(QT_FORMS_UI) $(BITCOIN_QT_BASE_CPP) qt/prcycoin.cpp $(BITCOIN_QT_WINDOWS_CPP) $(BITCOIN_QT_WALLET_CPP) $(BITCOIN_QT_H) $(BITCOIN_MM)
 	@test -n $(LUPDATE) || echo "lupdate is required for updating translations"
 	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(LUPDATE) $^ -locations relative -no-obsolete -ts $(srcdir)/qt/locale/prcycoin_en.ts
+	@test -n $(LCONVERT) || echo "lconvert is required for updating translations"
+	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(LCONVERT) -o $(srcdir)/qt/locale/prcycoin_en.xlf -i $(srcdir)/qt/locale/prcycoin_en.ts
 
 $(QT_QRC_LOCALE_CPP): $(QT_QRC_LOCALE) $(QT_QM)
 	@test -f $(RCC)

--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -275,7 +275,8 @@ void AddressBookPage::on_exportButton_clicked()
 
     if (!writer.write()) {
         QMessageBox::critical(this, tr("Exporting Failed"),
-            tr("There was an error trying to save the address list to %1. Please try again.").arg(filename));
+            //: %1 is a name of the file (e.g., "addrbook.csv") that the bitcoin addresses were exported to.
+            tr("There was an error trying to save the address list to %1. Please try again.", "An error message.").arg(filename));
     }
 }
 

--- a/src/qt/locale/prcycoin_en.ts
+++ b/src/qt/locale/prcycoin_en.ts
@@ -119,9 +119,11 @@
         <translation>Exporting Failed</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
-        <translation>There was an error trying to save the address list to %1. Please try again.</translation>
+        <comment>An error message.</comment>
+        <extracomment>%1 is a name of the file (e.g., &quot;addrbook.csv&quot;) that the bitcoin addresses were exported to.</extracomment>
+        <translation type="unfinished">There was an error trying to save the address list to %1. Please try again.</translation>
     </message>
 </context>
 <context>
@@ -250,7 +252,58 @@
         <translation>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</translation>
     </message>
     <message>
-        <location line="+111"/>
+        <location line="+8"/>
+        <location line="+7"/>
+        <location line="+39"/>
+        <location line="+6"/>
+        <source>Wallet Encryption Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-51"/>
+        <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <location line="+45"/>
+        <source>The supplied passphrases do not match. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-34"/>
+        <source>Wallet Unlock Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The passphrase entered for the wallet unlock was incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Wallet Decryption Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+17"/>
+        <source>The passphrase entered for the wallet decryption was incorrect. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-7"/>
+        <source>Passphrase Change Successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet passphrase was successfully changed.
+Please remember your passphrase as there is no way to recover it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+48"/>
         <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Warning: The Caps Lock key is on!</translation>
@@ -519,7 +572,7 @@
         <translation>Show information about Qt</translation>
     </message>
     <message>
-        <location line="+30"/>
+        <location line="+33"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Show / Hide</translation>
     </message>
@@ -549,7 +602,7 @@
         <translation>Backup wallet to another location</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+3"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Change Passphrase...</translation>
     </message>
@@ -723,18 +776,8 @@
         <source>PRivaCY Dex Link</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location line="+1"/>
-        <source>&amp;PRCY Checker</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>PRCY Checker Link</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message numerus="yes">
-        <location line="+638"/>
+        <location line="+644"/>
         <source>%n Active Connections</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -742,7 +785,7 @@
         </translation>
     </message>
     <message numerus="yes">
-        <location line="+18"/>
+        <location line="+19"/>
         <source>Processed %n blocks of transaction history.</source>
         <translation>
             <numerusform>Processed %n block of transaction history.</numerusform>
@@ -750,7 +793,7 @@
         </translation>
     </message>
     <message>
-        <location line="+170"/>
+        <location line="+172"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -760,18 +803,17 @@ Confirmations: %5
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
+        <location line="+49"/>
         <source>Staking Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
+        <location line="+27"/>
         <source>Staking Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+10"/>
-        <location line="+8"/>
         <source>Enabling Staking...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -781,12 +823,12 @@ Confirmations: %5
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-865"/>
+        <location line="-860"/>
         <source>&amp;File</source>
         <translation>&amp;File</translation>
     </message>
     <message>
-        <location line="-180"/>
+        <location line="-186"/>
         <source>&amp;Settings</source>
         <translation>&amp;Settings</translation>
     </message>
@@ -816,7 +858,7 @@ Confirmations: %5
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+12"/>
         <source>&amp;Staking</source>
         <translation type="unfinished"></translation>
     </message>
@@ -826,12 +868,12 @@ Confirmations: %5
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+6"/>
         <source>&amp;Network</source>
         <translation type="unfinished">&amp;Network</translation>
     </message>
     <message>
-        <location line="+28"/>
+        <location line="+31"/>
         <source>&amp;Debug Console</source>
         <translation type="unfinished"></translation>
     </message>
@@ -846,7 +888,7 @@ Confirmations: %5
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+129"/>
+        <location line="+131"/>
         <source>&amp;Tools</source>
         <translation>&amp;Tools</translation>
     </message>
@@ -856,12 +898,12 @@ Confirmations: %5
         <translation>&amp;Help</translation>
     </message>
     <message>
-        <location line="+620"/>
+        <location line="+625"/>
         <source>PRCY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-891"/>
+        <location line="-903"/>
         <source>&amp;Masternodes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -881,7 +923,17 @@ Confirmations: %5
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+44"/>
+        <source>&amp;Show Seed Phrase</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Show 24 word wallet seed phrase</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
         <source>&amp;MultiSend</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1026,7 +1078,17 @@ Confirmations: %5
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
+        <location line="+5"/>
+        <source>&amp;PRCY Toolkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>PRCY Toolkit Link</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>&amp;Telegram Tech Support</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1066,17 +1128,36 @@ Confirmations: %5
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+96"/>
+        <location line="+98"/>
         <source>Social</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+199"/>
+        <location line="+200"/>
         <source>PRCY client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+359"/>
+        <location line="+223"/>
+        <source>No Update Available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>No update available.
+
+Your wallet is up to date.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Error checking for updates.
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+128"/>
         <source>Up to date</source>
         <translation>Up to date</translation>
     </message>
@@ -1134,18 +1215,18 @@ Confirmations: %5
         <translation>Transactions after this will not yet be visible.</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+4"/>
         <source>Loading Blocks...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
-        <location line="+162"/>
+        <location line="+164"/>
         <source>Syncing Blocks...</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location line="-160"/>
+        <location line="-162"/>
         <source>%n Blocks</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -1153,7 +1234,8 @@ Confirmations: %5
         </translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="-196"/>
+        <location line="+217"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
@@ -1183,7 +1265,7 @@ Confirmations: %5
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
+        <location line="+57"/>
         <source>No Active Peers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1193,7 +1275,7 @@ Confirmations: %5
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+64"/>
+        <location line="+53"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt; for staking only</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1213,7 +1295,7 @@ Confirmations: %5
         <translation>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../prcycoin.cpp" line="+551"/>
+        <location filename="../prcycoin.cpp" line="+539"/>
         <source>A fatal error occurred. PRCY can no longer continue safely and will quit.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1259,7 +1341,7 @@ Confirmations: %5
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+83"/>
+        <location filename="../clientmodel.cpp" line="+81"/>
         <source>Total: %1 (IPv4: %2 / IPv6: %3 / Tor: %4 / Unknown: %5)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1377,7 +1459,7 @@ Confirmations: %5
         <translation>Priority</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+56"/>
+        <location filename="../coincontroldialog.cpp" line="+55"/>
         <source>Copy address</source>
         <translation>Copy address</translation>
     </message>
@@ -1699,6 +1781,67 @@ lowercase letters, numbers, symbols) </source>
         <source>Esc</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../encryptdialog.cpp" line="+37"/>
+        <location line="+11"/>
+        <source>Wallet Encryption Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-11"/>
+        <location line="+11"/>
+        <source>There was no passphrase entered for the wallet.
+
+Wallet encryption is required for the security of your funds.
+
+What would you like to do?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <location line="+9"/>
+        <location line="+8"/>
+        <location line="+10"/>
+        <location line="+17"/>
+        <source>Wallet Encryption Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-43"/>
+        <source>The passphrase entered for wallet encryption was empty. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>The passphrase&apos;s length has to be more than 10. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>The passphrase must contain lower, upper, digit, symbol. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>The passphrases entered for wallet encryption is too weak. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
+        <source>Wallet Encryption Successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet passphrase was successfully set.
+Please remember your passphrase as there is no way to recover it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>The passphrases entered for wallet encryption do not match. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>EnterMnemonics</name>
@@ -1715,6 +1858,26 @@ lowercase letters, numbers, symbols) </source>
     <message>
         <location line="+25"/>
         <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../entermnemonics.cpp" line="+29"/>
+        <source>Recovery Phrase Import Successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Your mnemonics have been successfully imported into the wallet. Rescanning will be scheduled to recover all your funds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Recovery Phrase Invalid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+0"/>
+        <source>Recovery phrase is invalid. Please try again and double check all words.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1795,12 +1958,12 @@ lowercase letters, numbers, symbols) </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+3"/>
         <source>Show splash screen on startup (default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
+        <location line="-2"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Set language, for example &quot;de_DE&quot; (default: system locale)</translation>
     </message>
@@ -1808,11 +1971,6 @@ lowercase letters, numbers, symbols) </source>
         <location line="+1"/>
         <source>Start minimized</source>
         <translation>Start minimized</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Set SSL root certificates for payment request (default: -system-)</source>
-        <translation>Set SSL root certificates for payment request (default: -system-)</translation>
     </message>
 </context>
 <context>
@@ -1824,7 +1982,7 @@ lowercase letters, numbers, symbols) </source>
     </message>
     <message>
         <location line="+27"/>
-        <location filename="../historypage.cpp" line="+299"/>
+        <location filename="../historypage.cpp" line="+300"/>
         <source>All Types</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1832,32 +1990,43 @@ lowercase letters, numbers, symbols) </source>
         <location line="+5"/>
         <location filename="../historypage.cpp" line="+3"/>
         <location line="+1"/>
-        <location line="+11"/>
+        <location line="+13"/>
         <source>Sent</source>
         <translation type="unfinished">Sent</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location filename="../historypage.cpp" line="-14"/>
+        <location filename="../historypage.cpp" line="-16"/>
         <location line="+1"/>
-        <location line="+13"/>
+        <location line="+15"/>
         <source>Received</source>
         <translation type="unfinished">Received</translation>
     </message>
     <message>
         <location line="+5"/>
-        <location filename="../historypage.cpp" line="-10"/>
+        <location filename="../historypage.cpp" line="-12"/>
         <location line="+1"/>
-        <location line="+9"/>
+        <location line="+8"/>
+        <location line="+3"/>
         <source>Mined</source>
         <translation type="unfinished">Mined</translation>
     </message>
     <message>
         <location line="+5"/>
+        <location filename="../historypage.cpp" line="-10"/>
+        <location line="+1"/>
+        <location line="+6"/>
+        <location line="+3"/>
+        <source>Minted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
         <location filename="../historypage.cpp" line="-8"/>
         <location line="+1"/>
-        <location line="+7"/>
-        <source>Minted</source>
+        <location line="+4"/>
+        <location line="+3"/>
+        <source>Masternode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1865,16 +2034,14 @@ lowercase letters, numbers, symbols) </source>
         <location filename="../historypage.cpp" line="-6"/>
         <location line="+1"/>
         <location line="+5"/>
-        <source>Masternode</source>
-        <translation type="unfinished"></translation>
+        <source>Payment to yourself</source>
+        <translation type="unfinished">Payment to yourself</translation>
     </message>
     <message>
         <location line="+5"/>
         <location filename="../historypage.cpp" line="-4"/>
-        <location line="+1"/>
-        <location line="+3"/>
-        <source>Payment to yourself</source>
-        <translation type="unfinished">Payment to yourself</translation>
+        <source>Rewards</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+27"/>
@@ -2275,24 +2442,9 @@ Please check the address and try again.</source>
         <translation>Open URI</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>Open payment request from URI or file</source>
-        <translation>Open payment request from URI or file</translation>
-    </message>
-    <message>
-        <location line="+9"/>
+        <location line="+15"/>
         <source>URI:</source>
         <translation>URI:</translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>Select payment request file</source>
-        <translation>Select payment request file</translation>
-    </message>
-    <message>
-        <location filename="../openuridialog.cpp" line="+46"/>
-        <source>Select payment request file to open</source>
-        <translation>Select payment request file to open</translation>
     </message>
 </context>
 <context>
@@ -2561,7 +2713,7 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation>&amp;Cancel</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+86"/>
+        <location filename="../optionsdialog.cpp" line="+85"/>
         <source>default</source>
         <translation>default</translation>
     </message>
@@ -2633,7 +2785,7 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
     </message>
     <message>
         <location line="+48"/>
-        <location filename="../optionspage.cpp" line="+370"/>
+        <location filename="../optionspage.cpp" line="+349"/>
         <source>Backup Wallet</source>
         <translation type="unfinished">Backup Wallet</translation>
     </message>
@@ -2683,6 +2835,11 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+7"/>
+        <source>Request passphrase before sending any transactions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+121"/>
         <source>Change current passphrase</source>
         <translation type="unfinished"></translation>
@@ -2724,7 +2881,7 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
     </message>
     <message>
         <location line="+16"/>
-        <source>Enabling this will incur a minimum 1 PRCY fee each time you receive a new deposit that needs to be consolidated for staking.</source>
+        <source>Enabling this will incur a maximum 0.1 PRCY fee each time you receive a new deposit that needs to be consolidated for staking.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2843,12 +3000,12 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-509"/>
+        <location line="-516"/>
         <source>Two Factor Authentication</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+65"/>
+        <location line="+72"/>
         <source>Remember my authentication code for</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2873,18 +3030,269 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../optionspage.cpp" line="+1"/>
-        <source>Wallet Data (*.dat)</source>
-        <translation type="unfinished">Wallet Data (*.dat)</translation>
-    </message>
-    <message>
-        <location line="+522"/>
-        <source>Copy</source>
+        <location filename="../optionspage.cpp" line="-134"/>
+        <source>Reserve Balance Empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>OK</source>
+        <source>PRCY reserve amount is empty and must be a minimum of 1.
+Please click Disable if you would like to turn it off.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+8"/>
+        <source>Invalid Reserve Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>The amount you have attempted to keep as spendable is greater than the %1 (%2M) limit. Please try a smaller amount.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>Reserve Balance Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Reserve balance of %1 PRCY is successfully set.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+12"/>
+        <source>Reserve Balance Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Reserve balance disabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+18"/>
+        <location line="+24"/>
+        <location line="+6"/>
+        <location line="+6"/>
+        <location line="+6"/>
+        <location line="+13"/>
+        <source>Wallet Encryption Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-54"/>
+        <source>The passphrase entered for wallet encryption was empty or contained spaces. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+24"/>
+        <source>The passphrase you have entered is the same as your old passphrase. Please use a different passphrase if you would like to change it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>The passphrase&apos;s length has to be more than 10. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>The passphrase must contain lower, upper, digit, symbol. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>The passphrase is too weak. You must use a minimum passphrase length of 10 characters and use uppercase letters, lowercase letters, numbers, and symbols. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Passphrase Change Successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet passphrase was successfully changed.
+Please remember your passphrase as there is no way to recover it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>The passphrases entered for wallet encryption do not match. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>Wallet Data (*.dat)</source>
+        <translation type="unfinished">Wallet Data (*.dat)</translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Wallet has been successfully backed up to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Wallet Backup Successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Wallet Backup Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Wallet backup failed. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+51"/>
+        <source>Staking Disabled - Syncing Masternode list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Enable Staking is disabled when you are still syncing the Masternode list as this is required. Please allow the wallet to fully sync this list before attempting to Enable Staking.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Staking Setting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <location line="+197"/>
+        <location line="+382"/>
+        <source>Please unlock the wallet with your passphrase before changing this setting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-569"/>
+        <source>PoW blocks are still being mined.
+Please wait until Block %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+82"/>
+        <source>Information</source>
+        <translation type="unfinished">Information</translation>
+    </message>
+    <message>
+        <location line="-64"/>
+        <source>Your stakeable balance is under the threshold of %1 PRCY. Please deposit more PRCY into your account in order to enable staking.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Your balance requires a consolidation transaction which incurs a fee of between %1 to %2 PRCY. However after that transaction fee, your balance will be below the staking threshold of %3 PRCY. Please deposit more PRCY into your account or reduce your reserved amount in order to enable staking.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Your stakeable balance is under the threshold of %1 PRCY. This is due to your reserve balance being too high. Please deposit more PRCY into your account or reduce your reserved amount in order to enable staking.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Your stakeable balance is under the threshold of %1 PRCY. This is due to your reserve balance of %2 PRCY being too high. The wallet software has tried to consolidate your funds with the reserve balance but without success because of a consolidation fee of %3 PRCY. Please wait around 10 minutes for the wallet to resolve the reserve to enable staking.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Warning: Staking Issue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+20"/>
+        <source>In order to enable staking with 100%% of your current balance, your previous PRCY deposits must be consolidated and reorganized. This will incur a fee of between %1 to %2 PRCY.
+
+Would you like to do this?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>In order to enable staking with 100%% of your current balance except the reserve balance, your previous PRCY deposits must be consolidated and reorganized. This will incur a fee of between %1 to %2 PRCY.
+
+Would you like to do this?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Staking Needs Consolidation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+19"/>
+        <source>Consolidation transaction created!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+101"/>
+        <source>2FA Setting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+48"/>
+        <source>SUCCESS!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Two-factor authentication has been successfully enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+168"/>
+        <source>UPNP Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>UPNP Settings successfully changed. Please restart the wallet for changes to take effect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <location line="+6"/>
+        <source>2FA Digit Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-5"/>
+        <source>2FA Digit Settings have been changed successfully.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>2FA Digit Settings have not been changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+43"/>
+        <source>Hide Balance When Unlocked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Attempt to Disable &apos;Hide Balance when unlocked&apos; failed or canceled. Wallet Locked for security.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
+        <source>Lock Send Tab When Unlocked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Attempt to Disable &apos;Lock Send Tab when unlocked&apos; failed or canceled. Wallet Locked for security.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Password Locked Setting</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2971,117 +3379,30 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+290"/>
-        <location line="+184"/>
-        <location line="+33"/>
-        <location line="+104"/>
-        <location line="+12"/>
-        <location line="+14"/>
+        <location filename="../paymentserver.cpp" line="+163"/>
         <source>Payment request error</source>
         <translation>Payment request error</translation>
     </message>
     <message>
-        <location line="-262"/>
+        <location line="+56"/>
         <location line="+5"/>
         <source>URI handling</source>
         <translation>URI handling</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <source>Payment request file handling</source>
-        <translation>Payment request file handling</translation>
-    </message>
-    <message>
-        <location line="-17"/>
+        <location line="-5"/>
         <source>Invalid payment address %1</source>
         <translation>Invalid payment address %1</translation>
     </message>
     <message>
-        <location line="-84"/>
+        <location line="-55"/>
         <source>Cannot start prcycoin: click-to-pay handler</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+61"/>
         <source>URI cannot be parsed! This can be caused by an invalid PRCY address or malformed URI parameters.</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+12"/>
-        <source>Payment request file cannot be read! This can be caused by an invalid payment request file.</source>
-        <translation>Payment request file cannot be read! This can be caused by an invalid payment request file.</translation>
-    </message>
-    <message>
-        <location line="+67"/>
-        <location line="+8"/>
-        <location line="+30"/>
-        <source>Payment request rejected</source>
-        <translation>Payment request rejected</translation>
-    </message>
-    <message>
-        <location line="-38"/>
-        <source>Payment request network doesn&apos;t match client network.</source>
-        <translation>Payment request network doesn&apos;t match client network.</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Payment request has expired.</source>
-        <translation>Payment request has expired.</translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>Payment request is not initialized.</source>
-        <translation>Payment request is not initialized.</translation>
-    </message>
-    <message>
-        <location line="+25"/>
-        <source>Unverified payment requests to custom payment scripts are unsupported.</source>
-        <translation>Unverified payment requests to custom payment scripts are unsupported.</translation>
-    </message>
-    <message>
-        <location line="+8"/>
-        <source>Requested payment amount of %1 is too small (considered dust).</source>
-        <translation>Requested payment amount of %1 is too small (considered dust).</translation>
-    </message>
-    <message>
-        <location line="+48"/>
-        <source>Refund from %1</source>
-        <translation>Refund from %1</translation>
-    </message>
-    <message>
-        <location line="+40"/>
-        <source>Payment request %1 is too large (%2 bytes, allowed %3 bytes).</source>
-        <translation>Payment request %1 is too large (%2 bytes, allowed %3 bytes).</translation>
-    </message>
-    <message>
-        <location line="+6"/>
-        <source>Payment request DoS protection</source>
-        <translation>Payment request DoS protection</translation>
-    </message>
-    <message>
-        <location line="+5"/>
-        <source>Error communicating with %1: %2</source>
-        <translation>Error communicating with %1: %2</translation>
-    </message>
-    <message>
-        <location line="+18"/>
-        <source>Payment request cannot be parsed!</source>
-        <translation>Payment request cannot be parsed!</translation>
-    </message>
-    <message>
-        <location line="+9"/>
-        <source>Bad response from server %1</source>
-        <translation>Bad response from server %1</translation>
-    </message>
-    <message>
-        <location line="+20"/>
-        <source>Network request error</source>
-        <translation>Network request error</translation>
-    </message>
-    <message>
-        <location line="+11"/>
-        <source>Payment acknowledged</source>
-        <translation>Payment acknowledged</translation>
     </message>
 </context>
 <context>
@@ -3125,7 +3446,7 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation>Amount</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+835"/>
+        <location filename="../guiutil.cpp" line="+822"/>
         <source>%1 d</source>
         <translation>%1 d</translation>
     </message>
@@ -3196,7 +3517,7 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation type="unfinished">%1 GB</translation>
     </message>
     <message>
-        <location filename="../prcycoin.cpp" line="+96"/>
+        <location filename="../prcycoin.cpp" line="+95"/>
         <location line="+7"/>
         <location line="+13"/>
         <location line="+19"/>
@@ -3265,27 +3586,26 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation>&amp;Information</translation>
     </message>
     <message>
-        <location line="+25"/>
+        <location line="+22"/>
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
-        <location line="+164"/>
+        <location line="+141"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location line="-157"/>
+        <location line="-134"/>
         <source>Client name</source>
         <translation>Client name</translation>
     </message>
     <message>
-        <location line="-23"/>
-        <location line="+33"/>
+        <location line="-20"/>
+        <location line="+30"/>
         <location line="+23"/>
         <location line="+26"/>
         <location line="+26"/>
-        <location line="+23"/>
         <location line="+23"/>
         <location line="+36"/>
         <location line="+23"/>
@@ -3293,7 +3613,7 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <location line="+36"/>
         <location line="+23"/>
         <location line="+66"/>
-        <location line="+375"/>
+        <location line="+477"/>
         <location line="+23"/>
         <location line="+23"/>
         <location line="+23"/>
@@ -3310,12 +3630,14 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <location line="+23"/>
         <location line="+26"/>
         <location line="+23"/>
-        <location line="+215"/>
+        <location line="+65"/>
+        <location line="+135"/>
+        <location line="+119"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="-1119"/>
+        <location line="-1325"/>
         <source>Number of connections</source>
         <translation>Number of connections</translation>
     </message>
@@ -3350,22 +3672,17 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation>Debug log file</translation>
     </message>
     <message>
-        <location line="-258"/>
+        <location line="-235"/>
         <source>Using OpenSSL version</source>
         <translation>Using OpenSSL version</translation>
     </message>
     <message>
-        <location line="+52"/>
-        <source>Build date</source>
-        <translation>Build date</translation>
-    </message>
-    <message>
-        <location line="+141"/>
+        <location line="+170"/>
         <source>Current number of blocks</source>
         <translation>Current number of blocks</translation>
     </message>
     <message>
-        <location line="-216"/>
+        <location line="-193"/>
         <source>Client version</source>
         <translation>Client version</translation>
     </message>
@@ -3375,7 +3692,7 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation>Using BerkeleyDB version</translation>
     </message>
     <message>
-        <location line="+239"/>
+        <location line="+216"/>
         <source>Open the PRCY debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3385,7 +3702,7 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation>Number of Masternodes</translation>
     </message>
     <message>
-        <location line="+146"/>
+        <location line="+143"/>
         <source>&amp;Console</source>
         <translation>&amp;Console</translation>
     </message>
@@ -3410,12 +3727,12 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation>Totals</translation>
     </message>
     <message>
-        <location line="+15"/>
+        <location line="+64"/>
         <source>Received</source>
         <translation>Received</translation>
     </message>
     <message>
-        <location line="+24"/>
+        <location line="+80"/>
         <source>Sent</source>
         <translation>Sent</translation>
     </message>
@@ -3431,8 +3748,8 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
     </message>
     <message>
         <location line="+59"/>
-        <location filename="../rpcconsole.cpp" line="+304"/>
-        <location line="+754"/>
+        <location filename="../rpcconsole.cpp" line="+322"/>
+        <location line="+755"/>
         <source>Select a peer to view detailed information.</source>
         <translation>Select a peer to view detailed information.</translation>
     </message>
@@ -3517,47 +3834,57 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation>&amp;Wallet Repair</translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+15"/>
+        <source>The buttons below will restart the wallet with command-line options to repair the wallet, fix issues with corrupt blockhain files or missing/obsolete transactions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+36"/>
+        <source>Custom Backup Path:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+165"/>
+        <source>Custom Backups Threshold:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+44"/>
         <source>Rebuild block chain index from current blk000??.dat files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+56"/>
-        <source>The buttons below will restart the wallet with command-line options to repair the wallet, fix issues with corrupt blockchain files or missing/obsolete transactions.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+30"/>
+        <location line="-235"/>
         <source>Wallet In Use:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-14"/>
+        <location line="+39"/>
         <source>Salvage wallet</source>
         <translation>Salvage wallet</translation>
     </message>
     <message>
-        <location line="+31"/>
+        <location line="+251"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-110"/>
+        <location line="+16"/>
         <source>Rescan blockchain files</source>
         <translation>Rescan blockchain files</translation>
     </message>
     <message>
-        <location line="+146"/>
+        <location line="-234"/>
         <source>Recover transactions 1</source>
         <translation>Recover transactions 1</translation>
     </message>
     <message>
-        <location line="-16"/>
+        <location line="+14"/>
         <source>Recover transactions from blockchain (keep meta-data, e.g. account owner).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-942"/>
+        <location line="-1003"/>
         <source>Data Directory</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3567,42 +3894,42 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+848"/>
+        <location line="+1074"/>
         <source>Recover transactions 2</source>
         <translation>Recover transactions 2</translation>
     </message>
     <message>
-        <location line="+57"/>
+        <location line="+156"/>
         <source>Rescan the block chain for missing wallet transactions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
+        <location line="-142"/>
         <source>Recover transactions from blockchain (drop meta-data).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-97"/>
+        <location line="-76"/>
         <source>Upgrade wallet format</source>
         <translation>Upgrade wallet format</translation>
     </message>
     <message>
-        <location line="+130"/>
+        <location line="+96"/>
         <source>-resync:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
+        <location line="+53"/>
         <source>Delete local Blockchain Folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
+        <location line="-46"/>
         <source>Deletes all local blockchain folders so the wallet synchronizes from scratch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-514"/>
+        <location line="-526"/>
         <source>Starting Block</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3617,22 +3944,22 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+510"/>
+        <location line="+334"/>
         <source>Wallet repair options.</source>
         <translation>Wallet repair options.</translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+57"/>
         <source>Upgrade wallet to latest format on startup. (Note: this is NOT an update of the wallet itself!)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-14"/>
+        <location line="+16"/>
         <source>Rebuild index</source>
         <translation>Rebuild index</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-398"/>
+        <location filename="../rpcconsole.cpp" line="-400"/>
         <source>In:</source>
         <translation>In:</translation>
     </message>
@@ -3647,7 +3974,7 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-221"/>
+        <location line="-220"/>
         <source>&amp;Disconnect Node</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3685,7 +4012,7 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+97"/>
+        <location line="+96"/>
         <source>This will delete your local blockchain folders and the wallet will synchronize the complete Blockchain from scratch.&lt;br /&gt;&lt;br /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3863,7 +4190,17 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation type="unfinished">Copy address</translation>
     </message>
     <message>
-        <location line="+224"/>
+        <location line="+157"/>
+        <source>Invalid Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Invalid amount entered. Please enter an amount less than %1 (%2M) PRCY.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+66"/>
         <source>Enter Label</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3945,73 +4282,156 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
     <name>RevealTxDialog</name>
     <message>
         <location filename="../forms/revealtxdialog.ui" line="+14"/>
+        <location line="+6"/>
         <source>Transaction Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+14"/>
+        <source>TXID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+33"/>
         <source>Copy transaction ID to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>TxId</source>
+        <location line="+20"/>
+        <source>Address:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
+        <location line="+46"/>
+        <source>Private Key:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Amount:</source>
+        <translation type="unfinished">Amount:</translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Fee:</source>
+        <translation type="unfinished">Fee:</translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Ring Size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+46"/>
+        <source>Payment ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+41"/>
+        <source>In Block:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>Height:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+53"/>
+        <source>Hash:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-312"/>
+        <location line="+292"/>
+        <location line="+53"/>
         <source>Copy address to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Address</source>
-        <translation type="unfinished">Address</translation>
-    </message>
-    <message>
-        <location line="+30"/>
+        <location line="-299"/>
         <source>Copy transaction private key to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>PrivKey</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+30"/>
+        <location line="+46"/>
         <source>Copy Transaction Amount to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Amount</source>
-        <translation type="unfinished">Amount</translation>
-    </message>
-    <message>
-        <location line="+30"/>
+        <location line="+46"/>
         <source>Copy Transaction Fee to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Fee</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+30"/>
+        <location line="+46"/>
         <location line="+46"/>
         <source>Copy Payment ID to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-30"/>
-        <source>Ring Size</source>
+        <location filename="../revealtxdialog.cpp" line="+200"/>
+        <source>Are You Sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
-        <source>Payment ID</source>
+        <location line="+1"/>
+        <source>Are you sure you would like to delete this transaction from the local wallet?
+
+Note: They can only be restored from backup or rescan.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Potential Masternode Collateral Detected!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Potential Masternode Collateral Detected!
+Are you sure?
+
+Note: They can only be restored from backup or rescan.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+14"/>
+        <source>Invalid or non-wallet transaction id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Invalid or non-wallet transaction id.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Unable to delete transaction id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Unable to delete transaction id.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Do not show successful confirmation again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Success!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Transaction ID successfully deleted.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4188,7 +4608,37 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation type="unfinished">Copy change</translation>
     </message>
     <message>
-        <location line="+143"/>
+        <location line="+77"/>
+        <source>Send Disabled - Syncing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Sending PRCY is disabled when you are still syncing the wallet. Please allow the wallet to fully sync before attempting to send a transaction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+23"/>
+        <source>Invalid Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Invalid address entered. Please make sure you are sending to a Stealth Address.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+7"/>
+        <source>Invalid Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Invalid amount entered. Please enter an amount less than your Spendable Balance.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+28"/>
         <source>Destination</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4213,7 +4663,59 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+138"/>
+        <location line="+16"/>
+        <source>Insufficient Spendable Funds!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Insufficient spendable funds. Send with smaller amount or wait for your coins become mature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Insufficient Reserve Funds!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Insufficient reserve funds. Send with smaller amount or turn off staking mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+67"/>
+        <source>Information</source>
+        <translation type="unfinished">Information</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Consolidation transaction created!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <location line="+8"/>
+        <source>Sweeping Transaction Creation Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-7"/>
+        <location line="+8"/>
+        <source>Sweeping transaction creation failed due to an internal error. Please try again later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+10"/>
+        <source>Unable to create transaction. Please try again later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Transaction Creation Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+32"/>
         <source>View on Explorer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4228,7 +4730,7 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+142"/>
+        <location line="+148"/>
         <source>Warning: Invalid PIVX address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4309,6 +4811,16 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <location line="+85"/>
         <source>Memo:</source>
         <translation>Memo:</translation>
+    </message>
+    <message>
+        <location filename="../sendcoinsentry.cpp" line="+139"/>
+        <source>Invalid Amount</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Invalid amount entered. Please enter an amount less than %1 (%2M) PRCY.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4557,7 +5069,7 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+78"/>
+        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -4714,12 +5226,12 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <location line="+10"/>
         <location line="+45"/>
         <location line="+23"/>
-        <location line="+50"/>
+        <location line="+37"/>
         <source>Credit</source>
         <translation>Credit</translation>
     </message>
     <message numerus="yes">
-        <location line="-126"/>
+        <location line="-113"/>
         <source>matures in %n more block(s)</source>
         <translation>
             <numerusform>matures in %n more block</numerusform>
@@ -4734,12 +5246,12 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
     <message>
         <location line="+49"/>
         <location line="+22"/>
-        <location line="+50"/>
+        <location line="+37"/>
         <source>Debit</source>
         <translation>Debit</translation>
     </message>
     <message>
-        <location line="-63"/>
+        <location line="-50"/>
         <source>Total debit</source>
         <translation>Total debit</translation>
     </message>
@@ -4780,12 +5292,7 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
-        <source>Merchant</source>
-        <translation>Merchant</translation>
-    </message>
-    <message>
-        <location line="+6"/>
+        <location line="+9"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</translation>
     </message>
@@ -4921,12 +5428,12 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation>Received from</translation>
     </message>
     <message>
-        <location line="+287"/>
+        <location line="+286"/>
         <source>Confirmed Count.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-284"/>
+        <location line="-283"/>
         <source>Sent to</source>
         <translation>Sent to</translation>
     </message>
@@ -4951,7 +5458,7 @@ https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source
         <translation>Mined</translation>
     </message>
     <message>
-        <location line="+35"/>
+        <location line="+34"/>
         <source>watch-only</source>
         <translation>watch-only</translation>
     </message>
@@ -5393,9 +5900,48 @@ Please try again.</source>
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+345"/>
+        <location filename="../walletmodel.cpp" line="+332"/>
         <source>Send Coins</source>
         <translation>Send Coins</translation>
+    </message>
+    <message>
+        <location line="+35"/>
+        <location line="+25"/>
+        <location line="+27"/>
+        <source>Mnemonic Recovery Phrase</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-51"/>
+        <location line="+25"/>
+        <source>Attempt to view Mnemonic Phrase failed or canceled. Wallet locked for security.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-13"/>
+        <source>Are You Sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Are you sure you would like to view your Mnemonic Phrase?
+You will be required to enter your passphrase. Failed or canceled attempts will be logged.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+34"/>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Below is your Mnemonic Recovery Phrase, consisting of 24 seed words. Please copy/write these words down in order. We strongly recommend keeping multiple copies in different locations.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5479,12 +6025,12 @@ Please try again.</source>
         <translation type="unfinished">Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+6"/>
         <source>Distributed under the MIT software license, see the accompanying file COPYING or &lt;http://www.opensource.org/licenses/mit-license.php&gt;.</source>
         <translation type="unfinished">Distributed under the MIT software license, see the accompanying file COPYING or &lt;http://www.opensource.org/licenses/mit-license.php&gt;.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+7"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished">Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</translation>
     </message>
@@ -5559,12 +6105,12 @@ Please try again.</source>
         <translation type="unfinished">Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+6"/>
         <source>Maximum size of data in data carrier transactions we relay and mine (default: %u)</source>
         <translation type="unfinished">Maximum size of data in data carrier transactions we relay and mine (default: %u)</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <location line="+5"/>
         <source>Maximum total fees to use in a single wallet transaction, setting too low may abort large transactions (default: %s)</source>
         <translation type="unfinished">Maximum total fees to use in a single wallet transaction, setting too low may abort large transactions (default: %s)</translation>
     </message>
@@ -5645,16 +6191,16 @@ Please try again.</source>
     </message>
     <message>
         <location line="+2"/>
-        <source>Unable to locate enough funds for this transaction that are not equal 10000 PRCY.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)</source>
         <translation type="unfinished">Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)</translation>
     </message>
     <message>
         <location line="+3"/>
+        <source>Username and hashed password for JSON-RPC connections. The field &lt;userpw&gt; comes in the format: &lt;USERNAME&gt;:&lt;SALT&gt;$&lt;HASH&gt;. A canonical python script is included in share/rpcuser. This option can be specified multiple times</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Warning: -maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
         <translation type="unfinished">Warning: -maxtxfee is set very high! Fees this large could be paid on a single transaction.</translation>
     </message>
@@ -5844,6 +6390,11 @@ Please try again.</source>
         <translation type="unfinished">Done loading</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>Enable Old Transaction Deletion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+2"/>
         <source>Enable publish hash transaction (locked via SwiftX) in &lt;address&gt;</source>
         <translation type="unfinished"></translation>
@@ -5895,11 +6446,6 @@ Please try again.</source>
     </message>
     <message>
         <location line="+1"/>
-        <source>Error recovering public key.</source>
-        <translation type="unfinished">Error recovering public key.</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>
@@ -5919,17 +6465,17 @@ Please try again.</source>
         <translation type="unfinished">Error: Unsupported argument -tor found, use -onion.</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+1"/>
+        <source>Failed to generate RingCT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished">Failed to listen on any port. Use -listen=0 if you want this.</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Failed to read block</source>
-        <translation type="unfinished">Failed to read block</translation>
-    </message>
-    <message>
-        <location line="+2"/>
+        <location line="+3"/>
         <source>Force safe mode (default: %u)</source>
         <translation type="unfinished">Force safe mode (default: %u)</translation>
     </message>
@@ -6009,27 +6555,22 @@ Please try again.</source>
         <translation type="unfinished">Invalid netmask specified in -whitelist: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Invalid private key.</source>
-        <translation type="unfinished">Invalid private key.</translation>
-    </message>
-    <message>
-        <location line="+35"/>
+        <location line="+39"/>
         <source>Reindex the %s money supply statistics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
+        <location line="+30"/>
         <source>SwiftX options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-228"/>
+        <location line="-226"/>
         <source>This is a pre-release test build - use at your own risk - do not use for staking or merchant applications!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-146"/>
+        <location line="-156"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect/-noconnect)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6039,8 +6580,18 @@ Please try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
+        <location line="+12"/>
+        <source>Delete transaction every &lt;n&gt; blocks during inital block download (default: %i)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
         <source>Enable SwiftX, show confirmations for locked transactions (bool, default: %s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Enable or disable staking functionality for PRCY inputs (0-1, default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6064,7 +6615,17 @@ Please try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
+        <location line="+25"/>
+        <source>Maximum average size of an index occurrence in the block spam filter (default: %u)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+6"/>
+        <source>Maximum size of the list of indexes in the block spam filter (default: %u)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+9"/>
         <source>Query for peer addresses via DNS lookup, if low on addresses (default: 1 unless -connect/-noconnect)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6084,7 +6645,7 @@ Please try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+45"/>
         <source>You have attempted to send more than 50 UTXOs in a single transaction. To work around this limitation, please either lower the total amount of the transaction or send two separate transactions with 50% of your total desired amount.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6189,7 +6750,7 @@ Please try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="+5"/>
         <source>Enable publish hash block in &lt;address&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6229,7 +6790,7 @@ Please try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
+        <location line="+4"/>
         <source>Error: -listen must be true if -masternode is set.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6244,17 +6805,7 @@ Please try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Failed to generate RingCT for Sweeping transaction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Failed to generate bulletproof for Sweeping transaction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+3"/>
         <source>Failed to generate bulletproof</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6264,7 +6815,7 @@ Please try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Fee (in %s/kB) to add to transactions you send (default: %s)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6294,17 +6845,12 @@ Please try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
+        <location line="+1"/>
         <source>Keep at most &lt;n&gt; unconnectable transactions in memory (default: %u)</source>
         <translation type="unfinished">Keep at most &lt;n&gt; unconnectable transactions in memory (default: %u)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Limit size of signature cache to &lt;n&gt; entries (default: %u)</source>
-        <translation type="unfinished">Limit size of signature cache to &lt;n&gt; entries (default: %u)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
+        <location line="+4"/>
         <source>Line: %d</source>
         <translation type="unfinished">Line: %d</translation>
     </message>
@@ -6404,7 +6950,7 @@ Please try again.</source>
         <translation type="unfinished">Number of automatic wallet backups (default: 10)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: %u)</source>
         <translation type="unfinished">Only accept block chain matching built-in checkpoints (default: %u)</translation>
     </message>
@@ -6500,11 +7046,6 @@ Please try again.</source>
     </message>
     <message>
         <location line="+1"/>
-        <source>Session timed out.</source>
-        <translation type="unfinished">Session timed out.</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished">Set database cache size in megabytes (%d to %d, default: %d)</translation>
     </message>
@@ -6559,17 +7100,27 @@ Please try again.</source>
         <translation type="unfinished">Shrink debug.log file on client startup (default: 1 when no -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Signing failed.</source>
-        <translation type="unfinished">Signing failed.</translation>
+        <location line="-54"/>
+        <source>Keep the last &lt;n&gt; transactions (default: %i)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>Signing timed out.</source>
-        <translation type="unfinished">Signing timed out.</translation>
+        <source>Keep transactions for at least &lt;n&gt; blocks (default: %i)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+1"/>
+        <source>Limit size of signature cache to &lt;n&gt; MiB (default: %u)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+21"/>
+        <source>Number of custom location backups to retain (default: %d)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+32"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished">Signing transaction failed</translation>
     </message>
@@ -6746,6 +7297,11 @@ Please try again.</source>
     <message>
         <location line="+1"/>
         <source>Use a custom max chain reorganization depth (default: %u)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Use block spam filter (default: %u)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qt/locale/prcycoin_en.xlf
+++ b/src/qt/locale/prcycoin_en.xlf
@@ -1,0 +1,7591 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:trolltech="urn:trolltech:names:ts:document:1.0">
+  <file original="../forms/addressbookpage.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="AddressBookPage">
+      <trans-unit id="_msg1" approved="yes">
+        <source xml:space="preserve">Right-click to edit address or label</source>
+        <target xml:space="preserve">Right-click to edit address or label</target>
+        <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg2" approved="yes">
+        <source xml:space="preserve">Create a new address</source>
+        <target xml:space="preserve">Create a new address</target>
+        <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg3" approved="yes">
+        <source xml:space="preserve">&amp;New</source>
+        <target xml:space="preserve">&amp;New</target>
+        <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg4" approved="yes">
+        <source xml:space="preserve">Copy the currently selected address to the system clipboard</source>
+        <target xml:space="preserve">Copy the currently selected address to the system clipboard</target>
+        <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg5" approved="yes">
+        <source xml:space="preserve">&amp;Copy</source>
+        <target xml:space="preserve">&amp;Copy</target>
+        <context-group purpose="location"><context context-type="linenumber">114</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg6" approved="yes">
+        <source xml:space="preserve">Delete the currently selected address from the list</source>
+        <target xml:space="preserve">Delete the currently selected address from the list</target>
+        <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg7" approved="yes">
+        <source xml:space="preserve">&amp;Delete</source>
+        <target xml:space="preserve">&amp;Delete</target>
+        <context-group purpose="location"><context context-type="linenumber">131</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg8" approved="yes">
+        <source xml:space="preserve">Export the data in the current tab to a file</source>
+        <target xml:space="preserve">Export the data in the current tab to a file</target>
+        <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg9" approved="yes">
+        <source xml:space="preserve">&amp;Export</source>
+        <target xml:space="preserve">&amp;Export</target>
+        <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg10" approved="yes">
+        <source xml:space="preserve">C&amp;lose</source>
+        <target xml:space="preserve">C&amp;lose</target>
+        <context-group purpose="location"><context context-type="linenumber">181</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../addressbookpage.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="AddressBookPage">
+      <trans-unit id="_msg11" approved="yes">
+        <source xml:space="preserve">Choose the address to send coins to</source>
+        <target xml:space="preserve">Choose the address to send coins to</target>
+        <context-group purpose="location"><context context-type="linenumber">44</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg12" approved="yes">
+        <source xml:space="preserve">Choose the address to receive coins with</source>
+        <target xml:space="preserve">Choose the address to receive coins with</target>
+        <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg13" approved="yes">
+        <source xml:space="preserve">C&amp;hoose</source>
+        <target xml:space="preserve">C&amp;hoose</target>
+        <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg14" approved="yes">
+        <source xml:space="preserve">Sending addresses</source>
+        <target xml:space="preserve">Sending addresses</target>
+        <context-group purpose="location"><context context-type="linenumber">59</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg15" approved="yes">
+        <source xml:space="preserve">Receiving addresses</source>
+        <target xml:space="preserve">Receiving addresses</target>
+        <context-group purpose="location"><context context-type="linenumber">62</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg16">
+        <source xml:space="preserve">These are your PRCY addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg17">
+        <source xml:space="preserve">These are your PRCY addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg18" approved="yes">
+        <source xml:space="preserve">&amp;Copy Address</source>
+        <target xml:space="preserve">&amp;Copy Address</target>
+        <context-group purpose="location"><context context-type="linenumber">79</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg19" approved="yes">
+        <source xml:space="preserve">Copy &amp;Label</source>
+        <target xml:space="preserve">Copy &amp;Label</target>
+        <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg20" approved="yes">
+        <source xml:space="preserve">&amp;Edit</source>
+        <target xml:space="preserve">&amp;Edit</target>
+        <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg21" approved="yes">
+        <source xml:space="preserve">Export Address List</source>
+        <target xml:space="preserve">Export Address List</target>
+        <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg22" approved="yes">
+        <source xml:space="preserve">Comma separated file (*.csv)</source>
+        <target xml:space="preserve">Comma separated file (*.csv)</target>
+        <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg23" approved="yes">
+        <source xml:space="preserve">Exporting Failed</source>
+        <target xml:space="preserve">Exporting Failed</target>
+        <context-group purpose="location"><context context-type="linenumber">277</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg24">
+        <source xml:space="preserve">There was an error trying to save the address list to %1. Please try again.</source>
+        <target xml:space="preserve" state="needs-review-translation">There was an error trying to save the address list to %1. Please try again.</target>
+        <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
+        <context-group><context context-type="x-gettext-msgctxt">An error message.</context></context-group>
+        <note annotates="source" from="developer">%1 is a name of the file (e.g., &quot;addrbook.csv&quot;) that the bitcoin addresses were exported to.</note>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../addresstablemodel.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="AddressTableModel">
+      <trans-unit id="_msg25" approved="yes">
+        <source xml:space="preserve">Label</source>
+        <target xml:space="preserve">Label</target>
+        <context-group purpose="location"><context context-type="linenumber">169</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg26" approved="yes">
+        <source xml:space="preserve">Address</source>
+        <target xml:space="preserve">Address</target>
+        <context-group purpose="location"><context context-type="linenumber">169</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg27" approved="yes">
+        <source xml:space="preserve">(no label)</source>
+        <target xml:space="preserve">(no label)</target>
+        <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/askpassphrasedialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="AskPassphraseDialog">
+      <trans-unit id="_msg28" approved="yes">
+        <source xml:space="preserve">Passphrase Dialog</source>
+        <target xml:space="preserve">Passphrase Dialog</target>
+        <context-group purpose="location"><context context-type="linenumber">26</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg29" approved="yes">
+        <source xml:space="preserve">Enter passphrase</source>
+        <target xml:space="preserve">Enter passphrase</target>
+        <context-group purpose="location"><context context-type="linenumber">56</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg30" approved="yes">
+        <source xml:space="preserve">New passphrase</source>
+        <target xml:space="preserve">New passphrase</target>
+        <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg31" approved="yes">
+        <source xml:space="preserve">Repeat new passphrase</source>
+        <target xml:space="preserve">Repeat new passphrase</target>
+        <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg32" approved="yes">
+        <source xml:space="preserve">Serves to disable the trivial sendmoney when OS account compromised. Provides no real security.</source>
+        <target xml:space="preserve">Serves to disable the trivial sendmoney when OS account compromised. Provides no real security.</target>
+        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg33">
+        <source xml:space="preserve">For staking only</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg34">
+        <source xml:space="preserve">Show passphrase</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">130</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../askpassphrasedialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="AskPassphraseDialog">
+      <trans-unit id="_msg35" approved="yes">
+        <source xml:space="preserve">Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
+        <target xml:space="preserve">Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</target>
+        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg36" approved="yes">
+        <source xml:space="preserve">This operation needs your wallet passphrase to decrypt the wallet.</source>
+        <target xml:space="preserve">This operation needs your wallet passphrase to decrypt the wallet.</target>
+        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg37" approved="yes">
+        <source xml:space="preserve">Enter the old and new passphrase to the wallet.</source>
+        <target xml:space="preserve">Enter the old and new passphrase to the wallet.</target>
+        <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg38">
+        <source xml:space="preserve">Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR COINS&lt;/b&gt;!</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg39">
+        <source xml:space="preserve">PRCY will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your PRCYs from being stolen by malware infecting your computer.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg40" approved="yes">
+        <source xml:space="preserve">Are you sure you wish to encrypt your wallet?</source>
+        <target xml:space="preserve">Are you sure you wish to encrypt your wallet?</target>
+        <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg41">
+        <source xml:space="preserve">Encrypt Wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg42">
+        <source xml:space="preserve">This operation needs your wallet passphrase to unlock the wallet.&lt;br/&gt;&lt;br/&gt;(Wallet may appear not responding as it rescans for all transactions)&lt;br/&gt;&lt;br/&gt;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">55</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg43">
+        <source xml:space="preserve">Unlock Wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg44">
+        <source xml:space="preserve">Decrypt Wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg45">
+        <source xml:space="preserve">Change Passphrase</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg46">
+        <source xml:space="preserve">Confirm Wallet Encryption</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg47">
+        <source xml:space="preserve">Wallet Encrypted</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">133</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg48" approved="yes">
+        <source xml:space="preserve">IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <target xml:space="preserve">IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</target>
+        <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg49">
+        <source xml:space="preserve">Wallet Encryption Failed</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">199</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg50">
+        <source xml:space="preserve">Wallet encryption failed due to an internal error. Your wallet was not encrypted. Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg51">
+        <source xml:space="preserve">The supplied passphrases do not match. Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">155</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">200</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg52">
+        <source xml:space="preserve">Wallet Unlock Failed</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg53">
+        <source xml:space="preserve">The passphrase entered for the wallet unlock was incorrect. Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg54">
+        <source xml:space="preserve">Wallet Decryption Failed</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg55">
+        <source xml:space="preserve">The passphrase entered for the wallet decryption was incorrect. Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">177</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">194</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg56">
+        <source xml:space="preserve">Passphrase Change Successful</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg57">
+        <source xml:space="preserve">Wallet passphrase was successfully changed.
+Please remember your passphrase as there is no way to recover it.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">188</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg58" approved="yes">
+        <source xml:space="preserve">Warning: The Caps Lock key is on!</source>
+        <target xml:space="preserve">Warning: The Caps Lock key is on!</target>
+        <context-group purpose="location"><context context-type="linenumber">236</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../bantablemodel.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="BanTableModel">
+      <trans-unit id="_msg59">
+        <source xml:space="preserve">IP/Netmask</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg60">
+        <source xml:space="preserve">Banned Until</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/bip38tooldialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="Bip38ToolDialog">
+      <trans-unit id="_msg61">
+        <source xml:space="preserve">BIP 38 Tool</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg62">
+        <source xml:space="preserve">&amp;BIP 38 Encrypt</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg63">
+        <source xml:space="preserve">Address:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">457</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg64">
+        <source xml:space="preserve">Enter a PRCY Address that you would like to encrypt using BIP 38. Enter a passphrase in the middle box. Press encrypt to compute the encrypted private key.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg65">
+        <source xml:space="preserve">The PRCY address to encrypt</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg66">
+        <source xml:space="preserve">Choose previously used address</source>
+        <target xml:space="preserve" state="needs-review-translation">Choose previously used address</target>
+        <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg67">
+        <source xml:space="preserve">Alt+A</source>
+        <target xml:space="preserve" state="needs-review-translation">Alt+A</target>
+        <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg68">
+        <source xml:space="preserve">Paste address from clipboard</source>
+        <target xml:space="preserve" state="needs-review-translation">Paste address from clipboard</target>
+        <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">308</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg69">
+        <source xml:space="preserve">Alt+P</source>
+        <target xml:space="preserve" state="needs-review-translation">Alt+P</target>
+        <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg70">
+        <source xml:space="preserve">Passphrase: </source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">118</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg71">
+        <source xml:space="preserve">Encrypted Key:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg72">
+        <source xml:space="preserve">Copy the current signature to the system clipboard</source>
+        <target xml:space="preserve" state="needs-review-translation">Copy the current signature to the system clipboard</target>
+        <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg73">
+        <source xml:space="preserve">Encrypt the private key for this PRCY address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">185</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg74">
+        <source xml:space="preserve">Reset all fields</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg75">
+        <source xml:space="preserve">The encrypted private key</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg76">
+        <source xml:space="preserve">Decrypt the entered key using the passphrase</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg77">
+        <source xml:space="preserve">Encrypt &amp;Key</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">188</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg78">
+        <source xml:space="preserve">Clear &amp;All</source>
+        <target xml:space="preserve" state="needs-review-translation">Clear &amp;All</target>
+        <context-group purpose="location"><context context-type="linenumber">205</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg79">
+        <source xml:space="preserve">&amp;BIP 38 Decrypt</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg80">
+        <source xml:space="preserve">Enter the BIP 38 encrypted private key. Enter the passphrase in the middle box. Click Decrypt Key to compute the private key. After the key is decrypted, clicking &apos;Import Address&apos; will add this private key to the wallet.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">270</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg81">
+        <source xml:space="preserve">Decrypt &amp;Key</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">359</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg82">
+        <source xml:space="preserve">Decrypted Key:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">436</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg83">
+        <source xml:space="preserve">Import Address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">450</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../bip38tooldialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="Bip38ToolDialog">
+      <trans-unit id="_msg84">
+        <source xml:space="preserve">Click &quot;Decrypt Key&quot; to compute key</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg85">
+        <source xml:space="preserve">The entered passphrase is invalid. </source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">121</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg86">
+        <source xml:space="preserve">Allowed: 0-9,a-z,A-Z,</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">121</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg87">
+        <source xml:space="preserve">The entered address is invalid.</source>
+        <target xml:space="preserve" state="needs-review-translation">The entered address is invalid.</target>
+        <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg88">
+        <source xml:space="preserve">Please check the address and try again.</source>
+        <target xml:space="preserve" state="needs-review-translation">Please check the address and try again.</target>
+        <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg89">
+        <source xml:space="preserve">The entered address does not refer to a key.</source>
+        <target xml:space="preserve" state="needs-review-translation">The entered address does not refer to a key.</target>
+        <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg90">
+        <source xml:space="preserve">Wallet unlock was cancelled.</source>
+        <target xml:space="preserve" state="needs-review-translation">Wallet unlock was cancelled.</target>
+        <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">206</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg91">
+        <source xml:space="preserve">Private key for the entered address is not available.</source>
+        <target xml:space="preserve" state="needs-review-translation">Private key for the entered address is not available.</target>
+        <context-group purpose="location"><context context-type="linenumber">150</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg92">
+        <source xml:space="preserve">Failed to decrypt.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">189</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg93">
+        <source xml:space="preserve">Please check the key and passphrase and try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">189</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg94">
+        <source xml:space="preserve">Data Not Valid.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg95">
+        <source xml:space="preserve">Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg96">
+        <source xml:space="preserve">Please wait while key is imported</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg97">
+        <source xml:space="preserve">Key Already Held By Wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">230</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg98">
+        <source xml:space="preserve">Error Adding Key To Wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg99">
+        <source xml:space="preserve">Successfully Added Private Key To Wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../bitcoingui.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="BitcoinGUI">
+      <trans-unit id="_msg100" approved="yes">
+        <source xml:space="preserve">Node</source>
+        <target xml:space="preserve">Node</target>
+        <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg101" approved="yes">
+        <source xml:space="preserve">&amp;Overview</source>
+        <target xml:space="preserve">&amp;Overview</target>
+        <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg102" approved="yes">
+        <source xml:space="preserve">&amp;Send</source>
+        <target xml:space="preserve">&amp;Send</target>
+        <context-group purpose="location"><context context-type="linenumber">293</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg103" approved="yes">
+        <source xml:space="preserve">&amp;Receive</source>
+        <target xml:space="preserve">&amp;Receive</target>
+        <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg104" approved="yes">
+        <source xml:space="preserve">E&amp;xit</source>
+        <target xml:space="preserve">E&amp;xit</target>
+        <context-group purpose="location"><context context-type="linenumber">355</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg105" approved="yes">
+        <source xml:space="preserve">Quit application</source>
+        <target xml:space="preserve">Quit application</target>
+        <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg106" approved="yes">
+        <source xml:space="preserve">About &amp;Qt</source>
+        <target xml:space="preserve">About &amp;Qt</target>
+        <context-group purpose="location"><context context-type="linenumber">362</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg107" approved="yes">
+        <source xml:space="preserve">Show information about Qt</source>
+        <target xml:space="preserve">Show information about Qt</target>
+        <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg108" approved="yes">
+        <source xml:space="preserve">&amp;Show / Hide</source>
+        <target xml:space="preserve">&amp;Show / Hide</target>
+        <context-group purpose="location"><context context-type="linenumber">396</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg109" approved="yes">
+        <source xml:space="preserve">Show or hide the main Window</source>
+        <target xml:space="preserve">Show or hide the main Window</target>
+        <context-group purpose="location"><context context-type="linenumber">397</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg110" approved="yes">
+        <source xml:space="preserve">&amp;Encrypt Wallet...</source>
+        <target xml:space="preserve">&amp;Encrypt Wallet...</target>
+        <context-group purpose="location"><context context-type="linenumber">399</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg111" approved="yes">
+        <source xml:space="preserve">Encrypt the private keys that belong to your wallet</source>
+        <target xml:space="preserve">Encrypt the private keys that belong to your wallet</target>
+        <context-group purpose="location"><context context-type="linenumber">400</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg112" approved="yes">
+        <source xml:space="preserve">&amp;Backup Wallet...</source>
+        <target xml:space="preserve">&amp;Backup Wallet...</target>
+        <context-group purpose="location"><context context-type="linenumber">402</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg113" approved="yes">
+        <source xml:space="preserve">Backup wallet to another location</source>
+        <target xml:space="preserve">Backup wallet to another location</target>
+        <context-group purpose="location"><context context-type="linenumber">403</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg114" approved="yes">
+        <source xml:space="preserve">&amp;Change Passphrase...</source>
+        <target xml:space="preserve">&amp;Change Passphrase...</target>
+        <context-group purpose="location"><context context-type="linenumber">406</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg115" approved="yes">
+        <source xml:space="preserve">Change the passphrase used for wallet encryption</source>
+        <target xml:space="preserve">Change the passphrase used for wallet encryption</target>
+        <context-group purpose="location"><context context-type="linenumber">407</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg116" approved="yes">
+        <source xml:space="preserve">&amp;Unlock Wallet...</source>
+        <target xml:space="preserve">&amp;Unlock Wallet...</target>
+        <context-group purpose="location"><context context-type="linenumber">408</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg117" approved="yes">
+        <source xml:space="preserve">Unlock wallet</source>
+        <target xml:space="preserve">Unlock wallet</target>
+        <context-group purpose="location"><context context-type="linenumber">409</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg118" approved="yes">
+        <source xml:space="preserve">&amp;Lock Wallet</source>
+        <target xml:space="preserve">&amp;Lock Wallet</target>
+        <context-group purpose="location"><context context-type="linenumber">410</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg119" approved="yes">
+        <source xml:space="preserve">&amp;Information</source>
+        <target xml:space="preserve">&amp;Information</target>
+        <context-group purpose="location"><context context-type="linenumber">415</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg120" approved="yes">
+        <source xml:space="preserve">Show diagnostic information</source>
+        <target xml:space="preserve">Show diagnostic information</target>
+        <context-group purpose="location"><context context-type="linenumber">416</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg121" approved="yes">
+        <source xml:space="preserve">Open debugging console</source>
+        <target xml:space="preserve">Open debugging console</target>
+        <context-group purpose="location"><context context-type="linenumber">418</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg122" approved="yes">
+        <source xml:space="preserve">&amp;Network Monitor</source>
+        <target xml:space="preserve">&amp;Network Monitor</target>
+        <context-group purpose="location"><context context-type="linenumber">420</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg123" approved="yes">
+        <source xml:space="preserve">Show network monitor</source>
+        <target xml:space="preserve">Show network monitor</target>
+        <context-group purpose="location"><context context-type="linenumber">421</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg124" approved="yes">
+        <source xml:space="preserve">Show peers info</source>
+        <target xml:space="preserve">Show peers info</target>
+        <context-group purpose="location"><context context-type="linenumber">423</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg125" approved="yes">
+        <source xml:space="preserve">Wallet &amp;Repair</source>
+        <target xml:space="preserve">Wallet &amp;Repair</target>
+        <context-group purpose="location"><context context-type="linenumber">424</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg126" approved="yes">
+        <source xml:space="preserve">Show wallet repair options</source>
+        <target xml:space="preserve">Show wallet repair options</target>
+        <context-group purpose="location"><context context-type="linenumber">425</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg127" approved="yes">
+        <source xml:space="preserve">Open configuration file</source>
+        <target xml:space="preserve">Open configuration file</target>
+        <context-group purpose="location"><context context-type="linenumber">427</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg128">
+        <source xml:space="preserve">Show &amp;PRCYcoin Folder</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">432</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg129">
+        <source xml:space="preserve">Show the PRCYcoin folder</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">433</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg130">
+        <source xml:space="preserve">Show &amp;Qt Folder</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">435</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg131">
+        <source xml:space="preserve">Show the Qt folder</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">436</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg132" approved="yes">
+        <source xml:space="preserve">Show Automatic &amp;Backups</source>
+        <target xml:space="preserve">Show Automatic &amp;Backups</target>
+        <context-group purpose="location"><context context-type="linenumber">438</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg133" approved="yes">
+        <source xml:space="preserve">Show automatically created wallet backups</source>
+        <target xml:space="preserve">Show automatically created wallet backups</target>
+        <context-group purpose="location"><context context-type="linenumber">439</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg134" approved="yes">
+        <source xml:space="preserve">&amp;Sending addresses...</source>
+        <target xml:space="preserve">&amp;Sending addresses...</target>
+        <context-group purpose="location"><context context-type="linenumber">441</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg135" approved="yes">
+        <source xml:space="preserve">Show the list of used sending addresses and labels</source>
+        <target xml:space="preserve">Show the list of used sending addresses and labels</target>
+        <context-group purpose="location"><context context-type="linenumber">442</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg136" approved="yes">
+        <source xml:space="preserve">&amp;Receiving addresses...</source>
+        <target xml:space="preserve">&amp;Receiving addresses...</target>
+        <context-group purpose="location"><context context-type="linenumber">443</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg137" approved="yes">
+        <source xml:space="preserve">Show the list of used receiving addresses and labels</source>
+        <target xml:space="preserve">Show the list of used receiving addresses and labels</target>
+        <context-group purpose="location"><context context-type="linenumber">444</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg138" approved="yes">
+        <source xml:space="preserve">Open &amp;URI...</source>
+        <target xml:space="preserve">Open &amp;URI...</target>
+        <context-group purpose="location"><context context-type="linenumber">446</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg139">
+        <source xml:space="preserve">&amp;Knowledge Base</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">475</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg140">
+        <source xml:space="preserve">Knowledge Base</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">476</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg141">
+        <source xml:space="preserve">&amp;GitHub Wiki</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">477</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg142">
+        <source xml:space="preserve">GitHub Wiki</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">478</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg143">
+        <source xml:space="preserve">&amp;Blockchain Explorer API</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">479</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg144">
+        <source xml:space="preserve">Blockchain Explorer API</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">480</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg145">
+        <source xml:space="preserve">&amp;Bridge</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">483</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg146">
+        <source xml:space="preserve">Bridge Link</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">484</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg147">
+        <source xml:space="preserve">&amp;PRivaCY DEX</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">485</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg148">
+        <source xml:space="preserve">PRivaCY Dex Link</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">486</context></context-group>
+      </trans-unit>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">1130</context></context-group>
+        <trans-unit id="_msg149[0]">
+          <source xml:space="preserve">%n Active Connections</source>
+          <target xml:space="preserve"></target>
+        </trans-unit>
+        <trans-unit id="_msg149[1]">
+          <source xml:space="preserve">%n Active Connections</source>
+          <target xml:space="preserve"></target>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">1149</context></context-group>
+        <trans-unit id="_msg150[0]" approved="yes">
+          <source xml:space="preserve">Processed %n blocks of transaction history.</source>
+          <target xml:space="preserve">Processed %n block of transaction history.</target>
+        </trans-unit>
+        <trans-unit id="_msg150[1]" approved="yes">
+          <source xml:space="preserve">Processed %n blocks of transaction history.</source>
+          <target xml:space="preserve">Processed %n blocks of transaction history.</target>
+        </trans-unit>
+      </group>
+      <trans-unit id="_msg151">
+        <source xml:space="preserve">Date: %1
+Amount: %2
+Type: %3
+Address: %4
+Confirmations: %5
+</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1321</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg152">
+        <source xml:space="preserve">Staking Disabled</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1370</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg153">
+        <source xml:space="preserve">Staking Enabled</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1397</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg154">
+        <source xml:space="preserve">Enabling Staking...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1407</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg155">
+        <source xml:space="preserve">Disabling Staking...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1411</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg156" approved="yes">
+        <source xml:space="preserve">&amp;File</source>
+        <target xml:space="preserve">&amp;File</target>
+        <context-group purpose="location"><context context-type="linenumber">551</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg157" approved="yes">
+        <source xml:space="preserve">&amp;Settings</source>
+        <target xml:space="preserve">&amp;Settings</target>
+        <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg158">
+        <source xml:space="preserve">PRivaCY Coin</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg159">
+        <source xml:space="preserve">Wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">135</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg160">
+        <source xml:space="preserve">&amp;History</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg161">
+        <source xml:space="preserve">Masternodes</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg162">
+        <source xml:space="preserve">Modify settings</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg163">
+        <source xml:space="preserve">&amp;Staking</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">379</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg164">
+        <source xml:space="preserve">Staking Status</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg165">
+        <source xml:space="preserve">&amp;Network</source>
+        <target xml:space="preserve" state="needs-review-translation">&amp;Network</target>
+        <context-group purpose="location"><context context-type="linenumber">386</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg166">
+        <source xml:space="preserve">&amp;Debug Console</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">417</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg167">
+        <source xml:space="preserve">&amp;Peers List</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">422</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg168">
+        <source xml:space="preserve">&amp;Blockchain Explorer</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">448</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg169" approved="yes">
+        <source xml:space="preserve">&amp;Tools</source>
+        <target xml:space="preserve">&amp;Tools</target>
+        <context-group purpose="location"><context context-type="linenumber">579</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg170" approved="yes">
+        <source xml:space="preserve">&amp;Help</source>
+        <target xml:space="preserve">&amp;Help</target>
+        <context-group purpose="location"><context context-type="linenumber">605</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg171">
+        <source xml:space="preserve">PRCY</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1230</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg172">
+        <source xml:space="preserve">&amp;Masternodes</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg173">
+        <source xml:space="preserve"> - Lite Mode</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg174">
+        <source xml:space="preserve">&amp;About PRCY</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">359</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg175">
+        <source xml:space="preserve">Show information about PRCY</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">360</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg176">
+        <source xml:space="preserve">&amp;Show Seed Phrase</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">404</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg177">
+        <source xml:space="preserve">Show 24 word wallet seed phrase</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">405</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg178">
+        <source xml:space="preserve">&amp;MultiSend</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">411</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg179">
+        <source xml:space="preserve">MultiSend Settings</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">412</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg180">
+        <source xml:space="preserve">Open Wallet &amp;Configuration File</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">426</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg181">
+        <source xml:space="preserve">Open &amp;Masternode Configuration File</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">429</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg182">
+        <source xml:space="preserve">Open Masternode configuration file</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">430</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg183">
+        <source xml:space="preserve">Open a PRCY: URI or payment request</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">447</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg184">
+        <source xml:space="preserve">Block explorer window</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">449</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg185">
+        <source xml:space="preserve">Facebook</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">451</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg186">
+        <source xml:space="preserve">PRCY Facebook</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">452</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg187">
+        <source xml:space="preserve">Twitter</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">453</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg188">
+        <source xml:space="preserve">PRCY Twitter</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">454</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg189">
+        <source xml:space="preserve">Discord</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">455</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg190">
+        <source xml:space="preserve">PRCY Discord</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">456</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg191">
+        <source xml:space="preserve">Telegram - Main</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">457</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg192">
+        <source xml:space="preserve">PRCY Telegram - Main</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">458</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg193">
+        <source xml:space="preserve">Telegram - Lounge</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">459</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg194">
+        <source xml:space="preserve">PRCY Telegram - Lounge</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">460</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg195">
+        <source xml:space="preserve">Medium</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">461</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg196">
+        <source xml:space="preserve">PRCY Medium</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">462</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg197">
+        <source xml:space="preserve">Steemit</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">463</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg198">
+        <source xml:space="preserve">PRCY Steemit</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">464</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg199">
+        <source xml:space="preserve">Instagram</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">465</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg200">
+        <source xml:space="preserve">PRCY Instagram</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">466</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg201">
+        <source xml:space="preserve">Reddit</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">467</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg202">
+        <source xml:space="preserve">PRCY Reddit</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">468</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg203">
+        <source xml:space="preserve">&amp;Command-line Options</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">470</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg204">
+        <source xml:space="preserve">Show the PRCY help message to get a list with possible PRCY command-line options</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">472</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg205">
+        <source xml:space="preserve">&amp;BootStrap</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">481</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg206">
+        <source xml:space="preserve">BootStrap Link</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">482</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg207">
+        <source xml:space="preserve">&amp;PRCY Toolkit</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">487</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg208">
+        <source xml:space="preserve">PRCY Toolkit Link</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">488</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg209">
+        <source xml:space="preserve">&amp;Telegram Tech Support</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">489</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg210">
+        <source xml:space="preserve">Telegram Tech Support</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">490</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg211">
+        <source xml:space="preserve">&amp;Telegram Masternode Support</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">491</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg212">
+        <source xml:space="preserve">Telegram Masternode Support</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">492</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg213">
+        <source xml:space="preserve">&amp;Discord Tech Support</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">493</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg214">
+        <source xml:space="preserve">Discord Tech Support</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">494</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg215">
+        <source xml:space="preserve">&amp;Check For Updates</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">495</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg216">
+        <source xml:space="preserve">Check For Updates</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">496</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg217">
+        <source xml:space="preserve">Social</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">594</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg218">
+        <source xml:space="preserve">PRCY client</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">794</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg219">
+        <source xml:space="preserve">No Update Available</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1017</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg220">
+        <source xml:space="preserve">No update available.
+
+Your wallet is up to date.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1018</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg221">
+        <source xml:space="preserve">Error checking for updates.
+
+</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1027</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg222" approved="yes">
+        <source xml:space="preserve">Up to date</source>
+        <target xml:space="preserve">Up to date</target>
+        <context-group purpose="location"><context context-type="linenumber">1155</context></context-group>
+      </trans-unit>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">1185</context></context-group>
+        <trans-unit id="_msg223[0]" approved="yes">
+          <source xml:space="preserve">%n hour(s)</source>
+          <target xml:space="preserve">%n hour</target>
+        </trans-unit>
+        <trans-unit id="_msg223[1]" approved="yes">
+          <source xml:space="preserve">%n hour(s)</source>
+          <target xml:space="preserve">%n hours</target>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">1187</context></context-group>
+        <trans-unit id="_msg224[0]" approved="yes">
+          <source xml:space="preserve">%n day(s)</source>
+          <target xml:space="preserve">%n day</target>
+        </trans-unit>
+        <trans-unit id="_msg224[1]" approved="yes">
+          <source xml:space="preserve">%n day(s)</source>
+          <target xml:space="preserve">%n days</target>
+        </trans-unit>
+      </group>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">1189</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1193</context></context-group>
+        <trans-unit id="_msg225[0]" approved="yes">
+          <source xml:space="preserve">%n week(s)</source>
+          <target xml:space="preserve">%n week</target>
+        </trans-unit>
+        <trans-unit id="_msg225[1]" approved="yes">
+          <source xml:space="preserve">%n week(s)</source>
+          <target xml:space="preserve">%n weeks</target>
+        </trans-unit>
+      </group>
+      <trans-unit id="_msg226" approved="yes">
+        <source xml:space="preserve">%1 and %2</source>
+        <target xml:space="preserve">%1 and %2</target>
+        <context-group purpose="location"><context context-type="linenumber">1193</context></context-group>
+      </trans-unit>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">1193</context></context-group>
+        <trans-unit id="_msg227[0]" approved="yes">
+          <source xml:space="preserve">%n year(s)</source>
+          <target xml:space="preserve">%n year</target>
+        </trans-unit>
+        <trans-unit id="_msg227[1]" approved="yes">
+          <source xml:space="preserve">%n year(s)</source>
+          <target xml:space="preserve">%n years</target>
+        </trans-unit>
+      </group>
+      <trans-unit id="_msg228" approved="yes">
+        <source xml:space="preserve">Catching up...</source>
+        <target xml:space="preserve">Catching up...</target>
+        <context-group purpose="location"><context context-type="linenumber">1196</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg229" approved="yes">
+        <source xml:space="preserve">Last received block was generated %1 ago.</source>
+        <target xml:space="preserve">Last received block was generated %1 ago.</target>
+        <context-group purpose="location"><context context-type="linenumber">1212</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg230" approved="yes">
+        <source xml:space="preserve">Transactions after this will not yet be visible.</source>
+        <target xml:space="preserve">Transactions after this will not yet be visible.</target>
+        <context-group purpose="location"><context context-type="linenumber">1214</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg231">
+        <source xml:space="preserve">Loading Blocks...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1218</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg232">
+        <source xml:space="preserve">Syncing Blocks...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1220</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1384</context></context-group>
+      </trans-unit>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">1222</context></context-group>
+        <trans-unit id="_msg233[0]">
+          <source xml:space="preserve">%n Blocks</source>
+          <target xml:space="preserve"></target>
+        </trans-unit>
+        <trans-unit id="_msg233[1]">
+          <source xml:space="preserve">%n Blocks</source>
+          <target xml:space="preserve"></target>
+        </trans-unit>
+      </group>
+      <trans-unit id="_msg234" approved="yes">
+        <source xml:space="preserve">Error</source>
+        <target xml:space="preserve">Error</target>
+        <context-group purpose="location"><context context-type="linenumber">1026</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1243</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg235" approved="yes">
+        <source xml:space="preserve">Warning</source>
+        <target xml:space="preserve">Warning</target>
+        <context-group purpose="location"><context context-type="linenumber">1246</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg236" approved="yes">
+        <source xml:space="preserve">Information</source>
+        <target xml:space="preserve">Information</target>
+        <context-group purpose="location"><context context-type="linenumber">1249</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg237" approved="yes">
+        <source xml:space="preserve">Sent transaction</source>
+        <target xml:space="preserve">Sent transaction</target>
+        <context-group purpose="location"><context context-type="linenumber">1320</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg238" approved="yes">
+        <source xml:space="preserve">Incoming transaction</source>
+        <target xml:space="preserve">Incoming transaction</target>
+        <context-group purpose="location"><context context-type="linenumber">1320</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg239">
+        <source xml:space="preserve">Sent MultiSend transaction</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1320</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg240">
+        <source xml:space="preserve">No Active Peers</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1377</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg241">
+        <source xml:space="preserve">Syncing MN List...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1391</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg242">
+        <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt; for staking only</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1444</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg243">
+        <source xml:space="preserve">Tor is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1474</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg244" approved="yes">
+        <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
+        <target xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</target>
+        <context-group purpose="location"><context context-type="linenumber">1434</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg245" approved="yes">
+        <source xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
+        <target xml:space="preserve">Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</target>
+        <context-group purpose="location"><context context-type="linenumber">1454</context></context-group>
+      </trans-unit>
+    </group>
+    <group restype="x-trolltech-linguist-context" resname="UnitDisplayStatusBarControl">
+      <trans-unit id="_msg246" approved="yes">
+        <source xml:space="preserve">Unit to show amounts in. Click to select another unit.</source>
+        <target xml:space="preserve">Unit to show amounts in. Click to select another unit.</target>
+        <context-group purpose="location"><context context-type="linenumber">1552</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../prcycoin.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="BitcoinGUI">
+      <trans-unit id="_msg247">
+        <source xml:space="preserve">A fatal error occurred. PRCY can no longer continue safely and will quit.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">539</context></context-group>
+      </trans-unit>
+    </group>
+    <group restype="x-trolltech-linguist-context" resname="QObject">
+      <trans-unit id="_msg248">
+        <source xml:space="preserve">PRCY</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">634</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">641</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">654</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">673</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg249">
+        <source xml:space="preserve">Error: Specified data directory &quot;%1&quot; does not exist.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">635</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg250">
+        <source xml:space="preserve">Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">642</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg251">
+        <source xml:space="preserve">Error: Invalid combination of -regtest and -testnet.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">654</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg252">
+        <source xml:space="preserve">Error reading masternode configuration file: %1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">674</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg253">
+        <source xml:space="preserve">PRCY didn&apos;t yet exit safely...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">717</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/blockexplorer.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="BlockExplorer">
+      <trans-unit id="_msg254">
+        <source xml:space="preserve">Blockchain Explorer</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg255">
+        <source xml:space="preserve">Back</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg256">
+        <source xml:space="preserve">Forward</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg257">
+        <source xml:space="preserve">Address / Block / Transaction</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">75</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg258">
+        <source xml:space="preserve">Search</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg259">
+        <source xml:space="preserve">TextLabel</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../blockexplorer.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="BlockExplorer">
+      <trans-unit id="_msg260">
+        <source xml:space="preserve">Not all transactions will be shown. To view all transactions you need to set txindex=1 in the configuration file (prcycoin.conf).</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">422</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../clientmodel.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="ClientModel">
+      <trans-unit id="_msg261">
+        <source xml:space="preserve">Total: %1 (IPv4: %2 / IPv6: %3 / Tor: %4 / Unknown: %5)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/coincontroldialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="CoinControlDialog">
+      <trans-unit id="_msg262" approved="yes">
+        <source xml:space="preserve">Quantity:</source>
+        <target xml:space="preserve">Quantity:</target>
+        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg263" approved="yes">
+        <source xml:space="preserve">Bytes:</source>
+        <target xml:space="preserve">Bytes:</target>
+        <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg264" approved="yes">
+        <source xml:space="preserve">Amount:</source>
+        <target xml:space="preserve">Amount:</target>
+        <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg265" approved="yes">
+        <source xml:space="preserve">Priority:</source>
+        <target xml:space="preserve">Priority:</target>
+        <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg266" approved="yes">
+        <source xml:space="preserve">Fee:</source>
+        <target xml:space="preserve">Fee:</target>
+        <context-group purpose="location"><context context-type="linenumber">196</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg267" approved="yes">
+        <source xml:space="preserve">Coin Selection</source>
+        <target xml:space="preserve">Coin Selection</target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg268" approved="yes">
+        <source xml:space="preserve">Dust:</source>
+        <target xml:space="preserve">Dust:</target>
+        <context-group purpose="location"><context context-type="linenumber">228</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg269" approved="yes">
+        <source xml:space="preserve">After Fee:</source>
+        <target xml:space="preserve">After Fee:</target>
+        <context-group purpose="location"><context context-type="linenumber">276</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg270" approved="yes">
+        <source xml:space="preserve">Change:</source>
+        <target xml:space="preserve">Change:</target>
+        <context-group purpose="location"><context context-type="linenumber">308</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg271" approved="yes">
+        <source xml:space="preserve">(un)select all</source>
+        <target xml:space="preserve">(un)select all</target>
+        <context-group purpose="location"><context context-type="linenumber">364</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg272">
+        <source xml:space="preserve">toggle lock state</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg273" approved="yes">
+        <source xml:space="preserve">Tree mode</source>
+        <target xml:space="preserve">Tree mode</target>
+        <context-group purpose="location"><context context-type="linenumber">396</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg274" approved="yes">
+        <source xml:space="preserve">List mode</source>
+        <target xml:space="preserve">List mode</target>
+        <context-group purpose="location"><context context-type="linenumber">409</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg275" approved="yes">
+        <source xml:space="preserve">(1 locked)</source>
+        <target xml:space="preserve">(1 locked)</target>
+        <context-group purpose="location"><context context-type="linenumber">419</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg276" approved="yes">
+        <source xml:space="preserve">Amount</source>
+        <target xml:space="preserve">Amount</target>
+        <context-group purpose="location"><context context-type="linenumber">465</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg277" approved="yes">
+        <source xml:space="preserve">Received with label</source>
+        <target xml:space="preserve">Received with label</target>
+        <context-group purpose="location"><context context-type="linenumber">470</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg278" approved="yes">
+        <source xml:space="preserve">Received with address</source>
+        <target xml:space="preserve">Received with address</target>
+        <context-group purpose="location"><context context-type="linenumber">475</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg279">
+        <source xml:space="preserve">Type</source>
+        <target xml:space="preserve" state="needs-review-translation">Type</target>
+        <context-group purpose="location"><context context-type="linenumber">480</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg280" approved="yes">
+        <source xml:space="preserve">Date</source>
+        <target xml:space="preserve">Date</target>
+        <context-group purpose="location"><context context-type="linenumber">485</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg281" approved="yes">
+        <source xml:space="preserve">Confirmations</source>
+        <target xml:space="preserve">Confirmations</target>
+        <context-group purpose="location"><context context-type="linenumber">490</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg282" approved="yes">
+        <source xml:space="preserve">Confirmed</source>
+        <target xml:space="preserve">Confirmed</target>
+        <context-group purpose="location"><context context-type="linenumber">493</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg283" approved="yes">
+        <source xml:space="preserve">Priority</source>
+        <target xml:space="preserve">Priority</target>
+        <context-group purpose="location"><context context-type="linenumber">498</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg284" approved="yes">
+        <source xml:space="preserve">medium</source>
+        <target xml:space="preserve">medium</target>
+        <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../coincontroldialog.cpp</context><context context-type="linenumber">461</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg285" approved="yes">
+        <source xml:space="preserve">no</source>
+        <target xml:space="preserve">no</target>
+        <context-group purpose="location"><context context-type="linenumber">244</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../coincontroldialog.cpp</context><context context-type="linenumber">663</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../coincontroldialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="CoinControlDialog">
+      <trans-unit id="_msg286" approved="yes">
+        <source xml:space="preserve">Copy address</source>
+        <target xml:space="preserve">Copy address</target>
+        <context-group purpose="location"><context context-type="linenumber">55</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg287" approved="yes">
+        <source xml:space="preserve">Copy label</source>
+        <target xml:space="preserve">Copy label</target>
+        <context-group purpose="location"><context context-type="linenumber">56</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg288" approved="yes">
+        <source xml:space="preserve">Copy amount</source>
+        <target xml:space="preserve">Copy amount</target>
+        <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg289" approved="yes">
+        <source xml:space="preserve">Copy transaction ID</source>
+        <target xml:space="preserve">Copy transaction ID</target>
+        <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg290" approved="yes">
+        <source xml:space="preserve">Lock unspent</source>
+        <target xml:space="preserve">Lock unspent</target>
+        <context-group purpose="location"><context context-type="linenumber">59</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg291" approved="yes">
+        <source xml:space="preserve">Unlock unspent</source>
+        <target xml:space="preserve">Unlock unspent</target>
+        <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg292" approved="yes">
+        <source xml:space="preserve">Copy quantity</source>
+        <target xml:space="preserve">Copy quantity</target>
+        <context-group purpose="location"><context context-type="linenumber">82</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg293" approved="yes">
+        <source xml:space="preserve">Copy fee</source>
+        <target xml:space="preserve">Copy fee</target>
+        <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg294" approved="yes">
+        <source xml:space="preserve">Copy after fee</source>
+        <target xml:space="preserve">Copy after fee</target>
+        <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg295" approved="yes">
+        <source xml:space="preserve">Copy bytes</source>
+        <target xml:space="preserve">Copy bytes</target>
+        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg296" approved="yes">
+        <source xml:space="preserve">Copy priority</source>
+        <target xml:space="preserve">Copy priority</target>
+        <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg297" approved="yes">
+        <source xml:space="preserve">Copy dust</source>
+        <target xml:space="preserve">Copy dust</target>
+        <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg298" approved="yes">
+        <source xml:space="preserve">Copy change</source>
+        <target xml:space="preserve">Copy change</target>
+        <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg299">
+        <source xml:space="preserve">Select all</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">196</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg300">
+        <source xml:space="preserve">Unselect all</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">198</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg301">
+        <source xml:space="preserve">Please switch to &quot;List mode&quot; to use this function.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">237</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg302" approved="yes">
+        <source xml:space="preserve">highest</source>
+        <target xml:space="preserve">highest</target>
+        <context-group purpose="location"><context context-type="linenumber">453</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg303" approved="yes">
+        <source xml:space="preserve">higher</source>
+        <target xml:space="preserve">higher</target>
+        <context-group purpose="location"><context context-type="linenumber">455</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg304" approved="yes">
+        <source xml:space="preserve">high</source>
+        <target xml:space="preserve">high</target>
+        <context-group purpose="location"><context context-type="linenumber">457</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg305" approved="yes">
+        <source xml:space="preserve">medium-high</source>
+        <target xml:space="preserve">medium-high</target>
+        <context-group purpose="location"><context context-type="linenumber">459</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg306" approved="yes">
+        <source xml:space="preserve">Can vary +/- %1 duff(s) per input.</source>
+        <target xml:space="preserve">Can vary +/- %1 duff(s) per input.</target>
+        <context-group purpose="location"><context context-type="linenumber">694</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg307" approved="yes">
+        <source xml:space="preserve">low-medium</source>
+        <target xml:space="preserve">low-medium</target>
+        <context-group purpose="location"><context context-type="linenumber">463</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg308" approved="yes">
+        <source xml:space="preserve">low</source>
+        <target xml:space="preserve">low</target>
+        <context-group purpose="location"><context context-type="linenumber">465</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg309" approved="yes">
+        <source xml:space="preserve">lower</source>
+        <target xml:space="preserve">lower</target>
+        <context-group purpose="location"><context context-type="linenumber">467</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg310" approved="yes">
+        <source xml:space="preserve">lowest</source>
+        <target xml:space="preserve">lowest</target>
+        <context-group purpose="location"><context context-type="linenumber">469</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg311" approved="yes">
+        <source xml:space="preserve">(%1 locked)</source>
+        <target xml:space="preserve">(%1 locked)</target>
+        <context-group purpose="location"><context context-type="linenumber">478</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg312" approved="yes">
+        <source xml:space="preserve">none</source>
+        <target xml:space="preserve">none</target>
+        <context-group purpose="location"><context context-type="linenumber">537</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg313" approved="yes">
+        <source xml:space="preserve">yes</source>
+        <target xml:space="preserve">yes</target>
+        <context-group purpose="location"><context context-type="linenumber">663</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg314" approved="yes">
+        <source xml:space="preserve">This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <target xml:space="preserve">This label turns red, if the transaction size is greater than 1000 bytes.</target>
+        <context-group purpose="location"><context context-type="linenumber">678</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg315" approved="yes">
+        <source xml:space="preserve">This means a fee of at least %1 per kB is required.</source>
+        <target xml:space="preserve">This means a fee of at least %1 per kB is required.</target>
+        <context-group purpose="location"><context context-type="linenumber">679</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">684</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg316" approved="yes">
+        <source xml:space="preserve">Can vary +/- 1 byte per input.</source>
+        <target xml:space="preserve">Can vary +/- 1 byte per input.</target>
+        <context-group purpose="location"><context context-type="linenumber">680</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg317" approved="yes">
+        <source xml:space="preserve">Transactions with higher priority are more likely to get included into a block.</source>
+        <target xml:space="preserve">Transactions with higher priority are more likely to get included into a block.</target>
+        <context-group purpose="location"><context context-type="linenumber">682</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg318" approved="yes">
+        <source xml:space="preserve">This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
+        <target xml:space="preserve">This label turns red, if the priority is smaller than &quot;medium&quot;.</target>
+        <context-group purpose="location"><context context-type="linenumber">683</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg319" approved="yes">
+        <source xml:space="preserve">This label turns red, if any recipient receives an amount smaller than %1.</source>
+        <target xml:space="preserve">This label turns red, if any recipient receives an amount smaller than %1.</target>
+        <context-group purpose="location"><context context-type="linenumber">686</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg320" approved="yes">
+        <source xml:space="preserve">(no label)</source>
+        <target xml:space="preserve">(no label)</target>
+        <context-group purpose="location"><context context-type="linenumber">740</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">803</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg321" approved="yes">
+        <source xml:space="preserve">change from %1 (%2)</source>
+        <target xml:space="preserve">change from %1 (%2)</target>
+        <context-group purpose="location"><context context-type="linenumber">798</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg322" approved="yes">
+        <source xml:space="preserve">(change)</source>
+        <target xml:space="preserve">(change)</target>
+        <context-group purpose="location"><context context-type="linenumber">799</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/editaddressdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="EditAddressDialog">
+      <trans-unit id="_msg323" approved="yes">
+        <source xml:space="preserve">Edit Address</source>
+        <target xml:space="preserve">Edit Address</target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg324" approved="yes">
+        <source xml:space="preserve">&amp;Label</source>
+        <target xml:space="preserve">&amp;Label</target>
+        <context-group purpose="location"><context context-type="linenumber">25</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg325" approved="yes">
+        <source xml:space="preserve">The label associated with this address list entry</source>
+        <target xml:space="preserve">The label associated with this address list entry</target>
+        <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg326" approved="yes">
+        <source xml:space="preserve">&amp;Address</source>
+        <target xml:space="preserve">&amp;Address</target>
+        <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg327" approved="yes">
+        <source xml:space="preserve">The address associated with this address list entry. This can only be modified for sending addresses.</source>
+        <target xml:space="preserve">The address associated with this address list entry. This can only be modified for sending addresses.</target>
+        <context-group purpose="location"><context context-type="linenumber">52</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../editaddressdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="EditAddressDialog">
+      <trans-unit id="_msg328" approved="yes">
+        <source xml:space="preserve">New receiving address</source>
+        <target xml:space="preserve">New receiving address</target>
+        <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg329" approved="yes">
+        <source xml:space="preserve">New sending address</source>
+        <target xml:space="preserve">New sending address</target>
+        <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg330" approved="yes">
+        <source xml:space="preserve">Edit receiving address</source>
+        <target xml:space="preserve">Edit receiving address</target>
+        <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg331" approved="yes">
+        <source xml:space="preserve">Edit sending address</source>
+        <target xml:space="preserve">Edit sending address</target>
+        <context-group purpose="location"><context context-type="linenumber">40</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg332">
+        <source xml:space="preserve">The entered address &quot;%1&quot; is not a valid PRCY address.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">107</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg333" approved="yes">
+        <source xml:space="preserve">The entered address &quot;%1&quot; is already in the address book.</source>
+        <target xml:space="preserve">The entered address &quot;%1&quot; is already in the address book.</target>
+        <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg334" approved="yes">
+        <source xml:space="preserve">Could not unlock wallet.</source>
+        <target xml:space="preserve">Could not unlock wallet.</target>
+        <context-group purpose="location"><context context-type="linenumber">117</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg335" approved="yes">
+        <source xml:space="preserve">New key generation failed.</source>
+        <target xml:space="preserve">New key generation failed.</target>
+        <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/encryptdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="EncryptDialog">
+      <trans-unit id="_msg336">
+        <source xml:space="preserve">Transaction Details</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg337">
+        <source xml:space="preserve">Encrypt Wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">31</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg338">
+        <source xml:space="preserve">Please enter a passphrase to encrypt your wallet. This is required.
+(You must use a minimum passphrase length of 10 characters and use uppercase letters, 
+lowercase letters, numbers, symbols) </source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg339">
+        <source xml:space="preserve">New passphrase</source>
+        <target xml:space="preserve" state="needs-review-translation">New passphrase</target>
+        <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg340">
+        <source xml:space="preserve">Repeat new passphrase</source>
+        <target xml:space="preserve" state="needs-review-translation">Repeat new passphrase</target>
+        <context-group purpose="location"><context context-type="linenumber">82</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg341">
+        <source xml:space="preserve">Show passphrase</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg342">
+        <source xml:space="preserve">Confirm</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">109</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg343">
+        <source xml:space="preserve">Return</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg344">
+        <source xml:space="preserve">Cancel</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg345">
+        <source xml:space="preserve">Esc</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../encryptdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="EncryptDialog">
+      <trans-unit id="_msg346">
+        <source xml:space="preserve">Wallet Encryption Required</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">37</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg347">
+        <source xml:space="preserve">There was no passphrase entered for the wallet.
+
+Wallet encryption is required for the security of your funds.
+
+What would you like to do?</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">37</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg348">
+        <source xml:space="preserve">Wallet Encryption Failed</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">111</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg349">
+        <source xml:space="preserve">The passphrase entered for wallet encryption was empty. Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg350">
+        <source xml:space="preserve">The passphrase&apos;s length has to be more than 10. Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">77</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg351">
+        <source xml:space="preserve">The passphrase must contain lower, upper, digit, symbol. Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg352">
+        <source xml:space="preserve">The passphrases entered for wallet encryption is too weak. Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg353">
+        <source xml:space="preserve">Wallet Encryption Successful</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg354">
+        <source xml:space="preserve">Wallet passphrase was successfully set.
+Please remember your passphrase as there is no way to recover it.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">105</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg355">
+        <source xml:space="preserve">The passphrases entered for wallet encryption do not match. Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/entermnemonics.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="EnterMnemonics">
+      <trans-unit id="_msg356">
+        <source xml:space="preserve">PRivaCY Coin Wallet Recovery Wizard</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg357">
+        <source xml:space="preserve">Enter your mnemonics recovery phrase to recover your wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg358">
+        <source xml:space="preserve">Next</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../entermnemonics.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="EnterMnemonics">
+      <trans-unit id="_msg359">
+        <source xml:space="preserve">Recovery Phrase Import Successful</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg360">
+        <source xml:space="preserve">Your mnemonics have been successfully imported into the wallet. Rescanning will be scheduled to recover all your funds.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg361">
+        <source xml:space="preserve">Recovery Phrase Invalid</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg362">
+        <source xml:space="preserve">Recovery phrase is invalid. Please try again and double check all words.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../intro.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="FreespaceChecker">
+      <trans-unit id="_msg363" approved="yes">
+        <source xml:space="preserve">A new data directory will be created.</source>
+        <target xml:space="preserve">A new data directory will be created.</target>
+        <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg364" approved="yes">
+        <source xml:space="preserve">name</source>
+        <target xml:space="preserve">name</target>
+        <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg365" approved="yes">
+        <source xml:space="preserve">Directory already exists. Add %1 if you intend to create a new directory here.</source>
+        <target xml:space="preserve">Directory already exists. Add %1 if you intend to create a new directory here.</target>
+        <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg366" approved="yes">
+        <source xml:space="preserve">Path already exists, and is not a directory.</source>
+        <target xml:space="preserve">Path already exists, and is not a directory.</target>
+        <context-group purpose="location"><context context-type="linenumber">97</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg367" approved="yes">
+        <source xml:space="preserve">Cannot create data directory here.</source>
+        <target xml:space="preserve">Cannot create data directory here.</target>
+        <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
+      </trans-unit>
+    </group>
+    <group restype="x-trolltech-linguist-context" resname="Intro">
+      <trans-unit id="_msg368">
+        <source xml:space="preserve">PRCY</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">186</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg369" approved="yes">
+        <source xml:space="preserve">Error: Specified data directory &quot;%1&quot; cannot be created.</source>
+        <target xml:space="preserve">Error: Specified data directory &quot;%1&quot; cannot be created.</target>
+        <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg370" approved="yes">
+        <source xml:space="preserve">Error</source>
+        <target xml:space="preserve">Error</target>
+        <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg371" approved="yes">
+        <source xml:space="preserve">%1 GB of free space available</source>
+        <target xml:space="preserve">%1 GB of free space available</target>
+        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg372" approved="yes">
+        <source xml:space="preserve">(of %1 GB needed)</source>
+        <target xml:space="preserve">(of %1 GB needed)</target>
+        <context-group purpose="location"><context context-type="linenumber">221</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../utilitydialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="HelpMessageDialog">
+      <trans-unit id="_msg373" approved="yes">
+        <source xml:space="preserve">version</source>
+        <target xml:space="preserve">version</target>
+        <context-group purpose="location"><context context-type="linenumber">38</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg374">
+        <source xml:space="preserve">PRCY</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">38</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg375" approved="yes">
+        <source xml:space="preserve">(%1-bit)</source>
+        <target xml:space="preserve">(%1-bit)</target>
+        <context-group purpose="location"><context context-type="linenumber">43</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">45</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg376">
+        <source xml:space="preserve">About PRCY</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg377" approved="yes">
+        <source xml:space="preserve">Command-line options</source>
+        <target xml:space="preserve">Command-line options</target>
+        <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg378" approved="yes">
+        <source xml:space="preserve">Usage:</source>
+        <target xml:space="preserve">Usage:</target>
+        <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg379" approved="yes">
+        <source xml:space="preserve">command-line options</source>
+        <target xml:space="preserve">command-line options</target>
+        <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg380">
+        <source xml:space="preserve">UI Options:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">79</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg381">
+        <source xml:space="preserve">Choose data directory on startup (default: %u)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg382">
+        <source xml:space="preserve">Show splash screen on startup (default: %u)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">83</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg383" approved="yes">
+        <source xml:space="preserve">Set language, for example &quot;de_DE&quot; (default: system locale)</source>
+        <target xml:space="preserve">Set language, for example &quot;de_DE&quot; (default: system locale)</target>
+        <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg384" approved="yes">
+        <source xml:space="preserve">Start minimized</source>
+        <target xml:space="preserve">Start minimized</target>
+        <context-group purpose="location"><context context-type="linenumber">82</context></context-group>
+      </trans-unit>
+    </group>
+    <group restype="x-trolltech-linguist-context" resname="ShutdownWindow">
+      <trans-unit id="_msg385">
+        <source xml:space="preserve">PRCY is shutting down...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg386" approved="yes">
+        <source xml:space="preserve">Do not shut down the computer until this window disappears.</source>
+        <target xml:space="preserve">Do not shut down the computer until this window disappears.</target>
+        <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/historypage.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="HistoryPage">
+      <trans-unit id="_msg387">
+        <source xml:space="preserve">to</source>
+        <target xml:space="preserve" state="needs-review-translation">to</target>
+        <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg388">
+        <source xml:space="preserve">All Types</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">300</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg389">
+        <source xml:space="preserve">Sent</source>
+        <target xml:space="preserve" state="needs-review-translation">Sent</target>
+        <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">303</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">304</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">317</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg390">
+        <source xml:space="preserve">Received</source>
+        <target xml:space="preserve" state="needs-review-translation">Received</target>
+        <context-group purpose="location"><context context-type="linenumber">94</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">301</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">302</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">317</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg391">
+        <source xml:space="preserve">Mined</source>
+        <target xml:space="preserve" state="needs-review-translation">Mined</target>
+        <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">305</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">306</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">314</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">317</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg392">
+        <source xml:space="preserve">Minted</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">307</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">308</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">314</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">317</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg393">
+        <source xml:space="preserve">Masternode</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">109</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">309</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">310</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">314</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">317</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg394">
+        <source xml:space="preserve">Payment to yourself</source>
+        <target xml:space="preserve" state="needs-review-translation">Payment to yourself</target>
+        <context-group purpose="location"><context context-type="linenumber">114</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">311</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">312</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">317</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg395">
+        <source xml:space="preserve">Rewards</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../historypage.cpp</context><context context-type="linenumber">313</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg396">
+        <source xml:space="preserve">Min Amount</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">146</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg397">
+        <source xml:space="preserve">Date</source>
+        <target xml:space="preserve" state="needs-review-translation">Date</target>
+        <context-group purpose="location"><context context-type="linenumber">200</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg398">
+        <source xml:space="preserve">Type</source>
+        <target xml:space="preserve" state="needs-review-translation">Type</target>
+        <context-group purpose="location"><context context-type="linenumber">205</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg399">
+        <source xml:space="preserve">Address/Description</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">210</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg400">
+        <source xml:space="preserve">Amount (PRCY)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg401">
+        <source xml:space="preserve">Confirmations</source>
+        <target xml:space="preserve" state="needs-review-translation">Confirmations</target>
+        <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/importorcreate.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="ImportOrCreate">
+      <trans-unit id="_msg402">
+        <source xml:space="preserve">PRivaCY Coin Wallet Wizard</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg403">
+        <source xml:space="preserve">Do you want to create a new wallet or recover from your mnemonics?</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg404">
+        <source xml:space="preserve">Create a new wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">41</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg405">
+        <source xml:space="preserve">Recover from a mnemonic phrase</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg406">
+        <source xml:space="preserve">Next</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../importorcreate.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="ImportOrCreate">
+      <trans-unit id="_msg407">
+        <source xml:space="preserve">Copy</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">40</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg408">
+        <source xml:space="preserve">OK</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">41</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/intro.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="Intro">
+      <trans-unit id="_msg409" approved="yes">
+        <source xml:space="preserve">Welcome</source>
+        <target xml:space="preserve">Welcome</target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg410">
+        <source xml:space="preserve">Welcome to the PRivaCY Coin Wallet.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">23</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg411">
+        <source xml:space="preserve">As this is the first time the program is launched, you can choose where the PRivaCY Coin Wallet will store its data.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg412">
+        <source xml:space="preserve">The PRivaCY Coin Wallet will download and store a copy of the PRCY block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">59</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg413" approved="yes">
+        <source xml:space="preserve">Use the default data directory</source>
+        <target xml:space="preserve">Use the default data directory</target>
+        <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg414" approved="yes">
+        <source xml:space="preserve">Use a custom data directory:</source>
+        <target xml:space="preserve">Use a custom data directory:</target>
+        <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/masternodelist.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="MasternodeList">
+      <trans-unit id="_msg415">
+        <source xml:space="preserve">Form</source>
+        <target xml:space="preserve" state="needs-review-translation">Form</target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg416">
+        <source xml:space="preserve">Alias</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">117</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg417">
+        <source xml:space="preserve">Address</source>
+        <target xml:space="preserve" state="needs-review-translation">Address</target>
+        <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg418">
+        <source xml:space="preserve">Status</source>
+        <target xml:space="preserve" state="needs-review-translation">Status</target>
+        <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg419">
+        <source xml:space="preserve">Active</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">132</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg420">
+        <source xml:space="preserve">Last Seen (UTC)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg421">
+        <source xml:space="preserve">Pubkey</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">142</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg422">
+        <source xml:space="preserve">S&amp;tart alias</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">155</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg423">
+        <source xml:space="preserve">Start &amp;all</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">162</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg424">
+        <source xml:space="preserve">Start &amp;MISSING</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">169</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg425">
+        <source xml:space="preserve">&amp;Update status</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../masternodelist.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="MasternodeList">
+      <trans-unit id="_msg426">
+        <source xml:space="preserve">Start alias</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg427">
+        <source xml:space="preserve">Confirm masternode start</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg428">
+        <source xml:space="preserve">Are you sure you want to start masternode %1?</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">242</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg429">
+        <source xml:space="preserve">Confirm all masternodes start</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg430">
+        <source xml:space="preserve">Are you sure you want to start ALL masternodes?</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg431">
+        <source xml:space="preserve">Command is not available right now</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg432">
+        <source xml:space="preserve">You can&apos;t use this command until masternode list is synced</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">290</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg433">
+        <source xml:space="preserve">Confirm missing masternodes start</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg434">
+        <source xml:space="preserve">Are you sure you want to start MISSING masternodes?</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">297</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/multisenddialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="MultiSendDialog">
+      <trans-unit id="_msg435">
+        <source xml:space="preserve">MultiSend</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">17</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg436">
+        <source xml:space="preserve">Enter whole numbers 1 - 100</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg437">
+        <source xml:space="preserve">Enter % to Give (1-100)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg438">
+        <source xml:space="preserve">Enter Address to Send to</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg439">
+        <source xml:space="preserve">MultiSend allows you to automatically send up to 100% of your stake or masternode reward to a list of other PRCY addresses after it matures.
+To Add: enter percentage to give and PRCY address to add to the MultiSend vector.
+To Delete: Enter address to delete and press delete.
+MultiSend will not be activated unless you have clicked Activate</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg440">
+        <source xml:space="preserve">Add to MultiSend Vector</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg441">
+        <source xml:space="preserve">Add</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">105</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg442">
+        <source xml:space="preserve">Deactivate MultiSend</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">118</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg443">
+        <source xml:space="preserve">Deactivate</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">121</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg444">
+        <source xml:space="preserve">Choose an address from the address book</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">134</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg445">
+        <source xml:space="preserve">Alt+A</source>
+        <target xml:space="preserve" state="needs-review-translation">Alt+A</target>
+        <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg446">
+        <source xml:space="preserve">Percentage of stake to send</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg447">
+        <source xml:space="preserve">Percentage:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">160</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg448">
+        <source xml:space="preserve">Address to send portion of stake to</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg449">
+        <source xml:space="preserve">Address:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg450">
+        <source xml:space="preserve">Delete Address From MultiSend Vector</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg451">
+        <source xml:space="preserve">Delete</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">195</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg452">
+        <source xml:space="preserve">Activate MultiSend</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg453">
+        <source xml:space="preserve">Activate</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">211</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg454">
+        <source xml:space="preserve">View MultiSend Vector</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">227</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg455">
+        <source xml:space="preserve">View MultiSend</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">230</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg456">
+        <source xml:space="preserve">Send For Stakes</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg457">
+        <source xml:space="preserve">Send For Masternode Rewards</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">253</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../multisenddialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="MultiSendDialog">
+      <trans-unit id="_msg458">
+        <source xml:space="preserve">The entered address:
+</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg459">
+        <source xml:space="preserve"> is invalid.
+Please check the address and try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg460">
+        <source xml:space="preserve">The total amount of your MultiSend vector is over 100% of your stake reward
+</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg461">
+        <source xml:space="preserve">Please Enter 1 - 100 for percent.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg462">
+        <source xml:space="preserve">MultiSend Vector
+</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">130</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg463">
+        <source xml:space="preserve">Removed </source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg464">
+        <source xml:space="preserve">Could not locate address
+</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/openuridialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="OpenURIDialog">
+      <trans-unit id="_msg465" approved="yes">
+        <source xml:space="preserve">Open URI</source>
+        <target xml:space="preserve">Open URI</target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg466" approved="yes">
+        <source xml:space="preserve">URI:</source>
+        <target xml:space="preserve">URI:</target>
+        <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/optionsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="OptionsDialog">
+      <trans-unit id="_msg467" approved="yes">
+        <source xml:space="preserve">Options</source>
+        <target xml:space="preserve">Options</target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg468" approved="yes">
+        <source xml:space="preserve">&amp;Main</source>
+        <target xml:space="preserve">&amp;Main</target>
+        <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg469" approved="yes">
+        <source xml:space="preserve">Size of &amp;database cache</source>
+        <target xml:space="preserve">Size of &amp;database cache</target>
+        <context-group purpose="location"><context context-type="linenumber">45</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg470" approved="yes">
+        <source xml:space="preserve">MB</source>
+        <target xml:space="preserve">MB</target>
+        <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg471" approved="yes">
+        <source xml:space="preserve">Number of script &amp;verification threads</source>
+        <target xml:space="preserve">Number of script &amp;verification threads</target>
+        <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg472" approved="yes">
+        <source xml:space="preserve">(0 = auto, &lt;0 = leave that many cores free)</source>
+        <target xml:space="preserve">(0 = auto, &lt;0 = leave that many cores free)</target>
+        <context-group purpose="location"><context context-type="linenumber">101</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg473" approved="yes">
+        <source xml:space="preserve">W&amp;allet</source>
+        <target xml:space="preserve">W&amp;allet</target>
+        <context-group purpose="location"><context context-type="linenumber">137</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg474" approved="yes">
+        <source xml:space="preserve">If you disable the spending of unconfirmed change, the change from a transaction&lt;br/&gt;cannot be used until that transaction has at least one confirmation.&lt;br/&gt;This also affects how your balance is computed.</source>
+        <target xml:space="preserve">If you disable the spending of unconfirmed change, the change from a transaction&lt;br/&gt;cannot be used until that transaction has at least one confirmation.&lt;br/&gt;This also affects how your balance is computed.</target>
+        <context-group purpose="location"><context context-type="linenumber">169</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg475">
+        <source xml:space="preserve">Automatically open the PRCY client port on the router. This only works when your router supports UPnP and it is enabled.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg476" approved="yes">
+        <source xml:space="preserve">Accept connections from outside</source>
+        <target xml:space="preserve">Accept connections from outside</target>
+        <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg477" approved="yes">
+        <source xml:space="preserve">Allow incoming connections</source>
+        <target xml:space="preserve">Allow incoming connections</target>
+        <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg478" approved="yes">
+        <source xml:space="preserve">&amp;Connect through SOCKS5 proxy (default proxy):</source>
+        <target xml:space="preserve">&amp;Connect through SOCKS5 proxy (default proxy):</target>
+        <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg479" approved="yes">
+        <source xml:space="preserve">Expert</source>
+        <target xml:space="preserve">Expert</target>
+        <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg480">
+        <source xml:space="preserve">Automatically start PRCY after logging in to the system.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg481">
+        <source xml:space="preserve">&amp;Start PRCY on system login</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg482" approved="yes">
+        <source xml:space="preserve">Whether to show coin control features or not.</source>
+        <target xml:space="preserve">Whether to show coin control features or not.</target>
+        <context-group purpose="location"><context context-type="linenumber">149</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg483" approved="yes">
+        <source xml:space="preserve">Enable coin &amp;control features</source>
+        <target xml:space="preserve">Enable coin &amp;control features</target>
+        <context-group purpose="location"><context context-type="linenumber">152</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg484">
+        <source xml:space="preserve">Show additional tab listing all your masternodes in first sub-tab&lt;br/&gt;and all masternodes on the network in second sub-tab.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg485">
+        <source xml:space="preserve">Show Masternodes Tab</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">162</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg486" approved="yes">
+        <source xml:space="preserve">&amp;Spend unconfirmed change</source>
+        <target xml:space="preserve">&amp;Spend unconfirmed change</target>
+        <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg487" approved="yes">
+        <source xml:space="preserve">&amp;Network</source>
+        <target xml:space="preserve">&amp;Network</target>
+        <context-group purpose="location"><context context-type="linenumber">196</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg488">
+        <source xml:space="preserve">Language missing or translation incomplete? Help contributing translations here:
+https://www.transifex.com/prcycoin-project/prcycoin-project-translations</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">409</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg489" approved="yes">
+        <source xml:space="preserve">Map port using &amp;UPnP</source>
+        <target xml:space="preserve">Map port using &amp;UPnP</target>
+        <context-group purpose="location"><context context-type="linenumber">205</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg490">
+        <source xml:space="preserve">Connect to the PRCY network through a SOCKS5 proxy.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg491" approved="yes">
+        <source xml:space="preserve">Proxy &amp;IP:</source>
+        <target xml:space="preserve">Proxy &amp;IP:</target>
+        <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg492" approved="yes">
+        <source xml:space="preserve">IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
+        <target xml:space="preserve">IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</target>
+        <context-group purpose="location"><context context-type="linenumber">259</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg493" approved="yes">
+        <source xml:space="preserve">&amp;Port:</source>
+        <target xml:space="preserve">&amp;Port:</target>
+        <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg494" approved="yes">
+        <source xml:space="preserve">Port of the proxy (e.g. 9050)</source>
+        <target xml:space="preserve">Port of the proxy (e.g. 9050)</target>
+        <context-group purpose="location"><context context-type="linenumber">291</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg495" approved="yes">
+        <source xml:space="preserve">&amp;Window</source>
+        <target xml:space="preserve">&amp;Window</target>
+        <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg496" approved="yes">
+        <source xml:space="preserve">Show only a tray icon after minimizing the window.</source>
+        <target xml:space="preserve">Show only a tray icon after minimizing the window.</target>
+        <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg497" approved="yes">
+        <source xml:space="preserve">&amp;Minimize to the tray instead of the taskbar</source>
+        <target xml:space="preserve">&amp;Minimize to the tray instead of the taskbar</target>
+        <context-group purpose="location"><context context-type="linenumber">336</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg498" approved="yes">
+        <source xml:space="preserve">Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
+        <target xml:space="preserve">Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</target>
+        <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg499" approved="yes">
+        <source xml:space="preserve">M&amp;inimize on close</source>
+        <target xml:space="preserve">M&amp;inimize on close</target>
+        <context-group purpose="location"><context context-type="linenumber">346</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg500" approved="yes">
+        <source xml:space="preserve">&amp;Display</source>
+        <target xml:space="preserve">&amp;Display</target>
+        <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg501" approved="yes">
+        <source xml:space="preserve">User Interface &amp;language:</source>
+        <target xml:space="preserve">User Interface &amp;language:</target>
+        <context-group purpose="location"><context context-type="linenumber">375</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg502">
+        <source xml:space="preserve">The user interface language can be set here. This setting will take effect after restarting PRCYcoin.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">388</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg503">
+        <source xml:space="preserve">Interface Mode:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">428</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg504">
+        <source xml:space="preserve">Light</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">449</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg505">
+        <source xml:space="preserve">Dark</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">511</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg506" approved="yes">
+        <source xml:space="preserve">&amp;Unit to show amounts in:</source>
+        <target xml:space="preserve">&amp;Unit to show amounts in:</target>
+        <context-group purpose="location"><context context-type="linenumber">537</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg507" approved="yes">
+        <source xml:space="preserve">Choose the default subdivision unit to show in the interface and when sending coins.</source>
+        <target xml:space="preserve">Choose the default subdivision unit to show in the interface and when sending coins.</target>
+        <context-group purpose="location"><context context-type="linenumber">550</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg508" approved="yes">
+        <source xml:space="preserve">Decimal digits</source>
+        <target xml:space="preserve">Decimal digits</target>
+        <context-group purpose="location"><context context-type="linenumber">561</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg509">
+        <source xml:space="preserve">Hide empty balances</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">575</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">581</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg510">
+        <source xml:space="preserve">Hide orphan stakes in transaction lists</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">588</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg511">
+        <source xml:space="preserve">Hide orphan stakes</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">591</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg512" approved="yes">
+        <source xml:space="preserve">Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <target xml:space="preserve">Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</target>
+        <context-group purpose="location"><context context-type="linenumber">615</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">628</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg513" approved="yes">
+        <source xml:space="preserve">Third party transaction URLs</source>
+        <target xml:space="preserve">Third party transaction URLs</target>
+        <context-group purpose="location"><context context-type="linenumber">618</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg514" approved="yes">
+        <source xml:space="preserve">Active command-line options that override above options:</source>
+        <target xml:space="preserve">Active command-line options that override above options:</target>
+        <context-group purpose="location"><context context-type="linenumber">659</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg515" approved="yes">
+        <source xml:space="preserve">Reset all client options to default.</source>
+        <target xml:space="preserve">Reset all client options to default.</target>
+        <context-group purpose="location"><context context-type="linenumber">702</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg516" approved="yes">
+        <source xml:space="preserve">&amp;Reset Options</source>
+        <target xml:space="preserve">&amp;Reset Options</target>
+        <context-group purpose="location"><context context-type="linenumber">705</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg517" approved="yes">
+        <source xml:space="preserve">&amp;OK</source>
+        <target xml:space="preserve">&amp;OK</target>
+        <context-group purpose="location"><context context-type="linenumber">766</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg518" approved="yes">
+        <source xml:space="preserve">&amp;Cancel</source>
+        <target xml:space="preserve">&amp;Cancel</target>
+        <context-group purpose="location"><context context-type="linenumber">779</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../optionsdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="OptionsDialog">
+      <trans-unit id="_msg519" approved="yes">
+        <source xml:space="preserve">default</source>
+        <target xml:space="preserve">default</target>
+        <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg520" approved="yes">
+        <source xml:space="preserve">none</source>
+        <target xml:space="preserve">none</target>
+        <context-group purpose="location"><context context-type="linenumber">131</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg521" approved="yes">
+        <source xml:space="preserve">Confirm options reset</source>
+        <target xml:space="preserve">Confirm options reset</target>
+        <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg522" approved="yes">
+        <source xml:space="preserve">Client restart required to activate changes.</source>
+        <target xml:space="preserve">Client restart required to activate changes.</target>
+        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg523" approved="yes">
+        <source xml:space="preserve">Client will be shutdown, do you want to proceed?</source>
+        <target xml:space="preserve">Client will be shutdown, do you want to proceed?</target>
+        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg524" approved="yes">
+        <source xml:space="preserve">This change would require a client restart.</source>
+        <target xml:space="preserve">This change would require a client restart.</target>
+        <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg525" approved="yes">
+        <source xml:space="preserve">The supplied proxy address is invalid.</source>
+        <target xml:space="preserve">The supplied proxy address is invalid.</target>
+        <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg526">
+        <source xml:space="preserve">The supplied proxy port is invalid.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">286</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg527">
+        <source xml:space="preserve">The supplied proxy settings are invalid.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/optionspage.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="OptionsPage">
+      <trans-unit id="_msg528">
+        <source xml:space="preserve">Turn staking on or off</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg529">
+        <source xml:space="preserve">On</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg530">
+        <source xml:space="preserve">Off</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">79</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">229</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg531">
+        <source xml:space="preserve">Staking Mode:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg532">
+        <source xml:space="preserve">Backup Wallet</source>
+        <target xml:space="preserve" state="needs-review-translation">Backup Wallet</target>
+        <context-group purpose="location"><context context-type="linenumber">105</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../optionspage.cpp</context><context context-type="linenumber">349</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg533">
+        <source xml:space="preserve">Show Seed Phrase</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg534">
+        <source xml:space="preserve">Theme Selection:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg535">
+        <source xml:space="preserve">Switch between Dark and Web Wallet theme</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">167</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg536">
+        <source xml:space="preserve">Dark</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg537">
+        <source xml:space="preserve">Web</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg538">
+        <source xml:space="preserve">Number of digits to use:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">244</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg539">
+        <source xml:space="preserve">6</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">255</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg540">
+        <source xml:space="preserve">8</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg541">
+        <source xml:space="preserve">Request authentication code before sending any transactions</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">270</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg542">
+        <source xml:space="preserve">Request passphrase before sending any transactions</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">277</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg543">
+        <source xml:space="preserve">Change current passphrase</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">398</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg544">
+        <source xml:space="preserve">Old passphrase</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">409</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg545">
+        <source xml:space="preserve">New passphrase</source>
+        <target xml:space="preserve" state="needs-review-translation">New passphrase</target>
+        <context-group purpose="location"><context context-type="linenumber">419</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg546">
+        <source xml:space="preserve">Repeat new passphrase</source>
+        <target xml:space="preserve" state="needs-review-translation">Repeat new passphrase</target>
+        <context-group purpose="location"><context context-type="linenumber">429</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg547">
+        <source xml:space="preserve">Show passphrase</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">436</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg548">
+        <source xml:space="preserve">Submit</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">457</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg549">
+        <source xml:space="preserve">Clear All</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">470</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg550">
+        <source xml:space="preserve">Quantity of PRCY to keep as spendable (not staking)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">484</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg551">
+        <source xml:space="preserve">Enabling this will incur a maximum 0.1 PRCY fee each time you receive a new deposit that needs to be consolidated for staking.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">500</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg552">
+        <source xml:space="preserve">Automatically add any new deposits received to your staked balance</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">503</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg553">
+        <source xml:space="preserve">Save</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">542</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg554">
+        <source xml:space="preserve">Disable</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">549</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg555">
+        <source xml:space="preserve">Network Settings</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">602</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg556">
+        <source xml:space="preserve">Automatically open the PRCY client port on the router. This only works when your router supports UPnP and it is enabled.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">608</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg557">
+        <source xml:space="preserve">Map port using &amp;UPnP</source>
+        <target xml:space="preserve" state="needs-review-translation">Map port using &amp;UPnP</target>
+        <context-group purpose="location"><context context-type="linenumber">611</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg558">
+        <source xml:space="preserve">Window Settings</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">621</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg559">
+        <source xml:space="preserve">&amp;Minimize to the tray instead of the taskbar</source>
+        <target xml:space="preserve" state="needs-review-translation">&amp;Minimize to the tray instead of the taskbar</target>
+        <context-group purpose="location"><context context-type="linenumber">627</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg560">
+        <source xml:space="preserve">M&amp;inimize on close</source>
+        <target xml:space="preserve" state="needs-review-translation">M&amp;inimize on close</target>
+        <context-group purpose="location"><context context-type="linenumber">634</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg561">
+        <source xml:space="preserve">Privacy Settings</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">644</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg562">
+        <source xml:space="preserve">Hide Balance when unlocked</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">650</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg563">
+        <source xml:space="preserve">Lock &quot;Send&quot; tab when unlocked</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">657</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg564">
+        <source xml:space="preserve">Alternative Currency Value</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">667</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg565">
+        <source xml:space="preserve">Display alternative currency value of wallet on Overview</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">675</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg566">
+        <source xml:space="preserve">Default Currency:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">682</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg567">
+        <source xml:space="preserve">USD</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">693</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg568">
+        <source xml:space="preserve">CAD</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">698</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg569">
+        <source xml:space="preserve">EUR</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">703</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg570">
+        <source xml:space="preserve">GBP</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">708</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg571">
+        <source xml:space="preserve">BTC</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">713</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg572">
+        <source xml:space="preserve">ETH</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">718</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg573">
+        <source xml:space="preserve">XAU</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">723</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg574">
+        <source xml:space="preserve">XAG</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">728</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg575">
+        <source xml:space="preserve">Two Factor Authentication</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg576">
+        <source xml:space="preserve">Remember my authentication code for</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg577">
+        <source xml:space="preserve">1 Day</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg578">
+        <source xml:space="preserve">1 Week</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg579">
+        <source xml:space="preserve">1 Month</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">313</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg580">
+        <source xml:space="preserve">Current Authentication Code</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../optionspage.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="OptionsPage">
+      <trans-unit id="_msg581">
+        <source xml:space="preserve">Reserve Balance Empty</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg582">
+        <source xml:space="preserve">PRCY reserve amount is empty and must be a minimum of 1.
+Please click Disable if you would like to turn it off.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">216</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg583">
+        <source xml:space="preserve">Invalid Reserve Amount</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">224</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg584">
+        <source xml:space="preserve">The amount you have attempted to keep as spendable is greater than the %1 (%2M) limit. Please try a smaller amount.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg585">
+        <source xml:space="preserve">Reserve Balance Set</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg586">
+        <source xml:space="preserve">Reserve balance of %1 PRCY is successfully set.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg587">
+        <source xml:space="preserve">Reserve Balance Disabled</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">252</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg588">
+        <source xml:space="preserve">Reserve balance disabled.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">253</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg589">
+        <source xml:space="preserve">Wallet Encryption Failed</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">307</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">313</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg590">
+        <source xml:space="preserve">The passphrase entered for wallet encryption was empty or contained spaces. Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">272</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg591">
+        <source xml:space="preserve">The passphrase you have entered is the same as your old passphrase. Please use a different passphrase if you would like to change it.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg592">
+        <source xml:space="preserve">The passphrase&apos;s length has to be more than 10. Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg593">
+        <source xml:space="preserve">The passphrase must contain lower, upper, digit, symbol. Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">308</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg594">
+        <source xml:space="preserve">The passphrase is too weak. You must use a minimum passphrase length of 10 characters and use uppercase letters, lowercase letters, numbers, and symbols. Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">314</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg595">
+        <source xml:space="preserve">Passphrase Change Successful</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg596">
+        <source xml:space="preserve">Wallet passphrase was successfully changed.
+Please remember your passphrase as there is no way to recover it.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">320</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg597">
+        <source xml:space="preserve">The passphrases entered for wallet encryption do not match. Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg598">
+        <source xml:space="preserve">Wallet Data (*.dat)</source>
+        <target xml:space="preserve" state="needs-review-translation">Wallet Data (*.dat)</target>
+        <context-group purpose="location"><context context-type="linenumber">350</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg599">
+        <source xml:space="preserve">Wallet has been successfully backed up to </source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">357</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg600">
+        <source xml:space="preserve">Wallet Backup Successful</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">359</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg601">
+        <source xml:space="preserve">Wallet Backup Failed</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg602">
+        <source xml:space="preserve">Wallet backup failed. Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg603">
+        <source xml:space="preserve">Staking Disabled - Syncing Masternode list</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">417</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg604">
+        <source xml:space="preserve">Enable Staking is disabled when you are still syncing the Masternode list as this is required. Please allow the wallet to fully sync this list before attempting to Enable Staking.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">418</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg605">
+        <source xml:space="preserve">Staking Setting</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">425</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg606">
+        <source xml:space="preserve">Please unlock the wallet with your passphrase before changing this setting.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">426</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">623</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1005</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg607">
+        <source xml:space="preserve">PoW blocks are still being mined.
+Please wait until Block %1.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">436</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg608">
+        <source xml:space="preserve">Information</source>
+        <target xml:space="preserve" state="needs-review-translation">Information</target>
+        <context-group purpose="location"><context context-type="linenumber">438</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">520</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg609">
+        <source xml:space="preserve">Your stakeable balance is under the threshold of %1 PRCY. Please deposit more PRCY into your account in order to enable staking.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">456</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg610">
+        <source xml:space="preserve">Your balance requires a consolidation transaction which incurs a fee of between %1 to %2 PRCY. However after that transaction fee, your balance will be below the staking threshold of %3 PRCY. Please deposit more PRCY into your account or reduce your reserved amount in order to enable staking.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">458</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg611">
+        <source xml:space="preserve">Your stakeable balance is under the threshold of %1 PRCY. This is due to your reserve balance being too high. Please deposit more PRCY into your account or reduce your reserved amount in order to enable staking.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">463</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg612">
+        <source xml:space="preserve">Your stakeable balance is under the threshold of %1 PRCY. This is due to your reserve balance of %2 PRCY being too high. The wallet software has tried to consolidate your funds with the reserve balance but without success because of a consolidation fee of %3 PRCY. Please wait around 10 minutes for the wallet to resolve the reserve to enable staking.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">467</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg613">
+        <source xml:space="preserve">Warning: Staking Issue</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">473</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg614">
+        <source xml:space="preserve">In order to enable staking with 100%% of your current balance, your previous PRCY deposits must be consolidated and reorganized. This will incur a fee of between %1 to %2 PRCY.
+
+Would you like to do this?</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">493</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg615">
+        <source xml:space="preserve">In order to enable staking with 100%% of your current balance except the reserve balance, your previous PRCY deposits must be consolidated and reorganized. This will incur a fee of between %1 to %2 PRCY.
+
+Would you like to do this?</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">497</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg616">
+        <source xml:space="preserve">Staking Needs Consolidation</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">502</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg617">
+        <source xml:space="preserve">Consolidation transaction created!</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">521</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg618">
+        <source xml:space="preserve">2FA Setting</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">622</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg619">
+        <source xml:space="preserve">SUCCESS!</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">670</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg620">
+        <source xml:space="preserve">Two-factor authentication has been successfully enabled.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">671</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg621">
+        <source xml:space="preserve">UPNP Settings</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">839</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg622">
+        <source xml:space="preserve">UPNP Settings successfully changed. Please restart the wallet for changes to take effect.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">840</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg623">
+        <source xml:space="preserve">2FA Digit Settings</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">873</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">879</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg624">
+        <source xml:space="preserve">2FA Digit Settings have been changed successfully.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">874</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg625">
+        <source xml:space="preserve">2FA Digit Settings have not been changed.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">880</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg626">
+        <source xml:space="preserve">Hide Balance When Unlocked</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">923</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg627">
+        <source xml:space="preserve">Attempt to Disable &apos;Hide Balance when unlocked&apos; failed or canceled. Wallet Locked for security.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">924</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg628">
+        <source xml:space="preserve">Lock Send Tab When Unlocked</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">957</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg629">
+        <source xml:space="preserve">Attempt to Disable &apos;Lock Send Tab when unlocked&apos; failed or canceled. Wallet Locked for security.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">958</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg630">
+        <source xml:space="preserve">Password Locked Setting</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1004</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/overviewpage.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="OverviewPage">
+      <trans-unit id="_msg631" approved="yes">
+        <source xml:space="preserve">Form</source>
+        <target xml:space="preserve">Form</target>
+        <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg632">
+        <source xml:space="preserve">Blocks</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg633">
+        <source xml:space="preserve">???</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg634">
+        <source xml:space="preserve"> of </source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg635">
+        <source xml:space="preserve">(loading)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg636">
+        <source xml:space="preserve">Balance</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">213</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg637">
+        <source xml:space="preserve">Your current balance</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">236</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg638" approved="yes">
+        <source xml:space="preserve">Your current spendable balance</source>
+        <target xml:space="preserve">Your current spendable balance</target>
+        <context-group purpose="location"><context context-type="linenumber">362</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg639" approved="yes">
+        <source xml:space="preserve">Pending:</source>
+        <target xml:space="preserve">Pending:</target>
+        <context-group purpose="location"><context context-type="linenumber">384</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg640" approved="yes">
+        <source xml:space="preserve">Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
+        <target xml:space="preserve">Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</target>
+        <context-group purpose="location"><context context-type="linenumber">403</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg641">
+        <source xml:space="preserve">(syncing)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">422</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg642">
+        <source xml:space="preserve">Recent Transactions</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">488</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">491</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg643">
+        <source xml:space="preserve">It is advised not to send or receive coins until your current sync is complete.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">551</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg644" approved="yes">
+        <source xml:space="preserve">Spendable:</source>
+        <target xml:space="preserve">Spendable:</target>
+        <context-group purpose="location"><context context-type="linenumber">337</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../overviewpage.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="OverviewPage">
+      <trans-unit id="_msg645" approved="yes">
+        <source xml:space="preserve"></source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">229</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../paymentserver.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="PaymentServer">
+      <trans-unit id="_msg646" approved="yes">
+        <source xml:space="preserve">Payment request error</source>
+        <target xml:space="preserve">Payment request error</target>
+        <context-group purpose="location"><context context-type="linenumber">163</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg647" approved="yes">
+        <source xml:space="preserve">URI handling</source>
+        <target xml:space="preserve">URI handling</target>
+        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">224</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg648" approved="yes">
+        <source xml:space="preserve">Invalid payment address %1</source>
+        <target xml:space="preserve">Invalid payment address %1</target>
+        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg649">
+        <source xml:space="preserve">Cannot start prcycoin: click-to-pay handler</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg650">
+        <source xml:space="preserve">URI cannot be parsed! This can be caused by an invalid PRCY address or malformed URI parameters.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../peertablemodel.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="PeerTableModel">
+      <trans-unit id="_msg651">
+        <source xml:space="preserve">NodeId</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg652">
+        <source xml:space="preserve">Node/Service</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg653">
+        <source xml:space="preserve">Ping</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg654">
+        <source xml:space="preserve">Sent</source>
+        <target xml:space="preserve" state="needs-review-translation">Sent</target>
+        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg655">
+        <source xml:space="preserve">Received</source>
+        <target xml:space="preserve" state="needs-review-translation">Received</target>
+        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg656">
+        <source xml:space="preserve">User Agent</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">120</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../bitcoinunits.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="QObject">
+      <trans-unit id="_msg657" approved="yes">
+        <source xml:space="preserve">Amount</source>
+        <target xml:space="preserve">Amount</target>
+        <context-group purpose="location"><context context-type="linenumber">256</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../guiutil.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="QObject">
+      <trans-unit id="_msg658" approved="yes">
+        <source xml:space="preserve">%1 d</source>
+        <target xml:space="preserve">%1 d</target>
+        <context-group purpose="location"><context context-type="linenumber">822</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg659" approved="yes">
+        <source xml:space="preserve">%1 h</source>
+        <target xml:space="preserve">%1 h</target>
+        <context-group purpose="location"><context context-type="linenumber">824</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg660" approved="yes">
+        <source xml:space="preserve">%1 m</source>
+        <target xml:space="preserve">%1 m</target>
+        <context-group purpose="location"><context context-type="linenumber">826</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg661" approved="yes">
+        <source xml:space="preserve">%1 s</source>
+        <target xml:space="preserve">%1 s</target>
+        <context-group purpose="location"><context context-type="linenumber">828</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">868</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg662" approved="yes">
+        <source xml:space="preserve">NETWORK</source>
+        <target xml:space="preserve">NETWORK</target>
+        <context-group purpose="location"><context context-type="linenumber">843</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg663">
+        <source xml:space="preserve">BLOOM</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">847</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg664" approved="yes">
+        <source xml:space="preserve">UNKNOWN</source>
+        <target xml:space="preserve">UNKNOWN</target>
+        <context-group purpose="location"><context context-type="linenumber">850</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg665" approved="yes">
+        <source xml:space="preserve">None</source>
+        <target xml:space="preserve">None</target>
+        <context-group purpose="location"><context context-type="linenumber">858</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg666" approved="yes">
+        <source xml:space="preserve">N/A</source>
+        <target xml:space="preserve">N/A</target>
+        <context-group purpose="location"><context context-type="linenumber">863</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg667" approved="yes">
+        <source xml:space="preserve">%1 ms</source>
+        <target xml:space="preserve">%1 ms</target>
+        <context-group purpose="location"><context context-type="linenumber">863</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg668">
+        <source xml:space="preserve">%1 B</source>
+        <target xml:space="preserve" state="needs-review-translation">%1 B</target>
+        <context-group purpose="location"><context context-type="linenumber">874</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg669">
+        <source xml:space="preserve">%1 KB</source>
+        <target xml:space="preserve" state="needs-review-translation">%1 KB</target>
+        <context-group purpose="location"><context context-type="linenumber">876</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg670">
+        <source xml:space="preserve">%1 MB</source>
+        <target xml:space="preserve" state="needs-review-translation">%1 MB</target>
+        <context-group purpose="location"><context context-type="linenumber">878</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg671">
+        <source xml:space="preserve">%1 GB</source>
+        <target xml:space="preserve" state="needs-review-translation">%1 GB</target>
+        <context-group purpose="location"><context context-type="linenumber">880</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../receiverequestdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="QRImageWidget">
+      <trans-unit id="_msg672" approved="yes">
+        <source xml:space="preserve">&amp;Save Image...</source>
+        <target xml:space="preserve">&amp;Save Image...</target>
+        <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg673" approved="yes">
+        <source xml:space="preserve">&amp;Copy Image</source>
+        <target xml:space="preserve">&amp;Copy Image</target>
+        <context-group purpose="location"><context context-type="linenumber">38</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg674" approved="yes">
+        <source xml:space="preserve">Save QR Code</source>
+        <target xml:space="preserve">Save QR Code</target>
+        <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg675" approved="yes">
+        <source xml:space="preserve">PNG Image (*.png)</source>
+        <target xml:space="preserve">PNG Image (*.png)</target>
+        <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
+      </trans-unit>
+    </group>
+    <group restype="x-trolltech-linguist-context" resname="ReceiveRequestDialog">
+      <trans-unit id="_msg676" approved="yes">
+        <source xml:space="preserve">Request payment to %1</source>
+        <target xml:space="preserve">Request payment to %1</target>
+        <context-group purpose="location"><context context-type="linenumber">132</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg677" approved="yes">
+        <source xml:space="preserve">Payment information</source>
+        <target xml:space="preserve">Payment information</target>
+        <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg678" approved="yes">
+        <source xml:space="preserve">URI</source>
+        <target xml:space="preserve">URI</target>
+        <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg679" approved="yes">
+        <source xml:space="preserve">Address</source>
+        <target xml:space="preserve">Address</target>
+        <context-group purpose="location"><context context-type="linenumber">141</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg680" approved="yes">
+        <source xml:space="preserve">Amount</source>
+        <target xml:space="preserve">Amount</target>
+        <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg681" approved="yes">
+        <source xml:space="preserve">Label</source>
+        <target xml:space="preserve">Label</target>
+        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg682" approved="yes">
+        <source xml:space="preserve">Message</source>
+        <target xml:space="preserve">Message</target>
+        <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg683" approved="yes">
+        <source xml:space="preserve">Resulting URI too long, try to reduce the text for label / message.</source>
+        <target xml:space="preserve">Resulting URI too long, try to reduce the text for label / message.</target>
+        <context-group purpose="location"><context context-type="linenumber">155</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg684" approved="yes">
+        <source xml:space="preserve">Error encoding URI into QR Code.</source>
+        <target xml:space="preserve">Error encoding URI into QR Code.</target>
+        <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/rpcconsole.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="RPCConsole">
+      <trans-unit id="_msg685" approved="yes">
+        <source xml:space="preserve">Tools window</source>
+        <target xml:space="preserve">Tools window</target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg686" approved="yes">
+        <source xml:space="preserve">&amp;Information</source>
+        <target xml:space="preserve">&amp;Information</target>
+        <context-group purpose="location"><context context-type="linenumber">24</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg687" approved="yes">
+        <source xml:space="preserve">General</source>
+        <target xml:space="preserve">General</target>
+        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg688" approved="yes">
+        <source xml:space="preserve">Name</source>
+        <target xml:space="preserve">Name</target>
+        <context-group purpose="location"><context context-type="linenumber">187</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg689" approved="yes">
+        <source xml:space="preserve">Client name</source>
+        <target xml:space="preserve">Client name</target>
+        <context-group purpose="location"><context context-type="linenumber">53</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg690" approved="yes">
+        <source xml:space="preserve">N/A</source>
+        <target xml:space="preserve">N/A</target>
+        <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">63</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">197</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">220</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">368</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">845</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">868</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">891</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">914</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">937</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">960</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">983</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1006</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1029</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1052</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1075</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1098</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1121</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1144</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1167</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1193</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1216</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1281</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1416</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">1535</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg691" approved="yes">
+        <source xml:space="preserve">Number of connections</source>
+        <target xml:space="preserve">Number of connections</target>
+        <context-group purpose="location"><context context-type="linenumber">210</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg692">
+        <source xml:space="preserve">Block chain</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">262</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg693" approved="yes">
+        <source xml:space="preserve">&amp;Open</source>
+        <target xml:space="preserve">&amp;Open</target>
+        <context-group purpose="location"><context context-type="linenumber">344</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg694" approved="yes">
+        <source xml:space="preserve">Startup time</source>
+        <target xml:space="preserve">Startup time</target>
+        <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg695" approved="yes">
+        <source xml:space="preserve">Network</source>
+        <target xml:space="preserve">Network</target>
+        <context-group purpose="location"><context context-type="linenumber">180</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg696" approved="yes">
+        <source xml:space="preserve">Last block time</source>
+        <target xml:space="preserve">Last block time</target>
+        <context-group purpose="location"><context context-type="linenumber">292</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg697" approved="yes">
+        <source xml:space="preserve">Debug log file</source>
+        <target xml:space="preserve">Debug log file</target>
+        <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg698" approved="yes">
+        <source xml:space="preserve">Using OpenSSL version</source>
+        <target xml:space="preserve">Using OpenSSL version</target>
+        <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg699" approved="yes">
+        <source xml:space="preserve">Current number of blocks</source>
+        <target xml:space="preserve">Current number of blocks</target>
+        <context-group purpose="location"><context context-type="linenumber">269</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg700" approved="yes">
+        <source xml:space="preserve">Client version</source>
+        <target xml:space="preserve">Client version</target>
+        <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg701" approved="yes">
+        <source xml:space="preserve">Using BerkeleyDB version</source>
+        <target xml:space="preserve">Using BerkeleyDB version</target>
+        <context-group purpose="location"><context context-type="linenumber">125</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg702">
+        <source xml:space="preserve">Open the PRCY debug log file from the current data directory. This can take a few seconds for large log files.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg703" approved="yes">
+        <source xml:space="preserve">Number of Masternodes</source>
+        <target xml:space="preserve">Number of Masternodes</target>
+        <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg704" approved="yes">
+        <source xml:space="preserve">&amp;Console</source>
+        <target xml:space="preserve">&amp;Console</target>
+        <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg705" approved="yes">
+        <source xml:space="preserve">Clear console</source>
+        <target xml:space="preserve">Clear console</target>
+        <context-group purpose="location"><context context-type="linenumber">425</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg706" approved="yes">
+        <source xml:space="preserve">&amp;Network Traffic</source>
+        <target xml:space="preserve">&amp;Network Traffic</target>
+        <context-group purpose="location"><context context-type="linenumber">448</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg707" approved="yes">
+        <source xml:space="preserve">&amp;Clear</source>
+        <target xml:space="preserve">&amp;Clear</target>
+        <context-group purpose="location"><context context-type="linenumber">500</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg708" approved="yes">
+        <source xml:space="preserve">Totals</source>
+        <target xml:space="preserve">Totals</target>
+        <context-group purpose="location"><context context-type="linenumber">516</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg709" approved="yes">
+        <source xml:space="preserve">Received</source>
+        <target xml:space="preserve">Received</target>
+        <context-group purpose="location"><context context-type="linenumber">580</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg710" approved="yes">
+        <source xml:space="preserve">Sent</source>
+        <target xml:space="preserve">Sent</target>
+        <context-group purpose="location"><context context-type="linenumber">660</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg711" approved="yes">
+        <source xml:space="preserve">&amp;Peers</source>
+        <target xml:space="preserve">&amp;Peers</target>
+        <context-group purpose="location"><context context-type="linenumber">701</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg712">
+        <source xml:space="preserve">Banned peers</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">751</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg713" approved="yes">
+        <source xml:space="preserve">Select a peer to view detailed information.</source>
+        <target xml:space="preserve">Select a peer to view detailed information.</target>
+        <context-group purpose="location"><context context-type="linenumber">810</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">322</context></context-group>
+        <context-group purpose="location"><context context-type="sourcefile">../rpcconsole.cpp</context><context context-type="linenumber">1077</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg714">
+        <source xml:space="preserve">Whitelisted</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">835</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg715" approved="yes">
+        <source xml:space="preserve">Direction</source>
+        <target xml:space="preserve">Direction</target>
+        <context-group purpose="location"><context context-type="linenumber">858</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg716">
+        <source xml:space="preserve">Protocol</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">881</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg717" approved="yes">
+        <source xml:space="preserve">Version</source>
+        <target xml:space="preserve">Version</target>
+        <context-group purpose="location"><context context-type="linenumber">904</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg718" approved="yes">
+        <source xml:space="preserve">Services</source>
+        <target xml:space="preserve">Services</target>
+        <context-group purpose="location"><context context-type="linenumber">927</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg719" approved="yes">
+        <source xml:space="preserve">Ban Score</source>
+        <target xml:space="preserve">Ban Score</target>
+        <context-group purpose="location"><context context-type="linenumber">1019</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg720" approved="yes">
+        <source xml:space="preserve">Connection Time</source>
+        <target xml:space="preserve">Connection Time</target>
+        <context-group purpose="location"><context context-type="linenumber">1042</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg721" approved="yes">
+        <source xml:space="preserve">Last Send</source>
+        <target xml:space="preserve">Last Send</target>
+        <context-group purpose="location"><context context-type="linenumber">1065</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg722" approved="yes">
+        <source xml:space="preserve">Last Receive</source>
+        <target xml:space="preserve">Last Receive</target>
+        <context-group purpose="location"><context context-type="linenumber">1088</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg723" approved="yes">
+        <source xml:space="preserve">Bytes Sent</source>
+        <target xml:space="preserve">Bytes Sent</target>
+        <context-group purpose="location"><context context-type="linenumber">1111</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg724" approved="yes">
+        <source xml:space="preserve">Bytes Received</source>
+        <target xml:space="preserve">Bytes Received</target>
+        <context-group purpose="location"><context context-type="linenumber">1134</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg725" approved="yes">
+        <source xml:space="preserve">Ping Time</source>
+        <target xml:space="preserve">Ping Time</target>
+        <context-group purpose="location"><context context-type="linenumber">1157</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg726">
+        <source xml:space="preserve">The duration of a currently outstanding ping.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1180</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg727">
+        <source xml:space="preserve">Ping Wait</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1183</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg728">
+        <source xml:space="preserve">Time Offset</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1206</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg729" approved="yes">
+        <source xml:space="preserve">&amp;Wallet Repair</source>
+        <target xml:space="preserve">&amp;Wallet Repair</target>
+        <context-group purpose="location"><context context-type="linenumber">1246</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg730">
+        <source xml:space="preserve">The buttons below will restart the wallet with command-line options to repair the wallet, fix issues with corrupt blockhain files or missing/obsolete transactions.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1261</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg731">
+        <source xml:space="preserve">Custom Backup Path:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1297</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg732">
+        <source xml:space="preserve">Custom Backups Threshold:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1462</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg733">
+        <source xml:space="preserve">Rebuild block chain index from current blk000??.dat files.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1506</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg734">
+        <source xml:space="preserve">Wallet In Use:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1271</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg735" approved="yes">
+        <source xml:space="preserve">Salvage wallet</source>
+        <target xml:space="preserve">Salvage wallet</target>
+        <context-group purpose="location"><context context-type="linenumber">1310</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg736">
+        <source xml:space="preserve">Attempt to recover private keys from a corrupt wallet.dat.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1561</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg737" approved="yes">
+        <source xml:space="preserve">Rescan blockchain files</source>
+        <target xml:space="preserve">Rescan blockchain files</target>
+        <context-group purpose="location"><context context-type="linenumber">1577</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg738" approved="yes">
+        <source xml:space="preserve">Recover transactions 1</source>
+        <target xml:space="preserve">Recover transactions 1</target>
+        <context-group purpose="location"><context context-type="linenumber">1343</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg739">
+        <source xml:space="preserve">Recover transactions from blockchain (keep meta-data, e.g. account owner).</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1357</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg740">
+        <source xml:space="preserve">Data Directory</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">354</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg741">
+        <source xml:space="preserve">Last block hash</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">361</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg742" approved="yes">
+        <source xml:space="preserve">Recover transactions 2</source>
+        <target xml:space="preserve">Recover transactions 2</target>
+        <context-group purpose="location"><context context-type="linenumber">1435</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg743">
+        <source xml:space="preserve">Rescan the block chain for missing wallet transactions.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1591</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg744">
+        <source xml:space="preserve">Recover transactions from blockchain (drop meta-data).</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1449</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg745" approved="yes">
+        <source xml:space="preserve">Upgrade wallet format</source>
+        <target xml:space="preserve">Upgrade wallet format</target>
+        <context-group purpose="location"><context context-type="linenumber">1373</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg746">
+        <source xml:space="preserve">-resync:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1469</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg747">
+        <source xml:space="preserve">Delete local Blockchain Folders</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1522</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg748">
+        <source xml:space="preserve">Deletes all local blockchain folders so the wallet synchronizes from scratch.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1476</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg749">
+        <source xml:space="preserve">Starting Block</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">950</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg750">
+        <source xml:space="preserve">Synced Headers</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">973</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg751">
+        <source xml:space="preserve">Synced Blocks</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">996</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg752" approved="yes">
+        <source xml:space="preserve">Wallet repair options.</source>
+        <target xml:space="preserve">Wallet repair options.</target>
+        <context-group purpose="location"><context context-type="linenumber">1330</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg753">
+        <source xml:space="preserve">Upgrade wallet to latest format on startup. (Note: this is NOT an update of the wallet itself!)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">1387</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg754" approved="yes">
+        <source xml:space="preserve">Rebuild index</source>
+        <target xml:space="preserve">Rebuild index</target>
+        <context-group purpose="location"><context context-type="linenumber">1403</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../rpcconsole.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="RPCConsole">
+      <trans-unit id="_msg755" approved="yes">
+        <source xml:space="preserve">In:</source>
+        <target xml:space="preserve">In:</target>
+        <context-group purpose="location"><context context-type="linenumber">677</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg756" approved="yes">
+        <source xml:space="preserve">Out:</source>
+        <target xml:space="preserve">Out:</target>
+        <context-group purpose="location"><context context-type="linenumber">678</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg757">
+        <source xml:space="preserve">Welcome to the PRCY RPC console.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">639</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg758">
+        <source xml:space="preserve">&amp;Disconnect Node</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">419</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg759">
+        <source xml:space="preserve">Ban Node for</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">420</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">421</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">422</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">423</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg760">
+        <source xml:space="preserve">1 &amp;hour</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">420</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg761">
+        <source xml:space="preserve">1 &amp;day</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">421</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg762">
+        <source xml:space="preserve">1 &amp;week</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">422</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg763">
+        <source xml:space="preserve">1 &amp;year</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">423</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg764">
+        <source xml:space="preserve">&amp;Unban Node</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">470</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg765">
+        <source xml:space="preserve">This will delete your local blockchain folders and the wallet will synchronize the complete Blockchain from scratch.&lt;br /&gt;&lt;br /&gt;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">566</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg766">
+        <source xml:space="preserve">This needs quite some time and downloads a lot of data.&lt;br /&gt;&lt;br /&gt;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">567</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg767">
+        <source xml:space="preserve">Your transactions and funds will be visible again after the download has completed.&lt;br /&gt;&lt;br /&gt;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">568</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg768">
+        <source xml:space="preserve">Do you want to continue?.&lt;br /&gt;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">569</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg769">
+        <source xml:space="preserve">Confirm resync Blockchain</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">570</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg770">
+        <source xml:space="preserve">Use up and down arrows to navigate history, and %1 to clear screen.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">640</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg771" approved="yes">
+        <source xml:space="preserve">Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
+        <target xml:space="preserve">Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</target>
+        <context-group purpose="location"><context context-type="linenumber">641</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg772">
+        <source xml:space="preserve">WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">643</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg773">
+        <source xml:space="preserve">(node id: %1)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">904</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg774" approved="yes">
+        <source xml:space="preserve">via %1</source>
+        <target xml:space="preserve">via %1</target>
+        <context-group purpose="location"><context context-type="linenumber">906</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg775" approved="yes">
+        <source xml:space="preserve">never</source>
+        <target xml:space="preserve">never</target>
+        <context-group purpose="location"><context context-type="linenumber">909</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">910</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg776" approved="yes">
+        <source xml:space="preserve">Inbound</source>
+        <target xml:space="preserve">Inbound</target>
+        <context-group purpose="location"><context context-type="linenumber">919</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg777" approved="yes">
+        <source xml:space="preserve">Outbound</source>
+        <target xml:space="preserve">Outbound</target>
+        <context-group purpose="location"><context context-type="linenumber">919</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg778">
+        <source xml:space="preserve">Yes</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">921</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg779">
+        <source xml:space="preserve">No</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">921</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg780" approved="yes">
+        <source xml:space="preserve">Unknown</source>
+        <target xml:space="preserve">Unknown</target>
+        <context-group purpose="location"><context context-type="linenumber">933</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">939</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/receivecoinsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="ReceiveCoinsDialog">
+      <trans-unit id="_msg781">
+        <source xml:space="preserve">An optional message to attach to the payment request, which will be displayed when the request is opened.&lt;br&gt;Note: The message will not be sent with the payment over the PRCY network.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">79</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg782">
+        <source xml:space="preserve">Description (optional)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg783">
+        <source xml:space="preserve">Description:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">82</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg784">
+        <source xml:space="preserve">Amount:</source>
+        <target xml:space="preserve" state="needs-review-translation">Amount:</target>
+        <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg785">
+        <source xml:space="preserve">List of addresses to receive with</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">108</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">115</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg786">
+        <source xml:space="preserve">Address:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">118</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg787">
+        <source xml:space="preserve">Submit payment request for address selected above</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg788">
+        <source xml:space="preserve">&amp;Submit</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg789">
+        <source xml:space="preserve">PRCY Amount (optional)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">177</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg790">
+        <source xml:space="preserve">Copy Master Account address to clipboard</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">227</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg791">
+        <source xml:space="preserve">Master Account address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">237</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg792">
+        <source xml:space="preserve">Remove Integrated Address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">259</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg793">
+        <source xml:space="preserve">Generate Integrated Address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">269</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg794" approved="yes">
+        <source xml:space="preserve">An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
+        <target xml:space="preserve">An optional amount to request. Leave this empty or zero to not request a specific amount.</target>
+        <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">174</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../receivecoinsdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="ReceiveCoinsDialog">
+      <trans-unit id="_msg795" approved="yes">
+        <source xml:space="preserve">Copy label</source>
+        <target xml:space="preserve">Copy label</target>
+        <context-group purpose="location"><context context-type="linenumber">36</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg796" approved="yes">
+        <source xml:space="preserve">Copy message</source>
+        <target xml:space="preserve">Copy message</target>
+        <context-group purpose="location"><context context-type="linenumber">37</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg797" approved="yes">
+        <source xml:space="preserve">Copy amount</source>
+        <target xml:space="preserve">Copy amount</target>
+        <context-group purpose="location"><context context-type="linenumber">38</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg798">
+        <source xml:space="preserve">Copy address</source>
+        <target xml:space="preserve" state="needs-review-translation">Copy address</target>
+        <context-group purpose="location"><context context-type="linenumber">39</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg799">
+        <source xml:space="preserve">Invalid Amount</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">196</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg800">
+        <source xml:space="preserve">Invalid amount entered. Please enter an amount less than %1 (%2M) PRCY.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">197</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg801">
+        <source xml:space="preserve">Enter Label</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg802">
+        <source xml:space="preserve">Label (Payment ID is added by default)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/receiverequestdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="ReceiveRequestDialog">
+      <trans-unit id="_msg803" approved="yes">
+        <source xml:space="preserve">QR Code</source>
+        <target xml:space="preserve">QR Code</target>
+        <context-group purpose="location"><context context-type="linenumber">29</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg804" approved="yes">
+        <source xml:space="preserve">Copy &amp;URI</source>
+        <target xml:space="preserve">Copy &amp;URI</target>
+        <context-group purpose="location"><context context-type="linenumber">75</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg805" approved="yes">
+        <source xml:space="preserve">Copy &amp;Address</source>
+        <target xml:space="preserve">Copy &amp;Address</target>
+        <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg806" approved="yes">
+        <source xml:space="preserve">&amp;Save Image...</source>
+        <target xml:space="preserve">&amp;Save Image...</target>
+        <context-group purpose="location"><context context-type="linenumber">95</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/revealtxdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="RevealTxDialog">
+      <trans-unit id="_msg807">
+        <source xml:space="preserve">Transaction Details</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg808">
+        <source xml:space="preserve">TXID:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg809">
+        <source xml:space="preserve">Copy transaction ID to clipboard</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg810">
+        <source xml:space="preserve">Address:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg811">
+        <source xml:space="preserve">Private Key:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">133</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg812">
+        <source xml:space="preserve">Amount:</source>
+        <target xml:space="preserve" state="needs-review-translation">Amount:</target>
+        <context-group purpose="location"><context context-type="linenumber">179</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg813">
+        <source xml:space="preserve">Fee:</source>
+        <target xml:space="preserve" state="needs-review-translation">Fee:</target>
+        <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg814">
+        <source xml:space="preserve">Ring Size:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg815">
+        <source xml:space="preserve">Payment ID:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">317</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg816">
+        <source xml:space="preserve">In Block:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">358</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg817">
+        <source xml:space="preserve">Height:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg818">
+        <source xml:space="preserve">Hash:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">425</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg819">
+        <source xml:space="preserve">Copy address to clipboard</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">113</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">405</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">458</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg820">
+        <source xml:space="preserve">Copy transaction private key to clipboard</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">159</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg821">
+        <source xml:space="preserve">Copy Transaction Amount to clipboard</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">205</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg822">
+        <source xml:space="preserve">Copy Transaction Fee to clipboard</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">251</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg823">
+        <source xml:space="preserve">Copy Payment ID to clipboard</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">297</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../revealtxdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="RevealTxDialog">
+      <trans-unit id="_msg824">
+        <source xml:space="preserve">Are You Sure?</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">200</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg825">
+        <source xml:space="preserve">Are you sure you would like to delete this transaction from the local wallet?
+
+Note: They can only be restored from backup or rescan.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">201</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg826">
+        <source xml:space="preserve">Potential Masternode Collateral Detected!</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">207</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg827">
+        <source xml:space="preserve">Potential Masternode Collateral Detected!
+Are you sure?
+
+Note: They can only be restored from backup or rescan.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg828">
+        <source xml:space="preserve">Invalid or non-wallet transaction id</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">222</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg829">
+        <source xml:space="preserve">Invalid or non-wallet transaction id.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">223</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg830">
+        <source xml:space="preserve">Unable to delete transaction id</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">230</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg831">
+        <source xml:space="preserve">Unable to delete transaction id.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg832">
+        <source xml:space="preserve">Do not show successful confirmation again</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg833">
+        <source xml:space="preserve">OK</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg834">
+        <source xml:space="preserve">Success!</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg835">
+        <source xml:space="preserve">Transaction ID successfully deleted.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">245</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/sendcoinsdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="SendCoinsDialog">
+      <trans-unit id="_msg836" approved="yes">
+        <source xml:space="preserve">Send Coins</source>
+        <target xml:space="preserve">Send Coins</target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg837" approved="yes">
+        <source xml:space="preserve">Confirm the send action</source>
+        <target xml:space="preserve">Confirm the send action</target>
+        <context-group purpose="location"><context context-type="linenumber">828</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg838" approved="yes">
+        <source xml:space="preserve">S&amp;end</source>
+        <target xml:space="preserve">S&amp;end</target>
+        <context-group purpose="location"><context context-type="linenumber">831</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg839" approved="yes">
+        <source xml:space="preserve">Send to multiple recipients at once</source>
+        <target xml:space="preserve">Send to multiple recipients at once</target>
+        <context-group purpose="location"><context context-type="linenumber">751</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg840">
+        <source xml:space="preserve">Coin Control Features</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg841">
+        <source xml:space="preserve">Open Coin Control...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">163</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg842">
+        <source xml:space="preserve">Coins automatically selected</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg843">
+        <source xml:space="preserve">Insufficient funds!</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">192</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg844">
+        <source xml:space="preserve">Quantity:</source>
+        <target xml:space="preserve" state="needs-review-translation">Quantity:</target>
+        <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg845">
+        <source xml:space="preserve">Bytes:</source>
+        <target xml:space="preserve" state="needs-review-translation">Bytes:</target>
+        <context-group purpose="location"><context context-type="linenumber">316</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg846">
+        <source xml:space="preserve">Amount:</source>
+        <target xml:space="preserve" state="needs-review-translation">Amount:</target>
+        <context-group purpose="location"><context context-type="linenumber">364</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg847">
+        <source xml:space="preserve">Priority:</source>
+        <target xml:space="preserve" state="needs-review-translation">Priority:</target>
+        <context-group purpose="location"><context context-type="linenumber">396</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg848">
+        <source xml:space="preserve">medium</source>
+        <target xml:space="preserve" state="needs-review-translation">medium</target>
+        <context-group purpose="location"><context context-type="linenumber">409</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg849">
+        <source xml:space="preserve">Fee:</source>
+        <target xml:space="preserve" state="needs-review-translation">Fee:</target>
+        <context-group purpose="location"><context context-type="linenumber">444</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg850">
+        <source xml:space="preserve">Dust:</source>
+        <target xml:space="preserve" state="needs-review-translation">Dust:</target>
+        <context-group purpose="location"><context context-type="linenumber">476</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg851">
+        <source xml:space="preserve">no</source>
+        <target xml:space="preserve" state="needs-review-translation">no</target>
+        <context-group purpose="location"><context context-type="linenumber">489</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg852">
+        <source xml:space="preserve">After Fee:</source>
+        <target xml:space="preserve" state="needs-review-translation">After Fee:</target>
+        <context-group purpose="location"><context context-type="linenumber">524</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg853">
+        <source xml:space="preserve">Change:</source>
+        <target xml:space="preserve" state="needs-review-translation">Change:</target>
+        <context-group purpose="location"><context context-type="linenumber">556</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg854">
+        <source xml:space="preserve">If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">600</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg855">
+        <source xml:space="preserve">Custom change address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">603</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg856">
+        <source xml:space="preserve">Split UTXO</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">623</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg857">
+        <source xml:space="preserve"># of outputs</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">636</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg858">
+        <source xml:space="preserve">UTXO Size:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">643</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg859">
+        <source xml:space="preserve">0 PRCY</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">650</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg860" approved="yes">
+        <source xml:space="preserve">Add &amp;Recipient</source>
+        <target xml:space="preserve">Add &amp;Recipient</target>
+        <context-group purpose="location"><context context-type="linenumber">754</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg861" approved="yes">
+        <source xml:space="preserve">Balance:</source>
+        <target xml:space="preserve">Balance:</target>
+        <context-group purpose="location"><context context-type="linenumber">43</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../sendcoinsdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="SendCoinsDialog">
+      <trans-unit id="_msg862">
+        <source xml:space="preserve">Copy quantity</source>
+        <target xml:space="preserve" state="needs-review-translation">Copy quantity</target>
+        <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg863">
+        <source xml:space="preserve">Copy amount</source>
+        <target xml:space="preserve" state="needs-review-translation">Copy amount</target>
+        <context-group purpose="location"><context context-type="linenumber">61</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg864">
+        <source xml:space="preserve">Copy fee</source>
+        <target xml:space="preserve" state="needs-review-translation">Copy fee</target>
+        <context-group purpose="location"><context context-type="linenumber">62</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg865">
+        <source xml:space="preserve">Copy after fee</source>
+        <target xml:space="preserve" state="needs-review-translation">Copy after fee</target>
+        <context-group purpose="location"><context context-type="linenumber">63</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg866">
+        <source xml:space="preserve">Copy bytes</source>
+        <target xml:space="preserve" state="needs-review-translation">Copy bytes</target>
+        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg867">
+        <source xml:space="preserve">Copy priority</source>
+        <target xml:space="preserve" state="needs-review-translation">Copy priority</target>
+        <context-group purpose="location"><context context-type="linenumber">65</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg868">
+        <source xml:space="preserve">Copy dust</source>
+        <target xml:space="preserve" state="needs-review-translation">Copy dust</target>
+        <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg869">
+        <source xml:space="preserve">Copy change</source>
+        <target xml:space="preserve" state="needs-review-translation">Copy change</target>
+        <context-group purpose="location"><context context-type="linenumber">67</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg870">
+        <source xml:space="preserve">Send Disabled - Syncing</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg871">
+        <source xml:space="preserve">Sending PRCY is disabled when you are still syncing the wallet. Please allow the wallet to fully sync before attempting to send a transaction.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg872">
+        <source xml:space="preserve">Invalid Address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg873">
+        <source xml:space="preserve">Invalid address entered. Please make sure you are sending to a Stealth Address.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">169</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg874">
+        <source xml:space="preserve">Invalid Amount</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">176</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg875">
+        <source xml:space="preserve">Invalid amount entered. Please enter an amount less than your Spendable Balance.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">177</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg876">
+        <source xml:space="preserve">Destination</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">205</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg877">
+        <source xml:space="preserve">Are you sure you want to send?</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">210</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg878">
+        <source xml:space="preserve">Estimated Transaction fee</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg879">
+        <source xml:space="preserve">&lt;span class=&apos;h3&apos;&gt;Total Amount = &lt;b&gt;%1&lt;/b&gt;&lt;br/&gt;&lt;/center&gt;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg880">
+        <source xml:space="preserve">Confirm Send Coins</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg881">
+        <source xml:space="preserve">Insufficient Spendable Funds!</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">249</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg882">
+        <source xml:space="preserve">Insufficient spendable funds. Send with smaller amount or wait for your coins become mature</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg883">
+        <source xml:space="preserve">Insufficient Reserve Funds!</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">254</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg884">
+        <source xml:space="preserve">Insufficient reserve funds. Send with smaller amount or turn off staking mode.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">255</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg885">
+        <source xml:space="preserve">Information</source>
+        <target xml:space="preserve" state="needs-review-translation">Information</target>
+        <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg886">
+        <source xml:space="preserve">Consolidation transaction created!</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg887">
+        <source xml:space="preserve">Sweeping Transaction Creation Error</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg888">
+        <source xml:space="preserve">Sweeping transaction creation failed due to an internal error. Please try again later.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">328</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">336</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg889">
+        <source xml:space="preserve">Unable to create transaction. Please try again later.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">346</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg890">
+        <source xml:space="preserve">Transaction Creation Error</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">349</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg891">
+        <source xml:space="preserve">View on Explorer</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg892">
+        <source xml:space="preserve">Copy</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">382</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg893">
+        <source xml:space="preserve">OK</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">383</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg894">
+        <source xml:space="preserve">Warning: Invalid PIVX address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">531</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg895">
+        <source xml:space="preserve">Warning: Unknown change address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">539</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg896">
+        <source xml:space="preserve">(no label)</source>
+        <target xml:space="preserve" state="needs-review-translation">(no label)</target>
+        <context-group purpose="location"><context context-type="linenumber">549</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/sendcoinsentry.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="SendCoinsEntry">
+      <trans-unit id="_msg897" approved="yes">
+        <source xml:space="preserve">Remove this entry</source>
+        <target xml:space="preserve">Remove this entry</target>
+        <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">310</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg898" approved="yes">
+        <source xml:space="preserve">A&amp;mount:</source>
+        <target xml:space="preserve">A&amp;mount:</target>
+        <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg899">
+        <source xml:space="preserve">PRivaCY Coin Wallet Address to send to</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg900">
+        <source xml:space="preserve">Wallet Address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg901">
+        <source xml:space="preserve">An optional description to attach to the payment</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">121</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg902">
+        <source xml:space="preserve">Description (Optional)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg903">
+        <source xml:space="preserve">Amount of PRCY to send to address above</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">163</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg904">
+        <source xml:space="preserve">PRCY Amount</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg905">
+        <source xml:space="preserve">Use Spendable Balance</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">179</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg906">
+        <source xml:space="preserve">Clear All</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">186</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg907" approved="yes">
+        <source xml:space="preserve">Pay To:</source>
+        <target xml:space="preserve">Pay To:</target>
+        <context-group purpose="location"><context context-type="linenumber">207</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">288</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg908" approved="yes">
+        <source xml:space="preserve">Memo:</source>
+        <target xml:space="preserve">Memo:</target>
+        <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../sendcoinsentry.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="SendCoinsEntry">
+      <trans-unit id="_msg909">
+        <source xml:space="preserve">Invalid Amount</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg910">
+        <source xml:space="preserve">Invalid amount entered. Please enter an amount less than %1 (%2M) PRCY.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/signverifymessagedialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="SignVerifyMessageDialog">
+      <trans-unit id="_msg911" approved="yes">
+        <source xml:space="preserve">Signatures - Sign / Verify a Message</source>
+        <target xml:space="preserve">Signatures - Sign / Verify a Message</target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg912" approved="yes">
+        <source xml:space="preserve">&amp;Sign Message</source>
+        <target xml:space="preserve">&amp;Sign Message</target>
+        <context-group purpose="location"><context context-type="linenumber">27</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg913" approved="yes">
+        <source xml:space="preserve">You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
+        <target xml:space="preserve">You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</target>
+        <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg914">
+        <source xml:space="preserve">The PRCY address to sign the message with</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">48</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg915" approved="yes">
+        <source xml:space="preserve">Choose previously used address</source>
+        <target xml:space="preserve">Choose previously used address</target>
+        <context-group purpose="location"><context context-type="linenumber">55</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg916" approved="yes">
+        <source xml:space="preserve">Alt+A</source>
+        <target xml:space="preserve">Alt+A</target>
+        <context-group purpose="location"><context context-type="linenumber">65</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg917" approved="yes">
+        <source xml:space="preserve">Paste address from clipboard</source>
+        <target xml:space="preserve">Paste address from clipboard</target>
+        <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg918" approved="yes">
+        <source xml:space="preserve">Alt+P</source>
+        <target xml:space="preserve">Alt+P</target>
+        <context-group purpose="location"><context context-type="linenumber">82</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg919" approved="yes">
+        <source xml:space="preserve">Enter the message you want to sign here</source>
+        <target xml:space="preserve">Enter the message you want to sign here</target>
+        <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg920" approved="yes">
+        <source xml:space="preserve">Signature</source>
+        <target xml:space="preserve">Signature</target>
+        <context-group purpose="location"><context context-type="linenumber">98</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg921" approved="yes">
+        <source xml:space="preserve">Copy the current signature to the system clipboard</source>
+        <target xml:space="preserve">Copy the current signature to the system clipboard</target>
+        <context-group purpose="location"><context context-type="linenumber">122</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg922">
+        <source xml:space="preserve">Sign the message to prove you own this PRCY address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg923">
+        <source xml:space="preserve">The PRCY address the message was signed with</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg924">
+        <source xml:space="preserve">Verify the message to ensure it was signed with the specified PRCY address</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">277</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg925" approved="yes">
+        <source xml:space="preserve">Sign &amp;Message</source>
+        <target xml:space="preserve">Sign &amp;Message</target>
+        <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg926" approved="yes">
+        <source xml:space="preserve">Reset all sign message fields</source>
+        <target xml:space="preserve">Reset all sign message fields</target>
+        <context-group purpose="location"><context context-type="linenumber">157</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg927" approved="yes">
+        <source xml:space="preserve">Clear &amp;All</source>
+        <target xml:space="preserve">Clear &amp;All</target>
+        <context-group purpose="location"><context context-type="linenumber">160</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">297</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg928" approved="yes">
+        <source xml:space="preserve">&amp;Verify Message</source>
+        <target xml:space="preserve">&amp;Verify Message</target>
+        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg929" approved="yes">
+        <source xml:space="preserve">Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
+        <target xml:space="preserve">Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</target>
+        <context-group purpose="location"><context context-type="linenumber">225</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg930" approved="yes">
+        <source xml:space="preserve">Verify &amp;Message</source>
+        <target xml:space="preserve">Verify &amp;Message</target>
+        <context-group purpose="location"><context context-type="linenumber">280</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg931" approved="yes">
+        <source xml:space="preserve">Reset all verify message fields</source>
+        <target xml:space="preserve">Reset all verify message fields</target>
+        <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../signverifymessagedialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="SignVerifyMessageDialog">
+      <trans-unit id="_msg932" approved="yes">
+        <source xml:space="preserve">Click &quot;Sign Message&quot; to generate signature</source>
+        <target xml:space="preserve">Click &quot;Sign Message&quot; to generate signature</target>
+        <context-group purpose="location"><context context-type="linenumber">31</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg933" approved="yes">
+        <source xml:space="preserve">The entered address is invalid.</source>
+        <target xml:space="preserve">The entered address is invalid.</target>
+        <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg934" approved="yes">
+        <source xml:space="preserve">Please check the address and try again.</source>
+        <target xml:space="preserve">Please check the address and try again.</target>
+        <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">117</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">190</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg935" approved="yes">
+        <source xml:space="preserve">The entered address does not refer to a key.</source>
+        <target xml:space="preserve">The entered address does not refer to a key.</target>
+        <context-group purpose="location"><context context-type="linenumber">117</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">190</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg936" approved="yes">
+        <source xml:space="preserve">Wallet unlock was cancelled.</source>
+        <target xml:space="preserve">Wallet unlock was cancelled.</target>
+        <context-group purpose="location"><context context-type="linenumber">124</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg937" approved="yes">
+        <source xml:space="preserve">Private key for the entered address is not available.</source>
+        <target xml:space="preserve">Private key for the entered address is not available.</target>
+        <context-group purpose="location"><context context-type="linenumber">131</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg938" approved="yes">
+        <source xml:space="preserve">Message signing failed.</source>
+        <target xml:space="preserve">Message signing failed.</target>
+        <context-group purpose="location"><context context-type="linenumber">142</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg939" approved="yes">
+        <source xml:space="preserve">Message signed.</source>
+        <target xml:space="preserve">Message signed.</target>
+        <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg940" approved="yes">
+        <source xml:space="preserve">The signature could not be decoded.</source>
+        <target xml:space="preserve">The signature could not be decoded.</target>
+        <context-group purpose="location"><context context-type="linenumber">200</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg941" approved="yes">
+        <source xml:space="preserve">Please check the signature and try again.</source>
+        <target xml:space="preserve">Please check the signature and try again.</target>
+        <context-group purpose="location"><context context-type="linenumber">200</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg942" approved="yes">
+        <source xml:space="preserve">The signature did not match the message digest.</source>
+        <target xml:space="preserve">The signature did not match the message digest.</target>
+        <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg943" approved="yes">
+        <source xml:space="preserve">Message verification failed.</source>
+        <target xml:space="preserve">Message verification failed.</target>
+        <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg944" approved="yes">
+        <source xml:space="preserve">Message verified.</source>
+        <target xml:space="preserve">Message verified.</target>
+        <context-group purpose="location"><context context-type="linenumber">223</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../splashscreen.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="SplashScreen">
+      <trans-unit id="_msg945">
+        <source xml:space="preserve">PRivaCY Coin Wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">37</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg946">
+        <source xml:space="preserve">PRivaCY Coin Lite Mode Wallet</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">40</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg947" approved="yes">
+        <source xml:space="preserve">Version %1</source>
+        <target xml:space="preserve">Version %1</target>
+        <context-group purpose="location"><context context-type="linenumber">42</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg948" approved="yes">
+        <source xml:space="preserve">The Bitcoin Core developers</source>
+        <target xml:space="preserve">The Bitcoin Core developers</target>
+        <context-group purpose="location"><context context-type="linenumber">43</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg949">
+        <source xml:space="preserve">The Dash Core developers</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">44</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg950">
+        <source xml:space="preserve">The PIVX Core developers</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">45</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg951">
+        <source xml:space="preserve">The DAPS Project developers</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg952">
+        <source xml:space="preserve">The PRivaCY Coin developers</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../networkstyle.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="SplashScreen">
+      <trans-unit id="_msg953" approved="yes">
+        <source xml:space="preserve">[testnet]</source>
+        <target xml:space="preserve">[testnet]</target>
+        <context-group purpose="location"><context context-type="linenumber">19</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../trafficgraphwidget.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="TrafficGraphWidget">
+      <trans-unit id="_msg954" approved="yes">
+        <source xml:space="preserve">KB/s</source>
+        <target xml:space="preserve">KB/s</target>
+        <context-group purpose="location"><context context-type="linenumber">79</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../transactiondesc.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="TransactionDesc">
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">33</context></context-group>
+        <trans-unit id="_msg955[0]" approved="yes">
+          <source xml:space="preserve">Open for %n more block(s)</source>
+          <target xml:space="preserve">Open for %n more block</target>
+        </trans-unit>
+        <trans-unit id="_msg955[1]" approved="yes">
+          <source xml:space="preserve">Open for %n more block(s)</source>
+          <target xml:space="preserve">Open for %n more blocks</target>
+        </trans-unit>
+      </group>
+      <trans-unit id="_msg956" approved="yes">
+        <source xml:space="preserve">Open until %1</source>
+        <target xml:space="preserve">Open until %1</target>
+        <context-group purpose="location"><context context-type="linenumber">35</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg957" approved="yes">
+        <source xml:space="preserve">conflicted</source>
+        <target xml:space="preserve">conflicted</target>
+        <context-group purpose="location"><context context-type="linenumber">43</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">54</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">76</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg958" approved="yes">
+        <source xml:space="preserve">%1/offline</source>
+        <target xml:space="preserve">%1/offline</target>
+        <context-group purpose="location"><context context-type="linenumber">78</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg959" approved="yes">
+        <source xml:space="preserve">%1/unconfirmed</source>
+        <target xml:space="preserve">%1/unconfirmed</target>
+        <context-group purpose="location"><context context-type="linenumber">80</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg960" approved="yes">
+        <source xml:space="preserve">%1 confirmations</source>
+        <target xml:space="preserve">%1 confirmations</target>
+        <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">82</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg961">
+        <source xml:space="preserve">%1/offline (verified via SwiftX)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">45</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg962">
+        <source xml:space="preserve">%1/confirmed (verified via SwiftX)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">47</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg963">
+        <source xml:space="preserve">%1 confirmations (verified via SwiftX)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg964">
+        <source xml:space="preserve">%1/offline (SwiftX verification in progress - %2 of %3 signatures)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">56</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg965">
+        <source xml:space="preserve">%1/confirmed (SwiftX verification in progress - %2 of %3 signatures )</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">58</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg966">
+        <source xml:space="preserve">%1 confirmations (SwiftX verification in progress - %2 of %3 signatures)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">60</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg967">
+        <source xml:space="preserve">%1/offline (SwiftX verification failed)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">66</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg968">
+        <source xml:space="preserve">%1/confirmed (SwiftX verification failed)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg969" approved="yes">
+        <source xml:space="preserve">Status</source>
+        <target xml:space="preserve">Status</target>
+        <context-group purpose="location"><context context-type="linenumber">100</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg970" approved="yes">
+        <source xml:space="preserve">, has not been successfully broadcast yet</source>
+        <target xml:space="preserve">, has not been successfully broadcast yet</target>
+        <context-group purpose="location"><context context-type="linenumber">104</context></context-group>
+      </trans-unit>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">106</context></context-group>
+        <trans-unit id="_msg971[0]" approved="yes">
+          <source xml:space="preserve">, broadcast through %n node(s)</source>
+          <target xml:space="preserve">, broadcast through %n node</target>
+        </trans-unit>
+        <trans-unit id="_msg971[1]" approved="yes">
+          <source xml:space="preserve">, broadcast through %n node(s)</source>
+          <target xml:space="preserve">, broadcast through %n nodes</target>
+        </trans-unit>
+      </group>
+      <trans-unit id="_msg972" approved="yes">
+        <source xml:space="preserve">Date</source>
+        <target xml:space="preserve">Date</target>
+        <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg973" approved="yes">
+        <source xml:space="preserve">Source</source>
+        <target xml:space="preserve">Source</target>
+        <context-group purpose="location"><context context-type="linenumber">116</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg974" approved="yes">
+        <source xml:space="preserve">Generated</source>
+        <target xml:space="preserve">Generated</target>
+        <context-group purpose="location"><context context-type="linenumber">116</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg975" approved="yes">
+        <source xml:space="preserve">From</source>
+        <target xml:space="preserve">From</target>
+        <context-group purpose="location"><context context-type="linenumber">119</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">190</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg976" approved="yes">
+        <source xml:space="preserve">unknown</source>
+        <target xml:space="preserve">unknown</target>
+        <context-group purpose="location"><context context-type="linenumber">127</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg977" approved="yes">
+        <source xml:space="preserve">To</source>
+        <target xml:space="preserve">To</target>
+        <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">147</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">205</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg978" approved="yes">
+        <source xml:space="preserve">own address</source>
+        <target xml:space="preserve">own address</target>
+        <context-group purpose="location"><context context-type="linenumber">130</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg979" approved="yes">
+        <source xml:space="preserve">watch-only</source>
+        <target xml:space="preserve">watch-only</target>
+        <context-group purpose="location"><context context-type="linenumber">130</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">190</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg980" approved="yes">
+        <source xml:space="preserve">label</source>
+        <target xml:space="preserve">label</target>
+        <context-group purpose="location"><context context-type="linenumber">132</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg981" approved="yes">
+        <source xml:space="preserve">Credit</source>
+        <target xml:space="preserve">Credit</target>
+        <context-group purpose="location"><context context-type="linenumber">164</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">174</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">219</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">242</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
+      </trans-unit>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">166</context></context-group>
+        <trans-unit id="_msg982[0]" approved="yes">
+          <source xml:space="preserve">matures in %n more block(s)</source>
+          <target xml:space="preserve">matures in %n more block</target>
+        </trans-unit>
+        <trans-unit id="_msg982[1]" approved="yes">
+          <source xml:space="preserve">matures in %n more block(s)</source>
+          <target xml:space="preserve">matures in %n more blocks</target>
+        </trans-unit>
+      </group>
+      <trans-unit id="_msg983" approved="yes">
+        <source xml:space="preserve">not accepted</source>
+        <target xml:space="preserve">not accepted</target>
+        <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg984" approved="yes">
+        <source xml:space="preserve">Debit</source>
+        <target xml:space="preserve">Debit</target>
+        <context-group purpose="location"><context context-type="linenumber">217</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">276</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg985" approved="yes">
+        <source xml:space="preserve">Total debit</source>
+        <target xml:space="preserve">Total debit</target>
+        <context-group purpose="location"><context context-type="linenumber">226</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg986" approved="yes">
+        <source xml:space="preserve">Total credit</source>
+        <target xml:space="preserve">Total credit</target>
+        <context-group purpose="location"><context context-type="linenumber">227</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg987" approved="yes">
+        <source xml:space="preserve">Transaction fee</source>
+        <target xml:space="preserve">Transaction fee</target>
+        <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg988" approved="yes">
+        <source xml:space="preserve">Net amount</source>
+        <target xml:space="preserve">Net amount</target>
+        <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg989" approved="yes">
+        <source xml:space="preserve">Message</source>
+        <target xml:space="preserve">Message</target>
+        <context-group purpose="location"><context context-type="linenumber">252</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">262</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg990" approved="yes">
+        <source xml:space="preserve">Comment</source>
+        <target xml:space="preserve">Comment</target>
+        <context-group purpose="location"><context context-type="linenumber">254</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg991" approved="yes">
+        <source xml:space="preserve">Transaction ID</source>
+        <target xml:space="preserve">Transaction ID</target>
+        <context-group purpose="location"><context context-type="linenumber">256</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg992">
+        <source xml:space="preserve">Output index</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg993" approved="yes">
+        <source xml:space="preserve">Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
+        <target xml:space="preserve">Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</target>
+        <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg994" approved="yes">
+        <source xml:space="preserve">Debug information</source>
+        <target xml:space="preserve">Debug information</target>
+        <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg995" approved="yes">
+        <source xml:space="preserve">Transaction</source>
+        <target xml:space="preserve">Transaction</target>
+        <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg996" approved="yes">
+        <source xml:space="preserve">Inputs</source>
+        <target xml:space="preserve">Inputs</target>
+        <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg997" approved="yes">
+        <source xml:space="preserve">Amount</source>
+        <target xml:space="preserve">Amount</target>
+        <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg998" approved="yes">
+        <source xml:space="preserve">true</source>
+        <target xml:space="preserve">true</target>
+        <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg999" approved="yes">
+        <source xml:space="preserve">false</source>
+        <target xml:space="preserve">false</target>
+        <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/transactiondescdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="TransactionDescDialog">
+      <trans-unit id="_msg1000" approved="yes">
+        <source xml:space="preserve">Transaction details</source>
+        <target xml:space="preserve">Transaction details</target>
+        <context-group purpose="location"><context context-type="linenumber">14</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1001" approved="yes">
+        <source xml:space="preserve">This pane shows a detailed description of the transaction</source>
+        <target xml:space="preserve">This pane shows a detailed description of the transaction</target>
+        <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../transactiontablemodel.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="TransactionTableModel">
+      <trans-unit id="_msg1002" approved="yes">
+        <source xml:space="preserve">Date</source>
+        <target xml:space="preserve">Date</target>
+        <context-group purpose="location"><context context-type="linenumber">290</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1003" approved="yes">
+        <source xml:space="preserve">Type</source>
+        <target xml:space="preserve">Type</target>
+        <context-group purpose="location"><context context-type="linenumber">290</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1004" approved="yes">
+        <source xml:space="preserve">Address</source>
+        <target xml:space="preserve">Address</target>
+        <context-group purpose="location"><context context-type="linenumber">290</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1005">
+        <source xml:space="preserve">Confirmations</source>
+        <target xml:space="preserve" state="needs-review-translation">Confirmations</target>
+        <context-group purpose="location"><context context-type="linenumber">290</context></context-group>
+      </trans-unit>
+      <group restype="x-gettext-plurals">
+        <context-group purpose="location"><context context-type="linenumber">348</context></context-group>
+        <trans-unit id="_msg1006[0]" approved="yes">
+          <source xml:space="preserve">Open for %n more block(s)</source>
+          <target xml:space="preserve">Open for %n more block</target>
+        </trans-unit>
+        <trans-unit id="_msg1006[1]" approved="yes">
+          <source xml:space="preserve">Open for %n more block(s)</source>
+          <target xml:space="preserve">Open for %n more blocks</target>
+        </trans-unit>
+      </group>
+      <trans-unit id="_msg1007" approved="yes">
+        <source xml:space="preserve">Open until %1</source>
+        <target xml:space="preserve">Open until %1</target>
+        <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1008" approved="yes">
+        <source xml:space="preserve">Offline</source>
+        <target xml:space="preserve">Offline</target>
+        <context-group purpose="location"><context context-type="linenumber">354</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1009" approved="yes">
+        <source xml:space="preserve">Unconfirmed</source>
+        <target xml:space="preserve">Unconfirmed</target>
+        <context-group purpose="location"><context context-type="linenumber">357</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1010" approved="yes">
+        <source xml:space="preserve">Confirming (%1 of %2 recommended confirmations)</source>
+        <target xml:space="preserve">Confirming (%1 of %2 recommended confirmations)</target>
+        <context-group purpose="location"><context context-type="linenumber">360</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1011" approved="yes">
+        <source xml:space="preserve">Confirmed (%1 confirmations)</source>
+        <target xml:space="preserve">Confirmed (%1 confirmations)</target>
+        <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1012" approved="yes">
+        <source xml:space="preserve">Conflicted</source>
+        <target xml:space="preserve">Conflicted</target>
+        <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1013" approved="yes">
+        <source xml:space="preserve">Immature (%1 confirmations, will be available after %2)</source>
+        <target xml:space="preserve">Immature (%1 confirmations, will be available after %2)</target>
+        <context-group purpose="location"><context context-type="linenumber">369</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1014" approved="yes">
+        <source xml:space="preserve">This block was not received by any other nodes and will probably not be accepted!</source>
+        <target xml:space="preserve">This block was not received by any other nodes and will probably not be accepted!</target>
+        <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1015" approved="yes">
+        <source xml:space="preserve">Received with</source>
+        <target xml:space="preserve">Received with</target>
+        <context-group purpose="location"><context context-type="linenumber">410</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1016">
+        <source xml:space="preserve">Masternode Reward</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">412</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1017" approved="yes">
+        <source xml:space="preserve">Received from</source>
+        <target xml:space="preserve">Received from</target>
+        <context-group purpose="location"><context context-type="linenumber">414</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1018">
+        <source xml:space="preserve">Confirmed Count.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">700</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1019" approved="yes">
+        <source xml:space="preserve">Sent to</source>
+        <target xml:space="preserve">Sent to</target>
+        <context-group purpose="location"><context context-type="linenumber">417</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1020">
+        <source xml:space="preserve">Orphan Block - Generated but not accepted. This does not impact your holdings.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">375</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1021" approved="yes">
+        <source xml:space="preserve">Payment to yourself</source>
+        <target xml:space="preserve">Payment to yourself</target>
+        <context-group purpose="location"><context context-type="linenumber">419</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1022">
+        <source xml:space="preserve">Minted</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">421</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1023" approved="yes">
+        <source xml:space="preserve">Mined</source>
+        <target xml:space="preserve">Mined</target>
+        <context-group purpose="location"><context context-type="linenumber">423</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1024" approved="yes">
+        <source xml:space="preserve">watch-only</source>
+        <target xml:space="preserve">watch-only</target>
+        <context-group purpose="location"><context context-type="linenumber">457</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1025" approved="yes">
+        <source xml:space="preserve">(n/a)</source>
+        <target xml:space="preserve">(n/a)</target>
+        <context-group purpose="location"><context context-type="linenumber">474</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1026" approved="yes">
+        <source xml:space="preserve">Transaction status. Hover over this field to show number of confirmations.</source>
+        <target xml:space="preserve">Transaction status. Hover over this field to show number of confirmations.</target>
+        <context-group purpose="location"><context context-type="linenumber">688</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1027" approved="yes">
+        <source xml:space="preserve">Date and time that the transaction was received.</source>
+        <target xml:space="preserve">Date and time that the transaction was received.</target>
+        <context-group purpose="location"><context context-type="linenumber">690</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1028" approved="yes">
+        <source xml:space="preserve">Type of transaction.</source>
+        <target xml:space="preserve">Type of transaction.</target>
+        <context-group purpose="location"><context context-type="linenumber">692</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1029" approved="yes">
+        <source xml:space="preserve">Whether or not a watch-only address is involved in this transaction.</source>
+        <target xml:space="preserve">Whether or not a watch-only address is involved in this transaction.</target>
+        <context-group purpose="location"><context context-type="linenumber">694</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1030" approved="yes">
+        <source xml:space="preserve">Destination address of transaction.</source>
+        <target xml:space="preserve">Destination address of transaction.</target>
+        <context-group purpose="location"><context context-type="linenumber">696</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1031" approved="yes">
+        <source xml:space="preserve">Amount removed from or added to balance.</source>
+        <target xml:space="preserve">Amount removed from or added to balance.</target>
+        <context-group purpose="location"><context context-type="linenumber">698</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../transactionview.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="TransactionView">
+      <trans-unit id="_msg1032" approved="yes">
+        <source xml:space="preserve">All</source>
+        <target xml:space="preserve">All</target>
+        <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">85</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1033" approved="yes">
+        <source xml:space="preserve">Today</source>
+        <target xml:space="preserve">Today</target>
+        <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1034" approved="yes">
+        <source xml:space="preserve">This week</source>
+        <target xml:space="preserve">This week</target>
+        <context-group purpose="location"><context context-type="linenumber">70</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1035" approved="yes">
+        <source xml:space="preserve">This month</source>
+        <target xml:space="preserve">This month</target>
+        <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1036" approved="yes">
+        <source xml:space="preserve">Last month</source>
+        <target xml:space="preserve">Last month</target>
+        <context-group purpose="location"><context context-type="linenumber">72</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1037" approved="yes">
+        <source xml:space="preserve">This year</source>
+        <target xml:space="preserve">This year</target>
+        <context-group purpose="location"><context context-type="linenumber">73</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1038" approved="yes">
+        <source xml:space="preserve">Range...</source>
+        <target xml:space="preserve">Range...</target>
+        <context-group purpose="location"><context context-type="linenumber">74</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1039" approved="yes">
+        <source xml:space="preserve">Most Common</source>
+        <target xml:space="preserve">Most Common</target>
+        <context-group purpose="location"><context context-type="linenumber">86</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1040" approved="yes">
+        <source xml:space="preserve">Received with</source>
+        <target xml:space="preserve">Received with</target>
+        <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1041" approved="yes">
+        <source xml:space="preserve">Sent to</source>
+        <target xml:space="preserve">Sent to</target>
+        <context-group purpose="location"><context context-type="linenumber">88</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1042" approved="yes">
+        <source xml:space="preserve">To yourself</source>
+        <target xml:space="preserve">To yourself</target>
+        <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1043" approved="yes">
+        <source xml:space="preserve">Mined</source>
+        <target xml:space="preserve">Mined</target>
+        <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1044">
+        <source xml:space="preserve">Minted</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">91</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1045">
+        <source xml:space="preserve">Masternode Reward</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">92</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1046" approved="yes">
+        <source xml:space="preserve">Other</source>
+        <target xml:space="preserve">Other</target>
+        <context-group purpose="location"><context context-type="linenumber">93</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1047" approved="yes">
+        <source xml:space="preserve">Enter address or label to search</source>
+        <target xml:space="preserve">Enter address or label to search</target>
+        <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1048" approved="yes">
+        <source xml:space="preserve">Min amount</source>
+        <target xml:space="preserve">Min amount</target>
+        <context-group purpose="location"><context context-type="linenumber">103</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1049" approved="yes">
+        <source xml:space="preserve">Copy address</source>
+        <target xml:space="preserve">Copy address</target>
+        <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1050" approved="yes">
+        <source xml:space="preserve">Copy label</source>
+        <target xml:space="preserve">Copy label</target>
+        <context-group purpose="location"><context context-type="linenumber">139</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1051" approved="yes">
+        <source xml:space="preserve">Copy amount</source>
+        <target xml:space="preserve">Copy amount</target>
+        <context-group purpose="location"><context context-type="linenumber">140</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1052" approved="yes">
+        <source xml:space="preserve">Copy transaction ID</source>
+        <target xml:space="preserve">Copy transaction ID</target>
+        <context-group purpose="location"><context context-type="linenumber">141</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1053" approved="yes">
+        <source xml:space="preserve">Edit label</source>
+        <target xml:space="preserve">Edit label</target>
+        <context-group purpose="location"><context context-type="linenumber">142</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1054" approved="yes">
+        <source xml:space="preserve">Show transaction details</source>
+        <target xml:space="preserve">Show transaction details</target>
+        <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1055">
+        <source xml:space="preserve">Hide orphan stakes</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">144</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1056" approved="yes">
+        <source xml:space="preserve">Export Transaction History</source>
+        <target xml:space="preserve">Export Transaction History</target>
+        <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1057" approved="yes">
+        <source xml:space="preserve">Comma separated file (*.csv)</source>
+        <target xml:space="preserve">Comma separated file (*.csv)</target>
+        <context-group purpose="location"><context context-type="linenumber">377</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1058" approved="yes">
+        <source xml:space="preserve">Confirmed</source>
+        <target xml:space="preserve">Confirmed</target>
+        <context-group purpose="location"><context context-type="linenumber">388</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1059" approved="yes">
+        <source xml:space="preserve">Watch-only</source>
+        <target xml:space="preserve">Watch-only</target>
+        <context-group purpose="location"><context context-type="linenumber">390</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1060" approved="yes">
+        <source xml:space="preserve">Date</source>
+        <target xml:space="preserve">Date</target>
+        <context-group purpose="location"><context context-type="linenumber">391</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1061" approved="yes">
+        <source xml:space="preserve">Type</source>
+        <target xml:space="preserve">Type</target>
+        <context-group purpose="location"><context context-type="linenumber">392</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1062" approved="yes">
+        <source xml:space="preserve">Label</source>
+        <target xml:space="preserve">Label</target>
+        <context-group purpose="location"><context context-type="linenumber">393</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1063" approved="yes">
+        <source xml:space="preserve">Address</source>
+        <target xml:space="preserve">Address</target>
+        <context-group purpose="location"><context context-type="linenumber">394</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1064" approved="yes">
+        <source xml:space="preserve">ID</source>
+        <target xml:space="preserve">ID</target>
+        <context-group purpose="location"><context context-type="linenumber">396</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1065" approved="yes">
+        <source xml:space="preserve">Exporting Failed</source>
+        <target xml:space="preserve">Exporting Failed</target>
+        <context-group purpose="location"><context context-type="linenumber">406</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1066" approved="yes">
+        <source xml:space="preserve">There was an error trying to save the transaction history to %1.</source>
+        <target xml:space="preserve">There was an error trying to save the transaction history to %1.</target>
+        <context-group purpose="location"><context context-type="linenumber">406</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1067" approved="yes">
+        <source xml:space="preserve">Exporting Successful</source>
+        <target xml:space="preserve">Exporting Successful</target>
+        <context-group purpose="location"><context context-type="linenumber">402</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1068" approved="yes">
+        <source xml:space="preserve">The transaction history was successfully saved to %1.</source>
+        <target xml:space="preserve">The transaction history was successfully saved to %1.</target>
+        <context-group purpose="location"><context context-type="linenumber">402</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1069" approved="yes">
+        <source xml:space="preserve">Range:</source>
+        <target xml:space="preserve">Range:</target>
+        <context-group purpose="location"><context context-type="linenumber">523</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1070" approved="yes">
+        <source xml:space="preserve">to</source>
+        <target xml:space="preserve">to</target>
+        <context-group purpose="location"><context context-type="linenumber">531</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/2faconfirmdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="TwoFAConfirmDialog">
+      <trans-unit id="_msg1071">
+        <source xml:space="preserve">Transaction Details</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1072">
+        <source xml:space="preserve">Enter Code</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">31</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1073">
+        <source xml:space="preserve">Please enter a six digit 2FA code:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">45</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1074">
+        <source xml:space="preserve">Confirm</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1075">
+        <source xml:space="preserve">Return</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1076">
+        <source xml:space="preserve">Cancel</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">312</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1077">
+        <source xml:space="preserve">Esc</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../2faconfirmdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="TwoFAConfirmDialog">
+      <trans-unit id="_msg1078">
+        <source xml:space="preserve">Wrong 2FA Code</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">169</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1079">
+        <source xml:space="preserve">Incorrect 2FA code entered.
+Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">170</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/2fadialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="TwoFADialog">
+      <trans-unit id="_msg1080">
+        <source xml:space="preserve">Transaction Details</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">20</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1081">
+        <source xml:space="preserve">Enabling 2FA in your PRCY Desktop App</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">31</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1082">
+        <source xml:space="preserve">After this step, you will need to periodically enter another 2FA code anytime you send a transaction from within this desktop app, so do not lose your 2FA code generator.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">56</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1083">
+        <source xml:space="preserve">Please enter a six digit 2FA code:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1084">
+        <source xml:space="preserve">Confirm</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1085">
+        <source xml:space="preserve">Return</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1086">
+        <source xml:space="preserve">Cancel</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">348</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1087">
+        <source xml:space="preserve">Esc</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1088">
+        <source xml:space="preserve">OPEN AUTHENTICATION APP</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../2fadialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="TwoFADialog">
+      <trans-unit id="_msg1089">
+        <source xml:space="preserve">Wrong 2FA Code</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">172</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1090">
+        <source xml:space="preserve">Incorrect 2FA code entered.
+Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/2faqrdialog.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="TwoFAQRDialog">
+      <trans-unit id="_msg1091">
+        <source xml:space="preserve">Below are your 2FA QR Code &amp; Recovery Key.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">28</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1092">
+        <source xml:space="preserve">Please store them safely. Use them to regain access if you lose your device.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">43</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1093">
+        <source xml:space="preserve">QR Code</source>
+        <target xml:space="preserve" state="needs-review-translation">QR Code</target>
+        <context-group purpose="location"><context context-type="linenumber">65</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1094">
+        <source xml:space="preserve">Cancel</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">129</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1095">
+        <source xml:space="preserve">Esc</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">132</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1096">
+        <source xml:space="preserve">Next</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">142</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1097">
+        <source xml:space="preserve">Return</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../2faqrdialog.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="TwoFAQRDialog">
+      <trans-unit id="_msg1098">
+        <source xml:space="preserve">Resulting URI too long, try to reduce the text for label / message.</source>
+        <target xml:space="preserve" state="needs-review-translation">Resulting URI too long, try to reduce the text for label / message.</target>
+        <context-group purpose="location"><context context-type="linenumber">89</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1099">
+        <source xml:space="preserve">Error encoding URI into QR Code.</source>
+        <target xml:space="preserve" state="needs-review-translation">Error encoding URI into QR Code.</target>
+        <context-group purpose="location"><context context-type="linenumber">93</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../forms/txentry.ui" datatype="x-trolltech-designer-ui" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="TxEntry">
+      <trans-unit id="_msg1100">
+        <source xml:space="preserve">TxAmount</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">62</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1101">
+        <source xml:space="preserve">lableDate</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">69</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1102">
+        <source xml:space="preserve">TRANSACTION ID</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1103">
+        <source xml:space="preserve">TO</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">173</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1104">
+        <source xml:space="preserve">MM/DD/YYYY</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">178</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../walletframe.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="WalletFrame">
+      <trans-unit id="_msg1105" approved="yes">
+        <source xml:space="preserve">No wallet has been loaded.</source>
+        <target xml:space="preserve">No wallet has been loaded.</target>
+        <context-group purpose="location"><context context-type="linenumber">25</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../walletmodel.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="WalletModel">
+      <trans-unit id="_msg1106" approved="yes">
+        <source xml:space="preserve">Send Coins</source>
+        <target xml:space="preserve">Send Coins</target>
+        <context-group purpose="location"><context context-type="linenumber">332</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1107">
+        <source xml:space="preserve">Mnemonic Recovery Phrase</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">392</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">419</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1108">
+        <source xml:space="preserve">Attempt to view Mnemonic Phrase failed or canceled. Wallet locked for security.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">368</context></context-group>
+        <context-group purpose="location"><context context-type="linenumber">393</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1109">
+        <source xml:space="preserve">Are You Sure?</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1110">
+        <source xml:space="preserve">Are you sure you would like to view your Mnemonic Phrase?
+You will be required to enter your passphrase. Failed or canceled attempts will be logged.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1111">
+        <source xml:space="preserve">Copy</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">415</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1112">
+        <source xml:space="preserve">OK</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">416</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1113">
+        <source xml:space="preserve">Below is your Mnemonic Recovery Phrase, consisting of 24 seed words. Please copy/write these words down in order. We strongly recommend keeping multiple copies in different locations.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">420</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../walletview.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="WalletView">
+      <trans-unit id="_msg1114" approved="yes">
+        <source xml:space="preserve">&amp;Export</source>
+        <target xml:space="preserve">&amp;Export</target>
+        <context-group purpose="location"><context context-type="linenumber">50</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1115" approved="yes">
+        <source xml:space="preserve">Export the data in the current tab to a file</source>
+        <target xml:space="preserve">Export the data in the current tab to a file</target>
+        <context-group purpose="location"><context context-type="linenumber">51</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1116" approved="yes">
+        <source xml:space="preserve">Selected amount:</source>
+        <target xml:space="preserve">Selected amount:</target>
+        <context-group purpose="location"><context context-type="linenumber">56</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1117" approved="yes">
+        <source xml:space="preserve">Backup Wallet</source>
+        <target xml:space="preserve">Backup Wallet</target>
+        <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1118" approved="yes">
+        <source xml:space="preserve">Wallet Data (*.dat)</source>
+        <target xml:space="preserve">Wallet Data (*.dat)</target>
+        <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+  <file original="../prcycoinstrings.cpp" datatype="cpp" source-language="en" target-language="en"><body>
+    <group restype="x-trolltech-linguist-context" resname="prcycoin-core">
+      <trans-unit id="_msg1119">
+        <source xml:space="preserve">(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)</source>
+        <target xml:space="preserve" state="needs-review-translation">(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)</target>
+        <context-group purpose="location"><context context-type="linenumber">12</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1120">
+        <source xml:space="preserve">Allow JSON-RPC connections from specified source. Valid for &lt;ip&gt; are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times</source>
+        <target xml:space="preserve" state="needs-review-translation">Allow JSON-RPC connections from specified source. Valid for &lt;ip&gt; are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times</target>
+        <context-group purpose="location"><context context-type="linenumber">18</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1121">
+        <source xml:space="preserve">Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
+        <target xml:space="preserve" state="needs-review-translation">Bind to given address and always listen on it. Use [host]:port notation for IPv6</target>
+        <context-group purpose="location"><context context-type="linenumber">22</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1122">
+        <source xml:space="preserve">Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6</source>
+        <target xml:space="preserve" state="needs-review-translation">Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6</target>
+        <context-group purpose="location"><context context-type="linenumber">25</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1123">
+        <source xml:space="preserve">Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6. This option can be specified multiple times (default: bind to all interfaces)</source>
+        <target xml:space="preserve" state="needs-review-translation">Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6. This option can be specified multiple times (default: bind to all interfaces)</target>
+        <context-group purpose="location"><context context-type="linenumber">28</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1124">
+        <source xml:space="preserve">Cannot obtain a lock on data directory %s. PRCY is probably already running.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">32</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1125">
+        <source xml:space="preserve">Change automatic finalized budget voting behavior. mode=auto: Vote for only exact finalized budget match to my generated budget. (string, default: auto)</source>
+        <target xml:space="preserve" state="needs-review-translation">Change automatic finalized budget voting behavior. mode=auto: Vote for only exact finalized budget match to my generated budget. (string, default: auto)</target>
+        <context-group purpose="location"><context context-type="linenumber">34</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1126">
+        <source xml:space="preserve">Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:%u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:%u)</target>
+        <context-group purpose="location"><context context-type="linenumber">40</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1127">
+        <source xml:space="preserve">Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)</source>
+        <target xml:space="preserve" state="needs-review-translation">Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)</target>
+        <context-group purpose="location"><context context-type="linenumber">43</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1128">
+        <source xml:space="preserve">Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup</source>
+        <target xml:space="preserve" state="needs-review-translation">Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup</target>
+        <context-group purpose="location"><context context-type="linenumber">46</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1129">
+        <source xml:space="preserve">Distributed under the MIT software license, see the accompanying file COPYING or &lt;http://www.opensource.org/licenses/mit-license.php&gt;.</source>
+        <target xml:space="preserve" state="needs-review-translation">Distributed under the MIT software license, see the accompanying file COPYING or &lt;http://www.opensource.org/licenses/mit-license.php&gt;.</target>
+        <context-group purpose="location"><context context-type="linenumber">52</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1130">
+        <source xml:space="preserve">Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
+        <target xml:space="preserve" state="needs-review-translation">Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</target>
+        <context-group purpose="location"><context context-type="linenumber">59</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1131">
+        <source xml:space="preserve">Error: Listening for incoming connections failed (listen returned error %s)</source>
+        <target xml:space="preserve" state="needs-review-translation">Error: Listening for incoming connections failed (listen returned error %s)</target>
+        <context-group purpose="location"><context context-type="linenumber">62</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1132">
+        <source xml:space="preserve">Error: Unsupported argument -socks found. Setting SOCKS version isn&apos;t possible anymore, only SOCKS5 proxies are supported.</source>
+        <target xml:space="preserve" state="needs-review-translation">Error: Unsupported argument -socks found. Setting SOCKS version isn&apos;t possible anymore, only SOCKS5 proxies are supported.</target>
+        <context-group purpose="location"><context context-type="linenumber">68</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1133">
+        <source xml:space="preserve">Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
+        <target xml:space="preserve" state="needs-review-translation">Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</target>
+        <context-group purpose="location"><context context-type="linenumber">75</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1134">
+        <source xml:space="preserve">Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
+        <target xml:space="preserve" state="needs-review-translation">Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</target>
+        <context-group purpose="location"><context context-type="linenumber">78</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1135">
+        <source xml:space="preserve">Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
+        <target xml:space="preserve" state="needs-review-translation">Execute command when the best block changes (%s in cmd is replaced by block hash)</target>
+        <context-group purpose="location"><context context-type="linenumber">81</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1136">
+        <source xml:space="preserve">Execute command when the best block changes and its size is over (%s in cmd is replaced by block hash, %d with the block size)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">84</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1137">
+        <source xml:space="preserve">Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">93</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1138">
+        <source xml:space="preserve">If paytxfee is not set, include enough fee so transactions begin confirmation on average within n blocks (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">If paytxfee is not set, include enough fee so transactions begin confirmation on average within n blocks (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">96</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1139">
+        <source xml:space="preserve">In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <target xml:space="preserve" state="needs-review-translation">In this mode -genproclimit controls how many blocks are generated immediately.</target>
+        <context-group purpose="location"><context context-type="linenumber">99</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1140">
+        <source xml:space="preserve">Invalid amount for -maxtxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
+        <target xml:space="preserve" state="needs-review-translation">Invalid amount for -maxtxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least the minrelay fee of %s to prevent stuck transactions)</target>
+        <context-group purpose="location"><context context-type="linenumber">102</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1141">
+        <source xml:space="preserve">Keep the specified amount available for spending at all times (default: 0)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">105</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1142">
+        <source xml:space="preserve">Loading... Please do not interrupt this process as it could lead to a corrupt wallet.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">107</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1143">
+        <source xml:space="preserve">Log transaction priority and fee per kB when mining blocks (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Log transaction priority and fee per kB when mining blocks (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">110</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1144">
+        <source xml:space="preserve">Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">112</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1145">
+        <source xml:space="preserve">Maximum size of data in data carrier transactions we relay and mine (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Maximum size of data in data carrier transactions we relay and mine (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">118</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1146">
+        <source xml:space="preserve">Maximum total fees to use in a single wallet transaction, setting too low may abort large transactions (default: %s)</source>
+        <target xml:space="preserve" state="needs-review-translation">Maximum total fees to use in a single wallet transaction, setting too low may abort large transactions (default: %s)</target>
+        <context-group purpose="location"><context context-type="linenumber">123</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1147">
+        <source xml:space="preserve">Number of seconds to keep misbehaving peers from reconnecting (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Number of seconds to keep misbehaving peers from reconnecting (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">126</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1148">
+        <source xml:space="preserve">Output debugging information (default: %u, supplying &lt;category&gt; is optional)</source>
+        <target xml:space="preserve" state="needs-review-translation">Output debugging information (default: %u, supplying &lt;category&gt; is optional)</target>
+        <context-group purpose="location"><context context-type="linenumber">128</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1149">
+        <source xml:space="preserve">Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">133</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1150">
+        <source xml:space="preserve">Require high priority for relaying free or low-fee transactions (default:%u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Require high priority for relaying free or low-fee transactions (default:%u)</target>
+        <context-group purpose="location"><context context-type="linenumber">136</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1151">
+        <source xml:space="preserve">Rescanning... Please do not interrupt this process as it could lead to a corrupt wallet.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">138</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1152">
+        <source xml:space="preserve">Send trace/debug info to console instead of debug.log file (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Send trace/debug info to console instead of debug.log file (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">141</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1153">
+        <source xml:space="preserve">Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
+        <target xml:space="preserve" state="needs-review-translation">Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</target>
+        <context-group purpose="location"><context context-type="linenumber">143</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1154">
+        <source xml:space="preserve">Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <target xml:space="preserve" state="needs-review-translation">Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</target>
+        <context-group purpose="location"><context context-type="linenumber">145</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1155">
+        <source xml:space="preserve">Set the number of threads for coin generation if enabled (-1 = all cores, default: %d)</source>
+        <target xml:space="preserve" state="needs-review-translation">Set the number of threads for coin generation if enabled (-1 = all cores, default: %d)</target>
+        <context-group purpose="location"><context context-type="linenumber">148</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1156">
+        <source xml:space="preserve">Show N confirmations for a successfully locked transaction (0-9999, default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Show N confirmations for a successfully locked transaction (0-9999, default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">151</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1157">
+        <source xml:space="preserve">Support filtering of blocks and transaction with bloom filters (default: %u)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">161</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1158">
+        <source xml:space="preserve">The block database contains a block which appears to be from the future. This may be due to your computer&apos;s date and time being set incorrectly. Only rebuild the block database if you are sure that your computer&apos;s date and time are correct</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">163</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1159">
+        <source xml:space="preserve">There is an internal error in generating bulletproofs. Please try again later.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">168</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1160">
+        <source xml:space="preserve">This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit &lt;https://www.openssl.org/&gt; and cryptographic software written by Eric Young and UPnP software written by Thomas Bernard.</source>
+        <target xml:space="preserve" state="needs-review-translation">This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit &lt;https://www.openssl.org/&gt; and cryptographic software written by Eric Young and UPnP software written by Thomas Bernard.</target>
+        <context-group purpose="location"><context context-type="linenumber">174</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1161">
+        <source xml:space="preserve">Unable to bind to %s on this computer. PRCY is probably already running.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">181</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1162">
+        <source xml:space="preserve">Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)</source>
+        <target xml:space="preserve" state="needs-review-translation">Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)</target>
+        <context-group purpose="location"><context context-type="linenumber">183</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1163">
+        <source xml:space="preserve">Username and hashed password for JSON-RPC connections. The field &lt;userpw&gt; comes in the format: &lt;USERNAME&gt;:&lt;SALT&gt;$&lt;HASH&gt;. A canonical python script is included in share/rpcuser. This option can be specified multiple times</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">186</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1164">
+        <source xml:space="preserve">Warning: -maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
+        <target xml:space="preserve" state="needs-review-translation">Warning: -maxtxfee is set very high! Fees this large could be paid on a single transaction.</target>
+        <context-group purpose="location"><context context-type="linenumber">190</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1165">
+        <source xml:space="preserve">Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
+        <target xml:space="preserve" state="needs-review-translation">Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</target>
+        <context-group purpose="location"><context context-type="linenumber">193</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1166">
+        <source xml:space="preserve">Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong PRCY will not work properly.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">196</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1167">
+        <source xml:space="preserve">Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
+        <target xml:space="preserve" state="needs-review-translation">Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</target>
+        <context-group purpose="location"><context context-type="linenumber">199</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1168">
+        <source xml:space="preserve">Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
+        <target xml:space="preserve" state="needs-review-translation">Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</target>
+        <context-group purpose="location"><context context-type="linenumber">202</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1169">
+        <source xml:space="preserve">Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
+        <target xml:space="preserve" state="needs-review-translation">Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</target>
+        <context-group purpose="location"><context context-type="linenumber">205</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1170">
+        <source xml:space="preserve">Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
+        <target xml:space="preserve" state="needs-review-translation">Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</target>
+        <context-group purpose="location"><context context-type="linenumber">208</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1171">
+        <source xml:space="preserve">Whitelist peers connecting from the given netmask or IP address. Can be specified multiple times.</source>
+        <target xml:space="preserve" state="needs-review-translation">Whitelist peers connecting from the given netmask or IP address. Can be specified multiple times.</target>
+        <context-group purpose="location"><context context-type="linenumber">212</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1172">
+        <source xml:space="preserve">Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway</source>
+        <target xml:space="preserve" state="needs-review-translation">Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway</target>
+        <context-group purpose="location"><context context-type="linenumber">215</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1173">
+        <source xml:space="preserve">You have attempted to send a total value that is comprised of more than 50 smaller deposits. This is a rare occurrence, and lowering the total value sent, or sending the same total value in two separate transactions will usually work around this limitation.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">218</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1174">
+        <source xml:space="preserve">You must specify a masternodeprivkey in the configuration. Please see documentation for help.</source>
+        <target xml:space="preserve" state="needs-review-translation">You must specify a masternodeprivkey in the configuration. Please see documentation for help.</target>
+        <context-group purpose="location"><context context-type="linenumber">228</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1175">
+        <source xml:space="preserve">(default: %s)</source>
+        <target xml:space="preserve" state="needs-review-translation">(default: %s)</target>
+        <context-group purpose="location"><context context-type="linenumber">231</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1176">
+        <source xml:space="preserve">(default: 1)</source>
+        <target xml:space="preserve" state="needs-review-translation">(default: 1)</target>
+        <context-group purpose="location"><context context-type="linenumber">232</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1177">
+        <source xml:space="preserve">Accept command line and JSON-RPC commands</source>
+        <target xml:space="preserve" state="needs-review-translation">Accept command line and JSON-RPC commands</target>
+        <context-group purpose="location"><context context-type="linenumber">235</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1178">
+        <source xml:space="preserve">Accept public REST requests (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Accept public REST requests (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">236</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1179">
+        <source xml:space="preserve">Add a node to connect to and attempt to keep the connection open</source>
+        <target xml:space="preserve" state="needs-review-translation">Add a node to connect to and attempt to keep the connection open</target>
+        <context-group purpose="location"><context context-type="linenumber">237</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1180">
+        <source xml:space="preserve">Allow DNS lookups for -addnode, -seednode and -connect</source>
+        <target xml:space="preserve" state="needs-review-translation">Allow DNS lookups for -addnode, -seednode and -connect</target>
+        <context-group purpose="location"><context context-type="linenumber">239</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1181">
+        <source xml:space="preserve">Always query for peer addresses via DNS lookup (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Always query for peer addresses via DNS lookup (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">240</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1182">
+        <source xml:space="preserve">Attempt to recover private keys from a corrupt wallet.dat</source>
+        <target xml:space="preserve" state="needs-review-translation">Attempt to recover private keys from a corrupt wallet.dat</target>
+        <context-group purpose="location"><context context-type="linenumber">243</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1183">
+        <source xml:space="preserve">Automatically create Tor hidden service (default: %d)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">244</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1184">
+        <source xml:space="preserve">Block creation options:</source>
+        <target xml:space="preserve" state="needs-review-translation">Block creation options:</target>
+        <context-group purpose="location"><context context-type="linenumber">245</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1185">
+        <source xml:space="preserve">Cannot downgrade wallet</source>
+        <target xml:space="preserve" state="needs-review-translation">Cannot downgrade wallet</target>
+        <context-group purpose="location"><context context-type="linenumber">250</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1186">
+        <source xml:space="preserve">Cannot write default address</source>
+        <target xml:space="preserve" state="needs-review-translation">Cannot write default address</target>
+        <context-group purpose="location"><context context-type="linenumber">256</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1187">
+        <source xml:space="preserve">Connect through SOCKS5 proxy</source>
+        <target xml:space="preserve" state="needs-review-translation">Connect through SOCKS5 proxy</target>
+        <context-group purpose="location"><context context-type="linenumber">257</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1188">
+        <source xml:space="preserve">Connect to a node to retrieve peer addresses, and disconnect</source>
+        <target xml:space="preserve" state="needs-review-translation">Connect to a node to retrieve peer addresses, and disconnect</target>
+        <context-group purpose="location"><context context-type="linenumber">258</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1189">
+        <source xml:space="preserve">Connection options:</source>
+        <target xml:space="preserve" state="needs-review-translation">Connection options:</target>
+        <context-group purpose="location"><context context-type="linenumber">259</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1190">
+        <source xml:space="preserve">Copyright (C) 2009-%i The Bitcoin Core Developers</source>
+        <target xml:space="preserve" state="needs-review-translation">Copyright (C) 2009-%i The Bitcoin Core Developers</target>
+        <context-group purpose="location"><context context-type="linenumber">260</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1191">
+        <source xml:space="preserve">Copyright (C) 2014-%i The Dash Core Developers</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">261</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1192">
+        <source xml:space="preserve">Corrupted block database detected</source>
+        <target xml:space="preserve" state="needs-review-translation">Corrupted block database detected</target>
+        <context-group purpose="location"><context context-type="linenumber">265</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1193">
+        <source xml:space="preserve">Could not parse masternode.conf</source>
+        <target xml:space="preserve" state="needs-review-translation">Could not parse masternode.conf</target>
+        <context-group purpose="location"><context context-type="linenumber">266</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1194">
+        <source xml:space="preserve">Debugging/Testing options:</source>
+        <target xml:space="preserve" state="needs-review-translation">Debugging/Testing options:</target>
+        <context-group purpose="location"><context context-type="linenumber">268</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1195">
+        <source xml:space="preserve">Delete blockchain folders and resync from scratch</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">269</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1196">
+        <source xml:space="preserve">Disable OS notifications for incoming transactions (default: %u)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">270</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1197">
+        <source xml:space="preserve">Disable safemode, override a real safe mode event (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Disable safemode, override a real safe mode event (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">271</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1198">
+        <source xml:space="preserve">Discover own IP address (default: 1 when listening and no -externalip)</source>
+        <target xml:space="preserve" state="needs-review-translation">Discover own IP address (default: 1 when listening and no -externalip)</target>
+        <context-group purpose="location"><context context-type="linenumber">272</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1199">
+        <source xml:space="preserve">Do not load the wallet and disable wallet RPC calls</source>
+        <target xml:space="preserve" state="needs-review-translation">Do not load the wallet and disable wallet RPC calls</target>
+        <context-group purpose="location"><context context-type="linenumber">275</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1200">
+        <source xml:space="preserve">Do you want to rebuild the block database now?</source>
+        <target xml:space="preserve" state="needs-review-translation">Do you want to rebuild the block database now?</target>
+        <context-group purpose="location"><context context-type="linenumber">276</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1201">
+        <source xml:space="preserve">Done loading</source>
+        <target xml:space="preserve" state="needs-review-translation">Done loading</target>
+        <context-group purpose="location"><context context-type="linenumber">277</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1202">
+        <source xml:space="preserve">Enable Old Transaction Deletion</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">278</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1203">
+        <source xml:space="preserve">Enable publish hash transaction (locked via SwiftX) in &lt;address&gt;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">280</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1204">
+        <source xml:space="preserve">Enable publish raw transaction (locked via SwiftX) in &lt;address&gt;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">283</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1205">
+        <source xml:space="preserve">Enable the client to act as a masternode (0-1, default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Enable the client to act as a masternode (0-1, default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">286</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1206">
+        <source xml:space="preserve">Error initializing block database</source>
+        <target xml:space="preserve" state="needs-review-translation">Error initializing block database</target>
+        <context-group purpose="location"><context context-type="linenumber">289</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1207">
+        <source xml:space="preserve">Error initializing wallet database environment %s!</source>
+        <target xml:space="preserve" state="needs-review-translation">Error initializing wallet database environment %s!</target>
+        <context-group purpose="location"><context context-type="linenumber">290</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1208">
+        <source xml:space="preserve">Error loading block database</source>
+        <target xml:space="preserve" state="needs-review-translation">Error loading block database</target>
+        <context-group purpose="location"><context context-type="linenumber">291</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1209">
+        <source xml:space="preserve">Error loading wallet.dat</source>
+        <target xml:space="preserve" state="needs-review-translation">Error loading wallet.dat</target>
+        <context-group purpose="location"><context context-type="linenumber">292</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1210">
+        <source xml:space="preserve">Error loading wallet.dat: Wallet corrupted</source>
+        <target xml:space="preserve" state="needs-review-translation">Error loading wallet.dat: Wallet corrupted</target>
+        <context-group purpose="location"><context context-type="linenumber">293</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1211">
+        <source xml:space="preserve">Error opening block database</source>
+        <target xml:space="preserve" state="needs-review-translation">Error opening block database</target>
+        <context-group purpose="location"><context context-type="linenumber">295</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1212">
+        <source xml:space="preserve">Error reading from database, shutting down.</source>
+        <target xml:space="preserve" state="needs-review-translation">Error reading from database, shutting down.</target>
+        <context-group purpose="location"><context context-type="linenumber">296</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1213">
+        <source xml:space="preserve">Error</source>
+        <target xml:space="preserve" state="needs-review-translation">Error</target>
+        <context-group purpose="location"><context context-type="linenumber">297</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1214">
+        <source xml:space="preserve">Error: A fatal internal error occured, see debug.log for details</source>
+        <target xml:space="preserve" state="needs-review-translation">Error: A fatal internal error occured, see debug.log for details</target>
+        <context-group purpose="location"><context context-type="linenumber">299</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1215">
+        <source xml:space="preserve">Error: Disk space is low!</source>
+        <target xml:space="preserve" state="needs-review-translation">Error: Disk space is low!</target>
+        <context-group purpose="location"><context context-type="linenumber">301</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1216">
+        <source xml:space="preserve">Error: Unsupported argument -tor found, use -onion.</source>
+        <target xml:space="preserve" state="needs-review-translation">Error: Unsupported argument -tor found, use -onion.</target>
+        <context-group purpose="location"><context context-type="linenumber">303</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1217">
+        <source xml:space="preserve">Failed to generate RingCT</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">304</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1218">
+        <source xml:space="preserve">Failed to listen on any port. Use -listen=0 if you want this.</source>
+        <target xml:space="preserve" state="needs-review-translation">Failed to listen on any port. Use -listen=0 if you want this.</target>
+        <context-group purpose="location"><context context-type="linenumber">306</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1219">
+        <source xml:space="preserve">Force safe mode (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Force safe mode (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">309</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1220">
+        <source xml:space="preserve">Generate coins (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Generate coins (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">310</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1221">
+        <source xml:space="preserve">How many blocks to check at startup (default: %u, 0 = all)</source>
+        <target xml:space="preserve" state="needs-review-translation">How many blocks to check at startup (default: %u, 0 = all)</target>
+        <context-group purpose="location"><context context-type="linenumber">311</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1222">
+        <source xml:space="preserve">If &lt;category&gt; is not supplied, output all debugging information.</source>
+        <target xml:space="preserve" state="needs-review-translation">If &lt;category&gt; is not supplied, output all debugging information.</target>
+        <context-group purpose="location"><context context-type="linenumber">312</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1223">
+        <source xml:space="preserve">Importing...</source>
+        <target xml:space="preserve" state="needs-review-translation">Importing...</target>
+        <context-group purpose="location"><context context-type="linenumber">313</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1224">
+        <source xml:space="preserve">Imports blocks from external blk000??.dat file</source>
+        <target xml:space="preserve" state="needs-review-translation">Imports blocks from external blk000??.dat file</target>
+        <context-group purpose="location"><context context-type="linenumber">314</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1225">
+        <source xml:space="preserve">Include IP addresses in debug output (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Include IP addresses in debug output (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">315</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1226">
+        <source xml:space="preserve">Incorrect or no genesis block found. Wrong datadir for network?</source>
+        <target xml:space="preserve" state="needs-review-translation">Incorrect or no genesis block found. Wrong datadir for network?</target>
+        <context-group purpose="location"><context context-type="linenumber">316</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1227">
+        <source xml:space="preserve">Information</source>
+        <target xml:space="preserve" state="needs-review-translation">Information</target>
+        <context-group purpose="location"><context context-type="linenumber">317</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1228">
+        <source xml:space="preserve">Initialization sanity check failed. PRCY is shutting down.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">318</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1229">
+        <source xml:space="preserve">Insufficient funds.</source>
+        <target xml:space="preserve" state="needs-review-translation">Insufficient funds.</target>
+        <context-group purpose="location"><context context-type="linenumber">320</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1230">
+        <source xml:space="preserve">Invalid -onion address or hostname: &apos;%s&apos;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">323</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1231">
+        <source xml:space="preserve">Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least %s)</source>
+        <target xml:space="preserve" state="needs-review-translation">Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos; (must be at least %s)</target>
+        <context-group purpose="location"><context context-type="linenumber">325</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1232">
+        <source xml:space="preserve">Invalid amount for -reservebalance=&lt;amount&gt;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">326</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1233">
+        <source xml:space="preserve">Invalid masternodeprivkey. Please see documenation.</source>
+        <target xml:space="preserve" state="needs-review-translation">Invalid masternodeprivkey. Please see documenation.</target>
+        <context-group purpose="location"><context context-type="linenumber">327</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1234">
+        <source xml:space="preserve">Invalid netmask specified in -whitelist: &apos;%s&apos;</source>
+        <target xml:space="preserve" state="needs-review-translation">Invalid netmask specified in -whitelist: &apos;%s&apos;</target>
+        <context-group purpose="location"><context context-type="linenumber">328</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1235">
+        <source xml:space="preserve">Reindex the %s money supply statistics</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">367</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1236">
+        <source xml:space="preserve">SwiftX options:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">397</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1237">
+        <source xml:space="preserve">This is a pre-release test build - use at your own risk - do not use for staking or merchant applications!</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">171</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1238">
+        <source xml:space="preserve">Accept connections from outside (default: 1 if no -proxy or -connect/-noconnect)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">15</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1239">
+        <source xml:space="preserve">Connect only to the specified node(s); -noconnect or -connect=0 alone to disable automatic connections</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">37</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1240">
+        <source xml:space="preserve">Delete transaction every &lt;n&gt; blocks during inital block download (default: %i)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">49</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1241">
+        <source xml:space="preserve">Enable SwiftX, show confirmations for locked transactions (bool, default: %s)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">55</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1242">
+        <source xml:space="preserve">Enable or disable staking functionality for PRCY inputs (0-1, default: %u)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">57</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1243">
+        <source xml:space="preserve">Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">64</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1244">
+        <source xml:space="preserve">Exclude debugging information for a category. Can be used in conjunction with -debug=1 to output debug logs for all categories except one or more specified categories.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">71</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1245">
+        <source xml:space="preserve">Fees (in %s/Kb) smaller than this are considered zero fee for relaying (default: %s)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">87</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1246">
+        <source xml:space="preserve">Fees (in %s/Kb) smaller than this are considered zero fee for transaction creation (default: %s)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">90</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1247">
+        <source xml:space="preserve">Maximum average size of an index occurrence in the block spam filter (default: %u)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">115</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1248">
+        <source xml:space="preserve">Maximum size of the list of indexes in the block spam filter (default: %u)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">121</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1249">
+        <source xml:space="preserve">Query for peer addresses via DNS lookup, if low on addresses (default: 1 unless -connect/-noconnect)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">130</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1250">
+        <source xml:space="preserve">Specify custom backup path to add a copy of any wallet backup. If set as dir, every backup generates a timestamped file. If set as file, will rewrite to that file every backup.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">154</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1251">
+        <source xml:space="preserve">Specify location of debug log file: this can be an absolute path or a path relative to the data directory (default: %s)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">158</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1252">
+        <source xml:space="preserve">Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">178</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1253">
+        <source xml:space="preserve">You have attempted to send more than 50 UTXOs in a single transaction. To work around this limitation, please either lower the total amount of the transaction or send two separate transactions with 50% of your total desired amount.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">223</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1254">
+        <source xml:space="preserve">(must be %d for %s-net)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">233</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1255">
+        <source xml:space="preserve">&lt;category&gt; can be:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">234</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1256">
+        <source xml:space="preserve">All inputs should have the same number of decoys</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">238</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1257">
+        <source xml:space="preserve">Append comment to the user agent string</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">241</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1258">
+        <source xml:space="preserve">Attempt to force blockchain corruption recovery</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">242</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1259">
+        <source xml:space="preserve">Cannot compute LIJ for ring signature in secp256k1_ec_pubkey_tweak_add</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">246</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1260">
+        <source xml:space="preserve">Cannot compute LIJ for ring signature in secp256k1_ec_pubkey_tweak_mul</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">247</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1261">
+        <source xml:space="preserve">Cannot compute RIJ for ring signature in secp256k1_ec_pubkey_tweak_mul</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">248</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1262">
+        <source xml:space="preserve">Cannot compute two elements and serialize it to pubkey</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">249</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1263">
+        <source xml:space="preserve">Cannot extract public key from script pubkey</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">251</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1264">
+        <source xml:space="preserve">Cannot find corresponding private key</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">252</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1265">
+        <source xml:space="preserve">Cannot parse the commitment for inputs</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">253</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1266">
+        <source xml:space="preserve">Cannot parse the commitment for transaction fee</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">254</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1267">
+        <source xml:space="preserve">Cannot resolve -%s address: &apos;%s&apos;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">255</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1268">
+        <source xml:space="preserve">Copyright (C) 2015-%i The PIVX Core Developers</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">262</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1269">
+        <source xml:space="preserve">Copyright (C) 2018-%i The DAPS Project developers</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">263</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1270">
+        <source xml:space="preserve">Copyright (C) 2020-%i The PRivaCY Coin Developers</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">264</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1271">
+        <source xml:space="preserve">Currently the Number of supported recipients must be 1</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">267</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1272">
+        <source xml:space="preserve">Display the stake modifier calculations in the debug.log file.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">273</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1273">
+        <source xml:space="preserve">Display verbose coin stake messages in the debug.log file.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">274</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1274">
+        <source xml:space="preserve">Enable publish hash block in &lt;address&gt;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">279</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1275">
+        <source xml:space="preserve">Enable publish hash transaction in &lt;address&gt;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">281</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1276">
+        <source xml:space="preserve">Enable publish raw block in &lt;address&gt;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">282</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1277">
+        <source xml:space="preserve">Enable publish raw transaction in &lt;address&gt;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">284</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1278">
+        <source xml:space="preserve">Enable staking functionality (0-1, default: %u)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">285</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1279">
+        <source xml:space="preserve">Error in CreateTransaction. Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">287</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1280">
+        <source xml:space="preserve">Error in CreateTransactionBulletProof. Please try again.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">288</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1281">
+        <source xml:space="preserve">Error loading wallet.dat: Wallet requires newer version of PRCYcoin</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">294</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1282">
+        <source xml:space="preserve">Error: -listen must be true if -masternode is set.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">298</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1283">
+        <source xml:space="preserve">Error: A fatal internal error occurred, see debug.log for details</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">300</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1284">
+        <source xml:space="preserve">Error: Invalid port %d for running a masternode.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">302</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1285">
+        <source xml:space="preserve">Failed to generate bulletproof</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">305</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1286">
+        <source xml:space="preserve">Failed to parse host:port string</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">307</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1287">
+        <source xml:space="preserve">Fee (in %s/kB) to add to transactions you send (default: %s)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">308</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1288">
+        <source xml:space="preserve">Input commitments are not correct</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">319</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1289">
+        <source xml:space="preserve">Invalid -masternodeaddr address: %s</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">321</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1290">
+        <source xml:space="preserve">Invalid -masternodeaddr port %d, only %d is supported on %s-net.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">322</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1291">
+        <source xml:space="preserve">Invalid amount for -%s=&lt;amount&gt;: &apos;%s&apos;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">324</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1292">
+        <source xml:space="preserve">Invalid port %d detected in masternode.conf</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">329</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1293">
+        <source xml:space="preserve">Keep at most &lt;n&gt; unconnectable transactions in memory (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Keep at most &lt;n&gt; unconnectable transactions in memory (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">330</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1294">
+        <source xml:space="preserve">Line: %d</source>
+        <target xml:space="preserve" state="needs-review-translation">Line: %d</target>
+        <context-group purpose="location"><context context-type="linenumber">334</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1295">
+        <source xml:space="preserve">Listen for JSON-RPC connections on &lt;port&gt; (default: %u or testnet: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Listen for JSON-RPC connections on &lt;port&gt; (default: %u or testnet: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">335</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1296">
+        <source xml:space="preserve">Listen for connections on &lt;port&gt; (default: %u or testnet: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Listen for connections on &lt;port&gt; (default: %u or testnet: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">336</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1297">
+        <source xml:space="preserve">Loading addresses...</source>
+        <target xml:space="preserve" state="needs-review-translation">Loading addresses...</target>
+        <context-group purpose="location"><context context-type="linenumber">337</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1298">
+        <source xml:space="preserve">Loading banlist...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">338</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1299">
+        <source xml:space="preserve">Loading block index...</source>
+        <target xml:space="preserve" state="needs-review-translation">Loading block index...</target>
+        <context-group purpose="location"><context context-type="linenumber">339</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1300">
+        <source xml:space="preserve">Loading budget cache...</source>
+        <target xml:space="preserve" state="needs-review-translation">Loading budget cache...</target>
+        <context-group purpose="location"><context context-type="linenumber">340</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1301">
+        <source xml:space="preserve">Loading masternode cache...</source>
+        <target xml:space="preserve" state="needs-review-translation">Loading masternode cache...</target>
+        <context-group purpose="location"><context context-type="linenumber">341</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1302">
+        <source xml:space="preserve">Loading masternode payment cache...</source>
+        <target xml:space="preserve" state="needs-review-translation">Loading masternode payment cache...</target>
+        <context-group purpose="location"><context context-type="linenumber">342</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1303">
+        <source xml:space="preserve">Lock masternodes from masternode configuration file (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Lock masternodes from masternode configuration file (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">343</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1304">
+        <source xml:space="preserve">Lookup(): Invalid -proxy address or hostname: &apos;%s&apos;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">344</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1305">
+        <source xml:space="preserve">Maintain at most &lt;n&gt; connections to peers (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Maintain at most &lt;n&gt; connections to peers (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">345</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1306">
+        <source xml:space="preserve">Masternode options:</source>
+        <target xml:space="preserve" state="needs-review-translation">Masternode options:</target>
+        <context-group purpose="location"><context context-type="linenumber">346</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1307">
+        <source xml:space="preserve">Masternodes are required to run on port %d for %s-net</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">347</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1308">
+        <source xml:space="preserve">Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">348</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1309">
+        <source xml:space="preserve">Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">349</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1310">
+        <source xml:space="preserve">Need to specify a port with -whitebind: &apos;%s&apos;</source>
+        <target xml:space="preserve" state="needs-review-translation">Need to specify a port with -whitebind: &apos;%s&apos;</target>
+        <context-group purpose="location"><context context-type="linenumber">350</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1311">
+        <source xml:space="preserve">Node relay options:</source>
+        <target xml:space="preserve" state="needs-review-translation">Node relay options:</target>
+        <context-group purpose="location"><context context-type="linenumber">351</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1312">
+        <source xml:space="preserve">Not enough file descriptors available.</source>
+        <target xml:space="preserve" state="needs-review-translation">Not enough file descriptors available.</target>
+        <context-group purpose="location"><context context-type="linenumber">352</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1313">
+        <source xml:space="preserve">Number of automatic wallet backups (default: 10)</source>
+        <target xml:space="preserve" state="needs-review-translation">Number of automatic wallet backups (default: 10)</target>
+        <context-group purpose="location"><context context-type="linenumber">353</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1314">
+        <source xml:space="preserve">Only accept block chain matching built-in checkpoints (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Only accept block chain matching built-in checkpoints (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">355</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1315">
+        <source xml:space="preserve">Only connect to nodes in network &lt;net&gt; (ipv4, ipv6 or onion)</source>
+        <target xml:space="preserve" state="needs-review-translation">Only connect to nodes in network &lt;net&gt; (ipv4, ipv6 or onion)</target>
+        <context-group purpose="location"><context context-type="linenumber">356</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1316">
+        <source xml:space="preserve">Options:</source>
+        <target xml:space="preserve" state="needs-review-translation">Options:</target>
+        <context-group purpose="location"><context context-type="linenumber">357</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1317">
+        <source xml:space="preserve">Password for JSON-RPC connections</source>
+        <target xml:space="preserve" state="needs-review-translation">Password for JSON-RPC connections</target>
+        <context-group purpose="location"><context context-type="linenumber">358</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1318">
+        <source xml:space="preserve">Preparing for resync...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">359</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1319">
+        <source xml:space="preserve">Prepend debug output with timestamp (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Prepend debug output with timestamp (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">360</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1320">
+        <source xml:space="preserve">Print version and exit</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">361</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1321">
+        <source xml:space="preserve">RPC server options:</source>
+        <target xml:space="preserve" state="needs-review-translation">RPC server options:</target>
+        <context-group purpose="location"><context context-type="linenumber">362</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1322">
+        <source xml:space="preserve">Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <target xml:space="preserve" state="needs-review-translation">Randomly drop 1 of every &lt;n&gt; network messages</target>
+        <context-group purpose="location"><context context-type="linenumber">363</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1323">
+        <source xml:space="preserve">Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <target xml:space="preserve" state="needs-review-translation">Randomly fuzz 1 of every &lt;n&gt; network messages</target>
+        <context-group purpose="location"><context context-type="linenumber">364</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1324">
+        <source xml:space="preserve">Rebuild block chain index from current blk000??.dat files</source>
+        <target xml:space="preserve" state="needs-review-translation">Rebuild block chain index from current blk000??.dat files</target>
+        <context-group purpose="location"><context context-type="linenumber">365</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1325">
+        <source xml:space="preserve">Recalculating PRCY supply...</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">366</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1326">
+        <source xml:space="preserve">Relay and mine data carrier transactions (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Relay and mine data carrier transactions (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">368</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1327">
+        <source xml:space="preserve">Relay non-P2SH multisig (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Relay non-P2SH multisig (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">369</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1328">
+        <source xml:space="preserve">Rescan the block chain for missing wallet transactions</source>
+        <target xml:space="preserve" state="needs-review-translation">Rescan the block chain for missing wallet transactions</target>
+        <context-group purpose="location"><context context-type="linenumber">370</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1329">
+        <source xml:space="preserve">Rescanning...</source>
+        <target xml:space="preserve" state="needs-review-translation">Rescanning...</target>
+        <context-group purpose="location"><context context-type="linenumber">371</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1330">
+        <source xml:space="preserve">Run a thread to flush wallet periodically (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Run a thread to flush wallet periodically (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">372</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1331">
+        <source xml:space="preserve">Run in the background as a daemon and accept commands</source>
+        <target xml:space="preserve" state="needs-review-translation">Run in the background as a daemon and accept commands</target>
+        <context-group purpose="location"><context context-type="linenumber">373</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1332">
+        <source xml:space="preserve">Send transactions as zero-fee transactions if possible (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Send transactions as zero-fee transactions if possible (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">374</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1333">
+        <source xml:space="preserve">Set database cache size in megabytes (%d to %d, default: %d)</source>
+        <target xml:space="preserve" state="needs-review-translation">Set database cache size in megabytes (%d to %d, default: %d)</target>
+        <context-group purpose="location"><context context-type="linenumber">375</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1334">
+        <source xml:space="preserve">Set external address:port to get to this masternode (example: %s)</source>
+        <target xml:space="preserve" state="needs-review-translation">Set external address:port to get to this masternode (example: %s)</target>
+        <context-group purpose="location"><context context-type="linenumber">376</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1335">
+        <source xml:space="preserve">Set key pool size to &lt;n&gt; (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Set key pool size to &lt;n&gt; (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">377</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1336">
+        <source xml:space="preserve">Set maximum block size in bytes (default: %d)</source>
+        <target xml:space="preserve" state="needs-review-translation">Set maximum block size in bytes (default: %d)</target>
+        <context-group purpose="location"><context context-type="linenumber">378</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1337">
+        <source xml:space="preserve">Set minimum block size in bytes (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Set minimum block size in bytes (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">379</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1338">
+        <source xml:space="preserve">Set the Maximum reorg depth (default: %u)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">380</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1339">
+        <source xml:space="preserve">Set the masternode private key</source>
+        <target xml:space="preserve" state="needs-review-translation">Set the masternode private key</target>
+        <context-group purpose="location"><context context-type="linenumber">381</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1340">
+        <source xml:space="preserve">Set the number of threads to service RPC calls (default: %d)</source>
+        <target xml:space="preserve" state="needs-review-translation">Set the number of threads to service RPC calls (default: %d)</target>
+        <context-group purpose="location"><context context-type="linenumber">382</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1341">
+        <source xml:space="preserve">Sets the DB_PRIVATE flag in the wallet db environment (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Sets the DB_PRIVATE flag in the wallet db environment (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">383</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1342">
+        <source xml:space="preserve">Show all debugging options (usage: --help -help-debug)</source>
+        <target xml:space="preserve" state="needs-review-translation">Show all debugging options (usage: --help -help-debug)</target>
+        <context-group purpose="location"><context context-type="linenumber">384</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1343">
+        <source xml:space="preserve">Shrink debug.log file on client startup (default: 1 when no -debug)</source>
+        <target xml:space="preserve" state="needs-review-translation">Shrink debug.log file on client startup (default: 1 when no -debug)</target>
+        <context-group purpose="location"><context context-type="linenumber">385</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1344">
+        <source xml:space="preserve">Keep the last &lt;n&gt; transactions (default: %i)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">331</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1345">
+        <source xml:space="preserve">Keep transactions for at least &lt;n&gt; blocks (default: %i)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">332</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1346">
+        <source xml:space="preserve">Limit size of signature cache to &lt;n&gt; MiB (default: %u)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">333</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1347">
+        <source xml:space="preserve">Number of custom location backups to retain (default: %d)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">354</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1348">
+        <source xml:space="preserve">Signing transaction failed</source>
+        <target xml:space="preserve" state="needs-review-translation">Signing transaction failed</target>
+        <context-group purpose="location"><context context-type="linenumber">386</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1349">
+        <source xml:space="preserve">Specify configuration file (default: %s)</source>
+        <target xml:space="preserve" state="needs-review-translation">Specify configuration file (default: %s)</target>
+        <context-group purpose="location"><context context-type="linenumber">387</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1350">
+        <source xml:space="preserve">Specify connection timeout in milliseconds (minimum: 1, default: %d)</source>
+        <target xml:space="preserve" state="needs-review-translation">Specify connection timeout in milliseconds (minimum: 1, default: %d)</target>
+        <context-group purpose="location"><context context-type="linenumber">388</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1351">
+        <source xml:space="preserve">Specify data directory</source>
+        <target xml:space="preserve" state="needs-review-translation">Specify data directory</target>
+        <context-group purpose="location"><context context-type="linenumber">389</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1352">
+        <source xml:space="preserve">Specify masternode configuration file (default: %s)</source>
+        <target xml:space="preserve" state="needs-review-translation">Specify masternode configuration file (default: %s)</target>
+        <context-group purpose="location"><context context-type="linenumber">390</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1353">
+        <source xml:space="preserve">Specify pid file (default: %s)</source>
+        <target xml:space="preserve" state="needs-review-translation">Specify pid file (default: %s)</target>
+        <context-group purpose="location"><context context-type="linenumber">391</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1354">
+        <source xml:space="preserve">Specify wallet file (within data directory)</source>
+        <target xml:space="preserve" state="needs-review-translation">Specify wallet file (within data directory)</target>
+        <context-group purpose="location"><context context-type="linenumber">392</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1355">
+        <source xml:space="preserve">Specify your own public address</source>
+        <target xml:space="preserve" state="needs-review-translation">Specify your own public address</target>
+        <context-group purpose="location"><context context-type="linenumber">393</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1356">
+        <source xml:space="preserve">Spend unconfirmed change when sending transactions (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Spend unconfirmed change when sending transactions (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">394</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1357">
+        <source xml:space="preserve">Staking options:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">395</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1358">
+        <source xml:space="preserve">Stop running after importing blocks from disk (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Stop running after importing blocks from disk (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">396</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1359">
+        <source xml:space="preserve">Synchronization failed</source>
+        <target xml:space="preserve" state="needs-review-translation">Synchronization failed</target>
+        <context-group purpose="location"><context context-type="linenumber">398</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1360">
+        <source xml:space="preserve">Synchronization finished</source>
+        <target xml:space="preserve" state="needs-review-translation">Synchronization finished</target>
+        <context-group purpose="location"><context context-type="linenumber">399</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1361">
+        <source xml:space="preserve">Synchronization pending...</source>
+        <target xml:space="preserve" state="needs-review-translation">Synchronization pending...</target>
+        <context-group purpose="location"><context context-type="linenumber">400</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1362">
+        <source xml:space="preserve">Synchronizing budgets...</source>
+        <target xml:space="preserve" state="needs-review-translation">Synchronizing budgets...</target>
+        <context-group purpose="location"><context context-type="linenumber">401</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1363">
+        <source xml:space="preserve">Synchronizing masternode winners...</source>
+        <target xml:space="preserve" state="needs-review-translation">Synchronizing masternode winners...</target>
+        <context-group purpose="location"><context context-type="linenumber">402</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1364">
+        <source xml:space="preserve">Synchronizing masternodes...</source>
+        <target xml:space="preserve" state="needs-review-translation">Synchronizing masternodes...</target>
+        <context-group purpose="location"><context context-type="linenumber">403</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1365">
+        <source xml:space="preserve">This help message</source>
+        <target xml:space="preserve" state="needs-review-translation">This help message</target>
+        <context-group purpose="location"><context context-type="linenumber">404</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1366">
+        <source xml:space="preserve">This is experimental software.</source>
+        <target xml:space="preserve" state="needs-review-translation">This is experimental software.</target>
+        <context-group purpose="location"><context context-type="linenumber">405</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1367">
+        <source xml:space="preserve">This is intended for regression testing tools and app development.</source>
+        <target xml:space="preserve" state="needs-review-translation">This is intended for regression testing tools and app development.</target>
+        <context-group purpose="location"><context context-type="linenumber">406</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1368">
+        <source xml:space="preserve">Threshold for disconnecting misbehaving peers (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Threshold for disconnecting misbehaving peers (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">407</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1369">
+        <source xml:space="preserve">Too many decoys</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">408</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1370">
+        <source xml:space="preserve">Tor control port password (default: empty)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">409</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1371">
+        <source xml:space="preserve">Tor control port to use if onion listening enabled (default: %s)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">410</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1372">
+        <source xml:space="preserve">Transaction amount too small</source>
+        <target xml:space="preserve" state="needs-review-translation">Transaction amount too small</target>
+        <context-group purpose="location"><context context-type="linenumber">411</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1373">
+        <source xml:space="preserve">Transaction amounts must be positive</source>
+        <target xml:space="preserve" state="needs-review-translation">Transaction amounts must be positive</target>
+        <context-group purpose="location"><context context-type="linenumber">412</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1374">
+        <source xml:space="preserve">Transaction too large for fee policy</source>
+        <target xml:space="preserve" state="needs-review-translation">Transaction too large for fee policy</target>
+        <context-group purpose="location"><context context-type="linenumber">413</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1375">
+        <source xml:space="preserve">Transaction too large</source>
+        <target xml:space="preserve" state="needs-review-translation">Transaction too large</target>
+        <context-group purpose="location"><context context-type="linenumber">414</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1376">
+        <source xml:space="preserve">Unable to bind to %s on this computer (bind returned error %s)</source>
+        <target xml:space="preserve" state="needs-review-translation">Unable to bind to %s on this computer (bind returned error %s)</target>
+        <context-group purpose="location"><context context-type="linenumber">415</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1377">
+        <source xml:space="preserve">Unable to start HTTP server. See debug log for details.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">416</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1378">
+        <source xml:space="preserve">Unknown network specified in -onlynet: &apos;%s&apos;</source>
+        <target xml:space="preserve" state="needs-review-translation">Unknown network specified in -onlynet: &apos;%s&apos;</target>
+        <context-group purpose="location"><context context-type="linenumber">417</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1379">
+        <source xml:space="preserve">Unsupported logging category %s=%s.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">418</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1380">
+        <source xml:space="preserve">Upgrade wallet to latest format</source>
+        <target xml:space="preserve" state="needs-review-translation">Upgrade wallet to latest format</target>
+        <context-group purpose="location"><context context-type="linenumber">419</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1381">
+        <source xml:space="preserve">Use UPnP to map the listening port (default: %u)</source>
+        <target xml:space="preserve" state="needs-review-translation">Use UPnP to map the listening port (default: %u)</target>
+        <context-group purpose="location"><context context-type="linenumber">420</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1382">
+        <source xml:space="preserve">Use UPnP to map the listening port (default: 1 when listening)</source>
+        <target xml:space="preserve" state="needs-review-translation">Use UPnP to map the listening port (default: 1 when listening)</target>
+        <context-group purpose="location"><context context-type="linenumber">421</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1383">
+        <source xml:space="preserve">Use a custom max chain reorganization depth (default: %u)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">422</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1384">
+        <source xml:space="preserve">Use block spam filter (default: %u)</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">423</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1385">
+        <source xml:space="preserve">Use the test network</source>
+        <target xml:space="preserve" state="needs-review-translation">Use the test network</target>
+        <context-group purpose="location"><context context-type="linenumber">424</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1386">
+        <source xml:space="preserve">User Agent comment (%s) contains unsafe characters.</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">425</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1387">
+        <source xml:space="preserve">Username for JSON-RPC connections</source>
+        <target xml:space="preserve" state="needs-review-translation">Username for JSON-RPC connections</target>
+        <context-group purpose="location"><context context-type="linenumber">426</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1388">
+        <source xml:space="preserve">Verifying blocks...</source>
+        <target xml:space="preserve" state="needs-review-translation">Verifying blocks...</target>
+        <context-group purpose="location"><context context-type="linenumber">427</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1389">
+        <source xml:space="preserve">Verifying wallet...</source>
+        <target xml:space="preserve" state="needs-review-translation">Verifying wallet...</target>
+        <context-group purpose="location"><context context-type="linenumber">428</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1390">
+        <source xml:space="preserve">Wallet %s resides outside data directory %s</source>
+        <target xml:space="preserve" state="needs-review-translation">Wallet %s resides outside data directory %s</target>
+        <context-group purpose="location"><context context-type="linenumber">429</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1391">
+        <source xml:space="preserve">Wallet needed to be rewritten: restart PRCY to complete</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">430</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1392">
+        <source xml:space="preserve">Wallet options:</source>
+        <target xml:space="preserve" state="needs-review-translation">Wallet options:</target>
+        <context-group purpose="location"><context context-type="linenumber">431</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1393">
+        <source xml:space="preserve">Wallet window title</source>
+        <target xml:space="preserve" state="needs-review-translation">Wallet window title</target>
+        <context-group purpose="location"><context context-type="linenumber">432</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1394">
+        <source xml:space="preserve">Warning</source>
+        <target xml:space="preserve" state="needs-review-translation">Warning</target>
+        <context-group purpose="location"><context context-type="linenumber">433</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1395">
+        <source xml:space="preserve">Warning: This version is obsolete, upgrade required!</source>
+        <target xml:space="preserve" state="needs-review-translation">Warning: This version is obsolete, upgrade required!</target>
+        <context-group purpose="location"><context context-type="linenumber">434</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1396">
+        <source xml:space="preserve">Warning: Unsupported argument -benchmark ignored, use -debug=bench.</source>
+        <target xml:space="preserve" state="needs-review-translation">Warning: Unsupported argument -benchmark ignored, use -debug=bench.</target>
+        <context-group purpose="location"><context context-type="linenumber">435</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1397">
+        <source xml:space="preserve">Warning: Unsupported argument -debugnet ignored, use -debug=net.</source>
+        <target xml:space="preserve" state="needs-review-translation">Warning: Unsupported argument -debugnet ignored, use -debug=net.</target>
+        <context-group purpose="location"><context context-type="linenumber">436</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1398">
+        <source xml:space="preserve">You need to rebuild the database using -reindex to change -txindex</source>
+        <target xml:space="preserve" state="needs-review-translation">You need to rebuild the database using -reindex to change -txindex</target>
+        <context-group purpose="location"><context context-type="linenumber">437</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1399">
+        <source xml:space="preserve">Zapping all transactions from wallet...</source>
+        <target xml:space="preserve" state="needs-review-translation">Zapping all transactions from wallet...</target>
+        <context-group purpose="location"><context context-type="linenumber">438</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1400">
+        <source xml:space="preserve">ZeroMQ notification options:</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">439</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1401">
+        <source xml:space="preserve">isValid(): Invalid -proxy address or hostname: &apos;%s&apos;</source>
+        <target xml:space="preserve"></target>
+        <context-group purpose="location"><context context-type="linenumber">440</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1402">
+        <source xml:space="preserve">on startup</source>
+        <target xml:space="preserve" state="needs-review-translation">on startup</target>
+        <context-group purpose="location"><context context-type="linenumber">441</context></context-group>
+      </trans-unit>
+      <trans-unit id="_msg1403">
+        <source xml:space="preserve">wallet.dat corrupt, salvage failed</source>
+        <target xml:space="preserve" state="needs-review-translation">wallet.dat corrupt, salvage failed</target>
+        <context-group purpose="location"><context context-type="linenumber">442</context></context-group>
+      </trans-unit>
+    </group>
+  </body></file>
+</xliff>

--- a/src/qt/prcycoinstrings.cpp
+++ b/src/qt/prcycoinstrings.cpp
@@ -47,10 +47,15 @@ QT_TRANSLATE_NOOP("prcycoin-core", ""
 "Delete all wallet transactions and only recover those parts of the "
 "blockchain through -rescan on startup"),
 QT_TRANSLATE_NOOP("prcycoin-core", ""
+"Delete transaction every <n> blocks during inital block download (default: "
+"%i)"),
+QT_TRANSLATE_NOOP("prcycoin-core", ""
 "Distributed under the MIT software license, see the accompanying file "
 "COPYING or <http://www.opensource.org/licenses/mit-license.php>."),
 QT_TRANSLATE_NOOP("prcycoin-core", ""
 "Enable SwiftX, show confirmations for locked transactions (bool, default: %s)"),
+QT_TRANSLATE_NOOP("prcycoin-core", ""
+"Enable or disable staking functionality for PRCY inputs (0-1, default: %u)"),
 QT_TRANSLATE_NOOP("prcycoin-core", ""
 "Enter regression test mode, which uses a special chain in which blocks can "
 "be solved instantly."),
@@ -108,8 +113,13 @@ QT_TRANSLATE_NOOP("prcycoin-core", ""
 "Maintain a full transaction index, used by the getrawtransaction rpc call "
 "(default: %u)"),
 QT_TRANSLATE_NOOP("prcycoin-core", ""
+"Maximum average size of an index occurrence in the block spam filter "
+"(default: %u)"),
+QT_TRANSLATE_NOOP("prcycoin-core", ""
 "Maximum size of data in data carrier transactions we relay and mine "
 "(default: %u)"),
+QT_TRANSLATE_NOOP("prcycoin-core", ""
+"Maximum size of the list of indexes in the block spam filter (default: %u)"),
 QT_TRANSLATE_NOOP("prcycoin-core", ""
 "Maximum total fees to use in a single wallet transaction, setting too low "
 "may abort large transactions (default: %s)"),
@@ -171,11 +181,12 @@ QT_TRANSLATE_NOOP("prcycoin-core", ""
 QT_TRANSLATE_NOOP("prcycoin-core", ""
 "Unable to bind to %s on this computer. PRCY is probably already running."),
 QT_TRANSLATE_NOOP("prcycoin-core", ""
-"Unable to locate enough funds for this transaction that are not equal 10000 "
-"PRCY."),
-QT_TRANSLATE_NOOP("prcycoin-core", ""
 "Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: "
 "%s)"),
+QT_TRANSLATE_NOOP("prcycoin-core", ""
+"Username and hashed password for JSON-RPC connections. The field <userpw> "
+"comes in the format: <USERNAME>:<SALT>$<HASH>. A canonical python script is "
+"included in share/rpcuser. This option can be specified multiple times"),
 QT_TRANSLATE_NOOP("prcycoin-core", ""
 "Warning: -maxtxfee is set very high! Fees this large could be paid on a "
 "single transaction."),
@@ -264,6 +275,7 @@ QT_TRANSLATE_NOOP("prcycoin-core", "Display verbose coin stake messages in the d
 QT_TRANSLATE_NOOP("prcycoin-core", "Do not load the wallet and disable wallet RPC calls"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Do you want to rebuild the block database now?"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Done loading"),
+QT_TRANSLATE_NOOP("prcycoin-core", "Enable Old Transaction Deletion"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Enable publish hash block in <address>"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Enable publish hash transaction (locked via SwiftX) in <address>"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Enable publish hash transaction in <address>"),
@@ -282,7 +294,6 @@ QT_TRANSLATE_NOOP("prcycoin-core", "Error loading wallet.dat: Wallet corrupted")
 QT_TRANSLATE_NOOP("prcycoin-core", "Error loading wallet.dat: Wallet requires newer version of PRCYcoin"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Error opening block database"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Error reading from database, shutting down."),
-QT_TRANSLATE_NOOP("prcycoin-core", "Error recovering public key."),
 QT_TRANSLATE_NOOP("prcycoin-core", "Error"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Error: -listen must be true if -masternode is set."),
 QT_TRANSLATE_NOOP("prcycoin-core", "Error: A fatal internal error occured, see debug.log for details"),
@@ -290,12 +301,10 @@ QT_TRANSLATE_NOOP("prcycoin-core", "Error: A fatal internal error occurred, see 
 QT_TRANSLATE_NOOP("prcycoin-core", "Error: Disk space is low!"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Error: Invalid port %d for running a masternode."),
 QT_TRANSLATE_NOOP("prcycoin-core", "Error: Unsupported argument -tor found, use -onion."),
-QT_TRANSLATE_NOOP("prcycoin-core", "Failed to generate RingCT for Sweeping transaction"),
-QT_TRANSLATE_NOOP("prcycoin-core", "Failed to generate bulletproof for Sweeping transaction"),
+QT_TRANSLATE_NOOP("prcycoin-core", "Failed to generate RingCT"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Failed to generate bulletproof"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Failed to listen on any port. Use -listen=0 if you want this."),
 QT_TRANSLATE_NOOP("prcycoin-core", "Failed to parse host:port string"),
-QT_TRANSLATE_NOOP("prcycoin-core", "Failed to read block"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Fee (in %s/kB) to add to transactions you send (default: %s)"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Force safe mode (default: %u)"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Generate coins (default: %u)"),
@@ -318,9 +327,10 @@ QT_TRANSLATE_NOOP("prcycoin-core", "Invalid amount for -reservebalance=<amount>"
 QT_TRANSLATE_NOOP("prcycoin-core", "Invalid masternodeprivkey. Please see documenation."),
 QT_TRANSLATE_NOOP("prcycoin-core", "Invalid netmask specified in -whitelist: '%s'"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Invalid port %d detected in masternode.conf"),
-QT_TRANSLATE_NOOP("prcycoin-core", "Invalid private key."),
 QT_TRANSLATE_NOOP("prcycoin-core", "Keep at most <n> unconnectable transactions in memory (default: %u)"),
-QT_TRANSLATE_NOOP("prcycoin-core", "Limit size of signature cache to <n> entries (default: %u)"),
+QT_TRANSLATE_NOOP("prcycoin-core", "Keep the last <n> transactions (default: %i)"),
+QT_TRANSLATE_NOOP("prcycoin-core", "Keep transactions for at least <n> blocks (default: %i)"),
+QT_TRANSLATE_NOOP("prcycoin-core", "Limit size of signature cache to <n> MiB (default: %u)"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Line: %d"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Listen for JSON-RPC connections on <port> (default: %u or testnet: %u)"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Listen for connections on <port> (default: %u or testnet: %u)"),
@@ -341,6 +351,7 @@ QT_TRANSLATE_NOOP("prcycoin-core", "Need to specify a port with -whitebind: '%s'
 QT_TRANSLATE_NOOP("prcycoin-core", "Node relay options:"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Not enough file descriptors available."),
 QT_TRANSLATE_NOOP("prcycoin-core", "Number of automatic wallet backups (default: 10)"),
+QT_TRANSLATE_NOOP("prcycoin-core", "Number of custom location backups to retain (default: %d)"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Only accept block chain matching built-in checkpoints (default: %u)"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Only connect to nodes in network <net> (ipv4, ipv6 or onion)"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Options:"),
@@ -361,7 +372,6 @@ QT_TRANSLATE_NOOP("prcycoin-core", "Rescanning..."),
 QT_TRANSLATE_NOOP("prcycoin-core", "Run a thread to flush wallet periodically (default: %u)"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Run in the background as a daemon and accept commands"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Send transactions as zero-fee transactions if possible (default: %u)"),
-QT_TRANSLATE_NOOP("prcycoin-core", "Session timed out."),
 QT_TRANSLATE_NOOP("prcycoin-core", "Set database cache size in megabytes (%d to %d, default: %d)"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Set external address:port to get to this masternode (example: %s)"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Set key pool size to <n> (default: %u)"),
@@ -373,8 +383,6 @@ QT_TRANSLATE_NOOP("prcycoin-core", "Set the number of threads to service RPC cal
 QT_TRANSLATE_NOOP("prcycoin-core", "Sets the DB_PRIVATE flag in the wallet db environment (default: %u)"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Show all debugging options (usage: --help -help-debug)"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Shrink debug.log file on client startup (default: 1 when no -debug)"),
-QT_TRANSLATE_NOOP("prcycoin-core", "Signing failed."),
-QT_TRANSLATE_NOOP("prcycoin-core", "Signing timed out."),
 QT_TRANSLATE_NOOP("prcycoin-core", "Signing transaction failed"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Specify configuration file (default: %s)"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Specify connection timeout in milliseconds (minimum: 1, default: %d)"),
@@ -412,6 +420,7 @@ QT_TRANSLATE_NOOP("prcycoin-core", "Upgrade wallet to latest format"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Use UPnP to map the listening port (default: %u)"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Use UPnP to map the listening port (default: 1 when listening)"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Use a custom max chain reorganization depth (default: %u)"),
+QT_TRANSLATE_NOOP("prcycoin-core", "Use block spam filter (default: %u)"),
 QT_TRANSLATE_NOOP("prcycoin-core", "Use the test network"),
 QT_TRANSLATE_NOOP("prcycoin-core", "User Agent comment (%s) contains unsafe characters."),
 QT_TRANSLATE_NOOP("prcycoin-core", "Username for JSON-RPC connections"),


### PR DESCRIPTION
> Currently, only a class name is provided to the Transifex translators as a context. Neither `disambiguation` parameter of the `tr()` function nor [translator comments](https://doc.qt.io/qt-5/i18n-source-translation.html#translator-comments), being included as XML elements to `*.ts` translation files, are not parsed by the Transifex due to its [limited support](https://docs.transifex.com/formats/qt-ts) of such files.
> 
> This PR makes possible to provide all of the context details via an intermediate [XLIFF](https://docs.transifex.com/formats/xliff) translation file.
> 
> With this PR `make -C src translate` produces the `src/qt/locale/bitcoin_en.xlf` file which must be provided to the Transifex as a translation source instead of `src/qt/locale/bitcoin_en.ts`.
> 
> Closes #21465.
> 
> An example translatable string with additional `<context>` and `<note>` XML elements:
> 
> https://github.com/bitcoin/bitcoin/blob/35d52397e72f3ab96a7797148666b501d50b445d/src/qt/locale/bitcoin_en.xlf#L126-L132

from https://github.com/bitcoin/bitcoin/pull/21694