### PR TITLE
depends: expat 2.5.0

### DIFF
--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -1,8 +1,8 @@
 package=expat
-$(package)_version=2.4.8
+$(package)_version=2.5.0
 $(package)_download_path=https://github.com/libexpat/libexpat/releases/download/R_$(subst .,_,$($(package)_version))/
 $(package)_file_name=$(package)-$($(package)_version).tar.xz
-$(package)_sha256_hash=f79b8f904b749e3e0d20afeadecf8249c55b2e32d4ebb089ae378df479dcaf25
+$(package)_sha256_hash=ef2420f0232c087801abf705e89ae65f6257df6b7931d37846a193ef2e8cdcbe
 
 # -D_DEFAULT_SOURCE defines __USE_MISC, which exposes additional
 # definitions in endian.h, which are required for a working


### PR DESCRIPTION
Major changes in last two updates:
```
Release 2.5.0 Tue October 25 2022
        Security fixes:
  #616 #649 #650  CVE-2022-43680 -- Fix heap use-after-free after overeager
                    destruction of a shared DTD in function
                    XML_ExternalEntityParserCreate in out-of-memory situations.
                    Expected impact is denial of service or potentially
                    arbitrary code execution.
```

```
Release 2.4.9 Tue September 20 2022
        Security fixes:
       #629 #640  CVE-2022-40674 -- Heap use-after-free vulnerability in
                    function doContent. Expected impact is denial of service
                    or potentially arbitrary code execution.
```

Full changelog is available [here](https://github.com/libexpat/libexpat/blob/R_2_5_0/expat/Changes).