### PR TITLE
[Upstream] C++11: s/boost::scoped_ptr/std::unique_ptr/

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -6,8 +6,6 @@
 
 #include "util.h"
 
-#include <boost/scoped_ptr.hpp>
-
 #include <leveldb/cache.h>
 #include <leveldb/env.h>
 #include <leveldb/filter_policy.h>
@@ -102,7 +100,7 @@ bool CDBWrapper::WriteBatch(CDBBatch& batch, bool fSync)
 
 bool CDBWrapper::IsEmpty()
 {
-    boost::scoped_ptr<CDBIterator> it(NewIterator());
+    std::unique_ptr<CDBIterator> it(NewIterator());
     it->SeekToFirst();
     return !(it->Valid());
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -192,7 +192,7 @@ std::map<uint256, NodeId> mapBlockSource;
      *
      * Memory used: 1.7MB
      */
-boost::scoped_ptr<CRollingBloomFilter> recentRejects;
+std::unique_ptr<CRollingBloomFilter> recentRejects;
 uint256 hashRecentRejectsChainTip;
 
 /** Blocks that are in flight, and that are in the queue to be downloaded. Protected by cs_main. */

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
         uint256 in2 = GetRandHash();
         BOOST_CHECK(dbw.Write(key2, in2));
 
-        boost::scoped_ptr<CDBIterator> it(const_cast<CDBWrapper*>(&dbw)->NewIterator());
+        std::unique_ptr<CDBIterator> it(const_cast<CDBWrapper*>(&dbw)->NewIterator());
 
         // Be sure to seek past any earlier key (if it exists)
         it->Seek(key);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -113,7 +113,7 @@ bool CCoinsViewDB::GetStats(CCoinsStats& stats) const
     /* It seems that there are no "const iterators" for LevelDB.  Since we
        only need read operations on it, use a const-cast to get around
        that restriction.  */
-    boost::scoped_ptr<CDBIterator> pcursor(const_cast<CDBWrapper*>(&db)->NewIterator());
+    std::unique_ptr<CDBIterator> pcursor(const_cast<CDBWrapper*>(&db)->NewIterator());
     pcursor->Seek(DB_COINS);
 
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
@@ -237,7 +237,7 @@ bool CBlockTreeDB::ReadInt(const std::string& name, int& nValue)
 
 bool CBlockTreeDB::LoadBlockIndexGuts()
 {
-    boost::scoped_ptr<CDBIterator> pcursor(NewIterator());
+    std::unique_ptr<CDBIterator> pcursor(NewIterator());
 
     pcursor->Seek(std::make_pair(DB_BLOCK_INDEX, UINT256_ZERO));
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -17,7 +17,6 @@
 #include "wallet/wallet.h"
 
 #include <atomic>
-#include <boost/scoped_ptr.hpp>
 #include <boost/thread.hpp>
 #include <fstream>
 
@@ -1153,7 +1152,7 @@ bool CWalletDB::Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys)
     LogPrintf("Salvage(aggressive) found %u records\n", salvagedData.size());
 
     bool fSuccess = allOK;
-    boost::scoped_ptr<Db> pdbCopy(new Db(dbenv.dbenv, 0));
+    std::unique_ptr<Db> pdbCopy(new Db(dbenv.dbenv, 0));
     int ret = pdbCopy->open(NULL,               // Txn pointer
         filename.c_str(),   // Filename
         "main",             // Logical db name


### PR DESCRIPTION
>I asked sipa what to use in C++11 instead of introducing a new boost::scoped_ptr and he answered std::unique_ptr. Then I realized that completely replacing boost::scoped_ptr with std::unique_ptr is currently quite trivial, just a diff of +11 -11.

from https://github.com/bitcoin/bitcoin/pull/8629