### PR TITLE
depends: libcurl 8.4.0

### DIFF
--- a/depends/packages/libcurl.mk
+++ b/depends/packages/libcurl.mk
@@ -1,9 +1,9 @@
 package=libcurl
-$(package)_version=8.3.0
+$(package)_version=8.4.0
 $(package)_dependencies=openssl
 $(package)_download_path=https://curl.haxx.se/download
 $(package)_file_name=curl-$($(package)_version).tar.xz
-$(package)_sha256_hash=376d627767d6c4f05105ab6d497b0d9aba7111770dd9d995225478209c37ea63
+$(package)_sha256_hash=16c62a9c4af0f703d28bda6d7bbf37ba47055ad3414d70dec63e2e6336f2a82d
 $(package)_config_opts=--disable-shared --enable-static --prefix=$(host_prefix) --host=$(HOST) --with-openssl
 $(package)_config_opts+=--disable-manual --disable-ntlm-wb --with-random=/dev/urandom
 $(package)_config_opts+=--disable-curldebug --disable-libcurl-option --disable-ldap --disable-ldaps


### PR DESCRIPTION
As we get closer to our next release, update `libcurl` as they just released today to fix a HIGH and LOW CVE.
Changes here: https://curl.se/changes.html#8_4_0