### PR TITLE
[Upstream] Access WorkQueue::running only within the cs lock

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -122,7 +122,7 @@ public:
     void Run()
     {
         ThreadCounter count(*this);
-        while (running) {
+        while (true) {
             std::unique_ptr<WorkItem> i;
             {
                 std::unique_lock<std::mutex> lock(cs);


### PR DESCRIPTION
> This removes a "race" between Interrupt() and Run(), though it
> should not effect any of our supported platforms.

from https://github.com/bitcoin/bitcoin/pull/9679