### PR TITLE
init: add option to manually set rescan height on startup

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -443,6 +443,7 @@ std::string HelpMessage(HelpMessageMode mode)
                 CURRENCY_UNIT, FormatMoney(CWallet::minTxFee.GetFeePerK())));
     strUsage += HelpMessageOpt("-paytxfee=<amt>", strprintf(_("Fee (in %s/kB) to add to transactions you send (default: %s)"), CURRENCY_UNIT, FormatMoney(payTxFee.GetFeePerK())));
     strUsage += HelpMessageOpt("-rescan", _("Rescan the block chain for missing wallet transactions") + " " + _("on startup"));
+    strUsage += HelpMessageOpt("-rescanheight", _("Rescan the block chain from the specified height when rescan=1 on startup"));
     strUsage += HelpMessageOpt("-salvagewallet", _("Attempt to recover private keys from a corrupt wallet.dat") + " " + _("on startup"));
     strUsage += HelpMessageOpt("-sendfreetransactions", strprintf(_("Send transactions as zero-fee transactions if possible (default: %u)"), 0));
     strUsage += HelpMessageOpt("-spendzeroconfchange", strprintf(_("Spend unconfirmed change when sending transactions (default: %u)"), 1));
@@ -1685,6 +1686,15 @@ bool AppInit2(bool isDaemon)
 
         if (GetBoolArg("-rescan", false)) {
             pindexRescan = chainActive.Genesis();
+
+            int rescanHeight = GetArg("-rescanheight", 0);
+            if (rescanHeight > 0) {
+                if (rescanHeight > chainActive.Tip()->nHeight) {
+                    pindexRescan = chainActive.Tip();
+                } else {
+                    pindexRescan = chainActive[rescanHeight];
+                }
+            }
         } else {
             CWalletDB walletdb(strWalletFile);
             CBlockLocator locator;


### PR DESCRIPTION
Simple cherry-pick from https://github.com/PirateNetwork/pirate/commit/b407f6feee40e41f2e46de62355b7512feee526f
adding `-rescanheight`, which will "Rescan the block chain from the specified height when rescan=1 on startup"