### PR TITLE
[Upstream] build, qt: Make QWindowsVistaStylePlugin available again (regression)

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -145,6 +145,7 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
       dnl https://bugreports.qt.io/browse/QTBUG-27097.
       AX_CHECK_LINK_FLAG([-lwtsapi32], [QT_LIBS="$QT_LIBS -lwtsapi32"], [AC_MSG_ERROR([could not link against -lwtsapi32])])
       _BITCOIN_QT_CHECK_STATIC_PLUGIN([QWindowsIntegrationPlugin], [-lqwindows])
+      _BITCOIN_QT_CHECK_STATIC_PLUGIN([QWindowsVistaStylePlugin], [-lqwindowsvistastyle])
       AC_DEFINE(QT_QPA_PLATFORM_WINDOWS, 1, [Define this symbol if the qt platform is windows])
     elif test "x$TARGET_OS" = xlinux; then
       dnl workaround for https://bugreports.qt.io/browse/QTBUG-74874

--- a/src/qt/prcycoin.cpp
+++ b/src/qt/prcycoin.cpp
@@ -71,6 +71,7 @@
 Q_IMPORT_PLUGIN(QXcbIntegrationPlugin);
 #elif defined(QT_QPA_PLATFORM_WINDOWS)
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
+Q_IMPORT_PLUGIN(QWindowsVistaStylePlugin);
 #elif defined(QT_QPA_PLATFORM_COCOA)
 Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin);
 Q_IMPORT_PLUGIN(QMacStylePlugin);


### PR DESCRIPTION
> This PR is similar to https://github.com/bitcoin/bitcoin/commit/1be8e0f2388e243d310fe7eeb46149a690de4ddf, and, actually, it is a https://github.com/bitcoin/bitcoin/pull/21376 follow up.
> 
> Required as in Qt 5.12.x style plugins are separated.
> 
> Fixes https://github.com/bitcoin/bitcoin/issues/22132.
> Fixes https://github.com/bitcoin-core/gui/issues/303.
> 
> Note for reviewers. Besides visual changes in the GUI, you could compare the first dozen of lines in the debug.log file.

from https://github.com/bitcoin/bitcoin/pull/22133