### PR TITLE
[Upstream] Fix various things -fsanitize complains about

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -113,7 +113,7 @@ static bool multiUserAuthorized(std::string strUserPass)
             std::string strHash = vFields[2];
 
             unsigned int KEY_SIZE = 32;
-            unsigned char *out = new unsigned char[KEY_SIZE]; 
+            unsigned char out[KEY_SIZE];
 
             CHMAC_SHA256(reinterpret_cast<const unsigned char*>(strSalt.c_str()), strSalt.size()).Write(reinterpret_cast<const unsigned char*>(strPass.c_str()), strPass.size()).Finalize(out);
             std::vector<unsigned char> hexvec(out, out+KEY_SIZE);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -18,10 +18,8 @@
 #include <univalue.h>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/dynamic_bitset.hpp>
 
 static const size_t MAX_GETUTXOS_OUTPOINTS = 15; //allow a max of 15 outpoints to be queried at once
-
 
 enum RetFormat {
     RF_UNDEF,
@@ -477,7 +475,8 @@ static bool rest_getutxos(HTTPRequest *req, const std::string &strURIPart) {
     std::vector<unsigned char> bitmap;
     std::vector<CCoin> outs;
     std::string bitmapStringRepresentation;
-    boost::dynamic_bitset<unsigned char> hits(vOutPoints.size());
+    std::vector<bool> hits;
+    bitmap.resize((vOutPoints.size() + 7) / 8);
     {
         LOCK2(cs_main, mempool.cs);
 
@@ -493,12 +492,12 @@ static bool rest_getutxos(HTTPRequest *req, const std::string &strURIPart) {
         for (size_t i = 0; i < vOutPoints.size(); i++) {
             CCoins coins;
             uint256 hash = vOutPoints[i].hash;
+            bool hit = false;
             if (view.GetCoins(hash, coins)) {
                 mempool.pruneSpent(hash, coins);
                 if (coins.IsAvailable(vOutPoints[i].n)) {
-                    hits[i] = true;
+                    hit = true;
                     // Safe to index into vout here because IsAvailable checked if it's off the end of the array, or if
-
                     // n is valid but points to an already spent output (IsNull).
                     CCoin coin;
                     coin.nTxVer = coins.nVersion;
@@ -509,11 +508,12 @@ static bool rest_getutxos(HTTPRequest *req, const std::string &strURIPart) {
                 }
             }
 
-            bitmapStringRepresentation.append(
-                    hits[i] ? "1" : "0"); // form a binary string representation (human-readable for json output)
+            hits.push_back(hit);
+            bitmapStringRepresentation.append(hit ? "1" : "0"); // form a binary string representation (human-readable for json output)
+            bitmap[i / 8] |= ((uint8_t)hit) << (i % 8);
         }
     }
-    boost::to_block_range(hits, std::back_inserter(bitmap));
+
     switch (rf) {
         case RF_BINARY: {
             // serialize data

--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -9,7 +9,7 @@
 #include "chainparams.h"
 #include "util.h"
 
-#include "test/test_bitcoin.h"
+#include "test/test_prcycoin.h"
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -8,7 +8,7 @@
 #include "key.h"
 #include "uint256.h"
 #include "util.h"
-#include "test/test_bitcoin.h"
+#include "test/test_prcycoin.h"
 
 #include <string>
 #include <vector>

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -10,7 +10,7 @@
 #include "uint256.h"
 #include "util.h"
 
-#include "test/test_bitcoin.h"
+#include "test/test_prcycoin.h"
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -162,12 +162,12 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
     bool fInboundIn = false;
 
     // Test that fFeeler is false by default.
-    CNode* pnode1 = new CNode(hSocket, addr, pszDest, fInboundIn);
+    std::unique_ptr<CNode> pnode1(new CNode(hSocket, addr, pszDest, fInboundIn));
     BOOST_CHECK(pnode1->fInbound == false);
     BOOST_CHECK(pnode1->fFeeler == false);
 
     fInboundIn = true;
-    CNode* pnode2 = new CNode(hSocket, addr, pszDest, fInboundIn);
+    std::unique_ptr<CNode> pnode2(new CNode(hSocket, addr, pszDest, fInboundIn));
     BOOST_CHECK(pnode2->fInbound == true);
     BOOST_CHECK(pnode2->fFeeler == false);
 }

--- a/src/test/raii_event_tests.cpp
+++ b/src/test/raii_event_tests.cpp
@@ -8,7 +8,7 @@
 
 #include "support/events.h"
 
-#include "test/test_bitcoin.h"
+#include "test/test_prcycoin.h"
 
 #include <vector>
 

--- a/src/test/scriptnum_tests.cpp
+++ b/src/test/scriptnum_tests.cpp
@@ -12,8 +12,10 @@
 
 BOOST_FIXTURE_TEST_SUITE(scriptnum_tests, BasicTestingSetup)
 
-static const long values[] = \
-{ 0, 1, CHAR_MIN, CHAR_MAX, UCHAR_MAX, SHRT_MIN, USHRT_MAX, INT_MIN, INT_MAX, static_cast<long>UINT_MAX, LONG_MIN, LONG_MAX };
+/** A selection of numbers that do not trigger int64_t overflow
+ *  when added/subtracted. */
+static const int64_t values[] = { 0, 1, -2, 127, 128, -255, 256, (1LL << 15) - 1, -(1LL << 16), (1LL << 24) - 1, (1LL << 31), 1 - (1LL << 32), 1LL << 40 };
+
 static const long offsets[] = { 1, 0x79, 0x80, 0x81, 0xFF, 0x7FFF, 0x8000, 0xFFFF, 0x10000};
 
 static bool verify(const CBigNum& bignum, const CScriptNum& scriptnum)

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -20,6 +20,7 @@
 // we repeat those tests this many times and only complain if all iterations of the test fail
 #define RANDOM_REPEATS 5
 
+std::vector<std::unique_ptr<CWalletTx>> wtxn;
 
 typedef std::set<std::pair<const CWalletTx*,unsigned int> > CoinSet;
 extern CWallet* pwalletMain;
@@ -81,21 +82,21 @@ static void add_coin(const CAmount& nValue, int nAge = 6*24, bool fIsFromMe = fa
         // so stop vin being empty, and cache a non-zero Debit to fake out IsFromMe()
         tx.vin.resize(1);
     }
-    CWalletTx* wtx = new CWalletTx(&wallet, tx);
+    std::unique_ptr<CWalletTx> wtx(new CWalletTx(&wallet, MakeTransactionRef(std::move(tx))));
     if (fIsFromMe)
     {
         wtx->fDebitCached = true;
         wtx->nDebitCached = 1;
     }
-    COutput output(wtx, nInput, nAge, true);
+    COutput output(wtx.get(), nInput, nAge, true);
     vCoins.push_back(output);
+    wtxn.emplace_back(std::move(wtx));
 }
 
 static void empty_wallet(void)
 {
-    for (COutput output : vCoins)
-        delete output.tx;
     vCoins.clear();
+    wtxn.clear();
 }
 
 static bool equal_sets(CoinSet a, CoinSet b)


### PR DESCRIPTION
> - The ReadLE32 etc functions in crypto/common.h where dereferencing type-punned pointers, which is undefined behaviour (and can cause consistent failure on some platforms due to misaligned reads). Fix this by memcpy()ing into a local variable first (as accessing a type's representation through a char* is always allowed).
> - The scriptnum tests were testing running several arithmetic operations on large integers, triggering signed integer overflow, which is undefined. Fix the tests by using integers limited to +/- 2^40 (larger than anything actually supported in script).
> - Fix a memory leak in the wallet tests: CWalletTx objects that weren't freed - wrap them in a unique_ptr.
> - Fix a memory leak in the net tests: a CNode object wasn't being freed - wrap them in a unique_ptr.
> - Fix a memory leak in the rpc auth: a buffer that wasn't being freed - switch it to a stack-allocated array.
> - The REST code for getutxos was using boost::dynamic_bitset, which apparently issues a rightshift by a negative amount. Fix this by replacing it with normal bit/byte vectors.
> 
> Now all unit tests and rpc tests run succesfully with -fsanitize=address -fsanitize=undefined -fsanitize=leak in GCC 6.2.0.
> 
> Thanks to @kcc for pointing me to these tools.

from https://github.com/bitcoin/bitcoin/pull/9512