### PR TITLE
depends: libcurl 8.2.1

### DIFF
--- a/depends/packages/libcurl.mk
+++ b/depends/packages/libcurl.mk
@@ -1,9 +1,9 @@
 package=libcurl
-$(package)_version=8.2.0
+$(package)_version=8.2.1
 $(package)_dependencies=openssl
 $(package)_download_path=https://curl.haxx.se/download
 $(package)_file_name=curl-$($(package)_version).tar.xz
-$(package)_sha256_hash=2859ec79e2cd96e976a99493547359b8001af1d1e21f3a3a3b846544ef54500f
+$(package)_sha256_hash=dd322f6bd0a20e6cebdfd388f69e98c3d183bed792cf4713c8a7ef498cba4894
 $(package)_config_opts=--disable-shared --enable-static --prefix=$(host_prefix) --host=$(HOST) --with-openssl
 $(package)_config_opts+=--disable-manual --disable-ntlm-wb --with-random=/dev/urandom
 $(package)_config_opts+=--disable-curldebug --disable-libcurl-option --disable-ldap --disable-ldaps


### PR DESCRIPTION
Updating `libcurl` to the latest version. 
Changelog: https://curl.se/changes.html

Also, a useful table for number of Bugfixes, Changes, and Days since last release: https://curl.se/docs/releases.html