### PR TITLE
[Upstream] depends: qrencode 4.1.1

### DIFF
--- a/depends/packages/qrencode.mk
+++ b/depends/packages/qrencode.mk
@@ -1,15 +1,16 @@
 package=qrencode
-$(package)_version=3.4.4
+$(package)_version=4.1.1
 $(package)_download_path=https://fukuchi.org/works/qrencode/
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=efe5188b1ddbcbf98763b819b146be6a90481aac30cfc8d858ab78a19cde1fa5
+$(package)_sha256_hash=e455d9732f8041cf5b9c388e345a641fd15707860f928e94507b1961256a6923
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-shared --without-tools --without-tests --disable-sdltest
+$(package)_config_opts=--disable-shared --without-tools --without-tests --without-png
 $(package)_config_opts += --disable-gprof --disable-gcov --disable-mudflap
 $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 $(package)_config_opts_linux=--with-pic
 $(package)_config_opts_android=--with-pic
+$(package)_cflags += -Wno-int-conversion -Wno-implicit-function-declaration
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
> Upgrade to the latest qrencode, and disable some warnings that cause compile failures with newer compilers (clang-15+).
> 
> I haven't tested this (from a GUI perspective) at all. This is just "good enough" to keep things compiling, and uses some similar work-arounds as we have with other older packages, i.e bdb.
> 
> Note that upstream, libqrencode is effectively unmaintained. No code changes for > 2 years. No responses to issues/PRs. Seems like the author has mostly dropped off of GitHub as well.
> 
> This fixes part of https://github.com/bitcoin/bitcoin/issues/27299.

from https://github.com/bitcoin/bitcoin/pull/27312