### PR TITLE
[Upstream] build: patch qt to explicitly define previously implicit header include

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -14,6 +14,7 @@ $(package)_patches+= fix_android_qmake_conf.patch fix_android_jni_static.patch d
 $(package)_patches+= no_sdk_version_check.patch
 $(package)_patches+= fix_qpainter_non_determinism.patch fix_lib_paths.patch
 $(package)_patches+= fix_limits_header.patch
+$(package)_patches+= fix_montery_include.patch
 
 # Update OSX_QT_TRANSLATIONS when this is updated
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
@@ -224,6 +225,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/no_sdk_version_check.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_lib_paths.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_limits_header.patch && \
+  patch -p1 -i $($(package)_patch_dir)/fix_montery_include.patch && \
   mkdir -p qtbase/mkspecs/macx-clang-linux &&\
   cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\
   cp -f $($(package)_patch_dir)/mac-qmake.conf qtbase/mkspecs/macx-clang-linux/qmake.conf && \

--- a/depends/patches/qt/fix_montery_include.patch
+++ b/depends/patches/qt/fix_montery_include.patch
@@ -1,0 +1,21 @@
+From dece6f5840463ae2ddf927d65eb1b3680e34a547
+From: Øystein Heskestad <oystein.heskestad@qt.io>
+Date: Wed, 27 Oct 2021 13:07:46 +0200
+Subject: [PATCH] Add missing macOS header file that was indirectly included before
+
+See: https://bugreports.qt.io/browse/QTBUG-97855
+
+Upstream Commits:
+ - Qt 6.2: c884bf138a21dd7320e35cef34d24e22e74d7ce0
+
+diff --git a/qtbase/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h b/qtbase/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h
+index e070ba97..07c75b04 100644
+--- a/qtbase/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h
++++ b/qtbase/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h
+@@ -40,6 +40,7 @@
+ #ifndef QIOSURFACEGRAPHICSBUFFER_H
+ #define QIOSURFACEGRAPHICSBUFFER_H
+
++#include <CoreGraphics/CGColorSpace.h>
+ #include <qpa/qplatformgraphicsbuffer.h>
+ #include <private/qcore_mac_p.h>


### PR DESCRIPTION
> **Description**
> macOS Monterey has refactored some includes such that implicitly defined headers were no longer exposed and that in turns breaks building Qt on macOS 12. First observed when building on an M1 Pro. See "Additional Reading" for more information.
> 
> **Additional Reading**
> - https://github.com/microsoft/vcpkg/issues/21055 (resolved by https://github.com/microsoft/vcpkg/commit/c32ccbb34caacea28ba2d2b3df232ee36359c9f6)
> - ["Add missing macOS header file that was indirectly included before"](https://code.qt.io/cgit/qt/qtbase.git/commit/src/plugins/platforms/cocoa?id=dece6f5840463ae2ddf927d65eb1b3680e34a547) on https://code.qt.io/

from https://github.com/bitcoin/bitcoin/pull/23580