### PR TITLE
[Upstream] build: Add ability to build qt in depends with -stdlib=libc++

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -127,7 +127,11 @@ $(package)_config_opts_linux += -ltcg
 endif
 $(package)_config_opts_arm_linux += -platform linux-g++ -xplatform bitcoin-linux-g++
 $(package)_config_opts_i686_linux  = -xplatform linux-g++-32
+ifneq (,$(findstring -stdlib=libc++,$($(1)_cxx)))
+$(package)_config_opts_x86_64_linux = -xplatform linux-clang-libc++
+else
 $(package)_config_opts_x86_64_linux = -xplatform linux-g++-64
+endif
 $(package)_config_opts_aarch64_linux = -xplatform linux-aarch64-gnu-g++
 $(package)_config_opts_riscv64_linux = -platform linux-g++ -xplatform bitcoin-linux-g++
 $(package)_config_opts_s390x_linux += -platform linux-g++ -xplatform linux-g++-64


### PR DESCRIPTION
> This PR makes possible to build the `qt` package in depends against `libc++` for x86_64 platform.
> 
> Fixes https://github.com/bitcoin/bitcoin/issues/22344.
> 
> Required for https://github.com/bitcoin/bitcoin/pull/22815.
> 
> Also this PR https://github.com/bitcoin/bitcoin/pull/23060#discussion_r716077050 the [no wallet] [bionic] task on CI:
> 
> - on master (https://github.com/bitcoin/bitcoin/commit/a8bbd4cc819633ec50ed0f763b6a75330ae055fb), https://api.cirrus-ci.com/v1/task/5558609250615296/logs/ci.log:
> ```
> Options used to compile and link:
>   external signer = yes
>   multiprocess    = no
>   with libs       = yes
>   with wallet     = no
>   with gui / qt   = no
> ```
> - this PR, https://api.cirrus-ci.com/v1/task/5502605561430016/logs/ci.log:
> ```
> Options used to compile and link:
>   external signer = yes
>   multiprocess    = no
>   with libs       = yes
>   with wallet     = no
>   with gui / qt   = yes
> ```

from https://github.com/bitcoin/bitcoin/pull/22814