### PR TITLE
[Upstream] refactor: Move GetDifficulty out of rpc/server.h

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -162,6 +162,7 @@ BITCOIN_CORE_H = \
   random.h \
   reverselock.h \
   reverse_iterate.h \
+  rpc/blockchain.h \
   rpc/client.h \
   rpc/protocol.h \
   rpc/server.h \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -31,6 +31,7 @@
 #include "miner.h"
 #include "netbase.h"
 #include "net.h"
+#include "rpc/blockchain.h"
 #include "rpc/server.h"
 #include "script/standard.h"
 #include "script/sigcache.h"

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -8,6 +8,7 @@
 #include "primitives/transaction.h"
 #include "main.h"
 #include "httpserver.h"
+#include "rpc/blockchain.h"
 #include "rpc/server.h"
 #include "streams.h"
 #include "sync.h"
@@ -54,18 +55,9 @@ struct CCoin {
     }
 };
 
-
-extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry);
-
-extern UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails = false);
-
-extern UniValue mempoolInfoToJSON();
-
-extern UniValue mempoolToJSON(bool fVerbose = false);
-
-extern void ScriptPubKeyToJSON(const CScript &scriptPubKey, UniValue &out, bool fIncludeHex);
-
-extern UniValue blockheaderToJSON(const CBlockIndex *blockindex);
+/* Defined in rawtransaction.cpp */
+void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry);
+void ScriptPubKeyToJSON(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex);
 
 static bool RESTERR(HTTPRequest *req, enum HTTPStatusCode status, std::string message) {
     req->WriteHeader("Content-Type", "text/plain");

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -94,7 +94,7 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     return result;
 }
 
-UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails = false)
+UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails)
 {
     UniValue result(UniValue::VOBJ);
     result.pushKV("hash", block.GetHash().GetHex());
@@ -379,7 +379,7 @@ UniValue getdifficulty(const UniValue& params, bool fHelp)
 }
 
 
-UniValue mempoolToJSON(bool fVerbose = false)
+UniValue mempoolToJSON(bool fVerbose)
 {
     if (fVerbose) {
         LOCK(mempool.cs);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -6,6 +6,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "rpc/blockchain.h"
+
 #include "checkpoints.h"
 #include "main.h"
 #include "rpc/server.h"

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -5,7 +5,12 @@
 #ifndef BITCOIN_RPC_BLOCKCHAIN_H
 #define BITCOIN_RPC_BLOCKCHAIN_H
 
+class CBlock;
 class CBlockIndex;
+class CScript;
+class CTransaction;
+class uint256;
+class UniValue;
 
 /**
  * Get the difficulty of the net wrt to the given block index, or the chain tip if
@@ -18,6 +23,18 @@ double GetDifficulty(const CBlockIndex* blockindex = nullptr);
 
 /** Callback for when block tip changed. */
 void RPCNotifyBlockChange(bool ibd, const CBlockIndex *);
+
+/** Block description to JSON */
+UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails = false);
+
+/** Mempool information to JSON */
+UniValue mempoolInfoToJSON();
+
+/** Mempool to JSON */
+UniValue mempoolToJSON(bool fVerbose = false);
+
+/** Block header to JSON */
+UniValue blockheaderToJSON(const CBlockIndex* blockindex);
 
 #endif
 

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -16,5 +16,8 @@ class CBlockIndex;
  */
 double GetDifficulty(const CBlockIndex* blockindex = nullptr);
 
+/** Callback for when block tip changed. */
+void RPCNotifyBlockChange(bool ibd, const CBlockIndex *);
+
 #endif
 

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_RPC_BLOCKCHAIN_H
+#define BITCOIN_RPC_BLOCKCHAIN_H
+
+class CBlockIndex;
+
+/**
+ * Get the difficulty of the net wrt to the given block index, or the chain tip if
+ * not provided.
+ *
+ * @return A floating point number that is a multiple of the main net minimum
+ * difficulty (4295032833 hashes).
+ */
+double GetDifficulty(const CBlockIndex* blockindex = nullptr);
+
+#endif
+

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -15,6 +15,7 @@
 #include "miner.h"
 #include "net.h"
 #include "poa.h"
+#include "rpc/blockchain.h"
 #include "rpc/server.h"
 #include "util.h"
 #ifdef ENABLE_WALLET

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -14,6 +14,7 @@
 #include "masternode-sync.h"
 #include "net.h"
 #include "netbase.h"
+#include "rpc/blockchain.h"
 #include "rpc/server.h"
 #include "timedata.h"
 #include "util.h"

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -361,6 +361,5 @@ bool StartRPC();
 void InterruptRPC();
 void StopRPC();
 std::string JSONRPCExecBatch(const UniValue& vReq);
-void RPCNotifyBlockChange(bool fInitialDownload, const CBlockIndex* pindex);
 
 #endif // BITCOIN_RPCSERVER_H

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -171,7 +171,6 @@ extern bool ParseBool(const UniValue& o, std::string strKey);
 extern int64_t nWalletUnlockTime;
 extern CAmount AmountFromValue(const UniValue& value);
 extern UniValue ValueFromAmount(const CAmount& amount);
-extern double GetDifficulty(const CBlockIndex* blockindex = NULL);
 extern std::string HelpRequiringPassphrase();
 extern std::string HelpExampleCli(std::string methodname, std::string args);
 extern std::string HelpExampleRpc(std::string methodname, std::string args);


### PR DESCRIPTION
> `GetDifficulty` has no business in `rpcserver.h`. Define it in the interface header of the implementation unit `rpcblockchain` where it is defined.
> 
> Also modernize the signature to:
> 
> `double GetDifficulty(const CBlockIndex* blockindex = nullptr);`
> (remove `extern`, replace `NULL` with `nullptr`)

from https://github.com/bitcoin/bitcoin/pull/10095