### PR TITLE
depends: zlib 1.3

### DIFF
--- a/depends/packages/zlib.mk
+++ b/depends/packages/zlib.mk
@@ -1,8 +1,8 @@
 package=zlib
-$(package)_version=1.2.13
+$(package)_version=1.3
 $(package)_download_path=https://www.zlib.net
 $(package)_file_name=$(package)-$($(package)_version).tar.xz
-$(package)_sha256_hash=d14c38e313afc35a9a8760dadf26042f51ea0f5d154b0630a31da0540107fb98
+$(package)_sha256_hash=8a9ba2898e1d0d774eca6ba5b4627a11e5588ba85c8851336eb38de4683050a7
 
 define $(package)_set_vars
 $(package)_config_opts= CC="$($(package)_cc)"


### PR DESCRIPTION
Updating zlib to the latest.

Changelog from zlib.net:
> Version 1.3 has these key updates from 1.2.13:
> 
> Building using K&R (pre-ANSI) function definitions is no longer supported.
> Fixed a bug in deflateBound() for level 0 and memLevel 9.
> Fixed a bug when gzungetc() is used immediately after gzopen().
> Fixed a bug when using gzflush() with a very small buffer.
> Fixed a crash when gzsetparams() is attempted for a transparent write.
> Fixed test/example.c to work with FORCE_STORED.
> Fixed minizip to allow it to open an empty zip file.
> Fixed reading disk number start on zip64 files in minizip.
> Fixed a logic error in minizip argument processing.