### PR TITLE
ci: fix build factory workflows

### DIFF
--- a/.github/workflows/prcy-build-factory-debug.yml
+++ b/.github/workflows/prcy-build-factory-debug.yml
@@ -4,19 +4,44 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 name: Github Actions CI for PRCY (Ubuntu 20 --enable-debug)
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:   # adds a manual "Run workflow" button (no [debug] needed)
 env:
   SOURCE_ARTIFACT: source
+# Container jobs default run: steps to plain sh, which has no brace expansion
+# (hosted runners defaulted to bash). Several packaging steps rely on braces.
+defaults:
+  run:
+    shell: bash
 jobs:
   create-source-distribution:
     name: Create Source Distribution
-    runs-on: ubuntu-20.04
-    if: "contains(github.event.head_commit.message, '[debug]')"
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
+    if: "github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, '[debug]')"
     env:
       ARTIFACT_DIR: source
     steps:
+    - name: Prepare container (ubuntu:20.04 base image)
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y \
+          sudo ca-certificates curl wget git \
+          build-essential g++ make autoconf automake libtool pkg-config cmake bison \
+          python3 python3-setuptools patch xz-utils bzip2 unzip zip bsdmainutils file \
+          clang llvm imagemagick gettext \
+          libtinfo5 zlib1g-dev libbz2-dev xorriso
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
+    - name: Ensure version.txt Exists
+      run: |
+        if [ ! -f version.txt ]; then
+          awk -F'[(,) ]+' '/^define\(_CLIENT_VERSION_(MAJOR|MINOR|REVISION|BUILD),/ {v[++i]=$3} END {print v[1]"."v[2]"."v[3]"."v[4]}' configure.ac > version.txt
+          echo "version.txt missing from repo; generated $(cat version.txt) from configure.ac"
+        fi
     - name: Create Version Variable
       run: |
         export VERSION=$(cat version.txt | sed 's/[^0-9,.]//g')
@@ -47,22 +72,34 @@ jobs:
       run: |
         mv depends.tar.gz prcycoin.tar.gz $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
         path: ${{ env.ARTIFACT_DIR }}
   build-x86_64-linux:
     name: Build for x86 Linux 64bit
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
     env:
       ARTIFACT_DIR: prcycoin-x86_64-linux-debug
       TEST_LOG_ARTIFACT_DIR: test-logs
     steps:
+    - name: Prepare container (ubuntu:20.04 base image)
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y \
+          sudo ca-certificates curl wget git \
+          build-essential g++ make autoconf automake libtool pkg-config cmake bison \
+          python3 python3-setuptools patch xz-utils bzip2 unzip zip bsdmainutils file \
+          clang llvm imagemagick gettext \
+          libtinfo5 zlib1g-dev libbz2-dev xorriso
     - name: Getting Source
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
+        path: ${{ env.SOURCE_ARTIFACT }}
     - name: Extract Archives
       run: |
         tar -xzf depends.tar.gz
@@ -99,21 +136,33 @@ jobs:
         chmod +x $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt}
         mv $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v6
       with:
         name: prcycoin-v${{ env.VERSION }}-x86_64-linux-debug
         path: ${{ env.ARTIFACT_DIR }}
   build-win64:
     name: Build for Win64
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
     env:
       ARTIFACT_DIR: prcycoin-win64-debug
     steps:
+    - name: Prepare container (ubuntu:20.04 base image)
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y \
+          sudo ca-certificates curl wget git \
+          build-essential g++ make autoconf automake libtool pkg-config cmake bison \
+          python3 python3-setuptools patch xz-utils bzip2 unzip zip bsdmainutils file \
+          clang llvm imagemagick gettext \
+          libtinfo5 zlib1g-dev libbz2-dev xorriso
     - name: Getting Source
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
+        path: ${{ env.SOURCE_ARTIFACT }}
     - name: Extract Archives
       run: |
         tar -xzf depends.tar.gz
@@ -154,22 +203,34 @@ jobs:
         strip $SOURCE_ARTIFACT/src/{prcycoin-cli.exe,prcycoin-tx.exe,prcycoind.exe,qt/prcycoin-qt.exe}
         mv $SOURCE_ARTIFACT/{prcycoin-*.exe,src/prcycoin-cli.exe,src/prcycoin-tx.exe,src/prcycoind.exe,src/qt/prcycoin-qt.exe} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v6
       with:
         name: prcycoin-v${{ env.VERSION }}-win64-debug
         path: ${{ env.ARTIFACT_DIR }}
   build-osx64:
     name: Build for MacOSX
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
     env:
       ARTIFACT_DIR: prcycoin-macosx-debug
       SDK_URL: https://bitcoincore.org/depends-sources/sdks
     steps:
+    - name: Prepare container (ubuntu:20.04 base image)
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y \
+          sudo ca-certificates curl wget git \
+          build-essential g++ make autoconf automake libtool pkg-config cmake bison \
+          python3 python3-setuptools patch xz-utils bzip2 unzip zip bsdmainutils file \
+          clang llvm imagemagick gettext \
+          libtinfo5 zlib1g-dev libbz2-dev xorriso
     - name: Getting Source
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
+        path: ${{ env.SOURCE_ARTIFACT }}
     - name: Extract Archives
       run: |
         tar -xzf depends.tar.gz
@@ -223,21 +284,33 @@ jobs:
         mkdir -p $ARTIFACT_DIR
         mv $SOURCE_ARTIFACT/{*.dmg,src/prcycoin-cli,src/prcycoin-tx,src/prcycoind,src/qt/prcycoin-qt} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v6
       with:
         name: prcycoin-v${{ env.VERSION }}-macosx-debug
         path: ${{ env.ARTIFACT_DIR }}
   build-aarch64-linux:
     name: Build for ARM Linux 64bit
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
     env:
       ARTIFACT_DIR: prcycoin-aarch64-linux-debug
     steps:
+    - name: Prepare container (ubuntu:20.04 base image)
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y \
+          sudo ca-certificates curl wget git \
+          build-essential g++ make autoconf automake libtool pkg-config cmake bison \
+          python3 python3-setuptools patch xz-utils bzip2 unzip zip bsdmainutils file \
+          clang llvm imagemagick gettext \
+          libtinfo5 zlib1g-dev libbz2-dev xorriso
     - name: Getting Source
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
+        path: ${{ env.SOURCE_ARTIFACT }}
     - name: Extract Archives
       run: |
         tar -xzf depends.tar.gz
@@ -273,21 +346,33 @@ jobs:
         chmod +x $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt}
         mv $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v6
       with:
         name: prcycoin-v${{ env.VERSION }}-aarch64-linux-debug
         path: ${{ env.ARTIFACT_DIR }}
   build-arm-linux-gnueabihf:
     name: Build for ARM Linux 32bit
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
     env:
       ARTIFACT_DIR: prcycoin-arm32-debug
     steps:
+    - name: Prepare container (ubuntu:20.04 base image)
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y \
+          sudo ca-certificates curl wget git \
+          build-essential g++ make autoconf automake libtool pkg-config cmake bison \
+          python3 python3-setuptools patch xz-utils bzip2 unzip zip bsdmainutils file \
+          clang llvm imagemagick gettext \
+          libtinfo5 zlib1g-dev libbz2-dev xorriso
     - name: Getting Source
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
+        path: ${{ env.SOURCE_ARTIFACT }}
     - name: Extract Archives
       run: |
         tar -xzf depends.tar.gz
@@ -323,21 +408,33 @@ jobs:
         chmod +x $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt}
         mv $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v6
       with:
         name: prcycoin-v${{ env.VERSION }}-arm32-debug
         path: ${{ env.ARTIFACT_DIR }}
   build-riscv64-linux-gnu:
     name: Build for RISC-V 64-bit
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
     env:
       ARTIFACT_DIR: prcycoin-riscv64-debug
     steps:
+    - name: Prepare container (ubuntu:20.04 base image)
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y \
+          sudo ca-certificates curl wget git \
+          build-essential g++ make autoconf automake libtool pkg-config cmake bison \
+          python3 python3-setuptools patch xz-utils bzip2 unzip zip bsdmainutils file \
+          clang llvm imagemagick gettext \
+          libtinfo5 zlib1g-dev libbz2-dev xorriso
     - name: Getting Source
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
+        path: ${{ env.SOURCE_ARTIFACT }}
     - name: Extract Archives
       run: |
         tar -xzf depends.tar.gz
@@ -373,7 +470,7 @@ jobs:
         chmod +x $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt}
         mv $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v6
       with:
         name: prcycoin-v${{ env.VERSION }}-riscv64-debug
         path: ${{ env.ARTIFACT_DIR }}

--- a/.github/workflows/prcy-build-factory.yml
+++ b/.github/workflows/prcy-build-factory.yml
@@ -4,19 +4,44 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 name: Github Actions CI for PRCY (Ubuntu 20)
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:   # adds a manual "Run workflow" button (no [focal] needed)
 env:
   SOURCE_ARTIFACT: source
+# Container jobs default run: steps to plain sh, which has no brace expansion
+# (hosted runners defaulted to bash). Several packaging steps rely on braces.
+defaults:
+  run:
+    shell: bash
 jobs:
   create-source-distribution:
     name: Create Source Distribution
-    runs-on: ubuntu-20.04
-    if: "contains(github.event.head_commit.message, '[focal]')"
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
+    if: "github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, '[focal]')"
     env:
       ARTIFACT_DIR: source
     steps:
+    - name: Prepare container (ubuntu:20.04 base image)
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y \
+          sudo ca-certificates curl wget git \
+          build-essential g++ make autoconf automake libtool pkg-config cmake bison \
+          python3 python3-setuptools patch xz-utils bzip2 unzip zip bsdmainutils file \
+          clang llvm imagemagick gettext \
+          libtinfo5 zlib1g-dev libbz2-dev xorriso
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
+    - name: Ensure version.txt Exists
+      run: |
+        if [ ! -f version.txt ]; then
+          awk -F'[(,) ]+' '/^define\(_CLIENT_VERSION_(MAJOR|MINOR|REVISION|BUILD),/ {v[++i]=$3} END {print v[1]"."v[2]"."v[3]"."v[4]}' configure.ac > version.txt
+          echo "version.txt missing from repo; generated $(cat version.txt) from configure.ac"
+        fi
     - name: Create Version Variable
       run: |
         export VERSION=$(cat version.txt | sed 's/[^0-9,.]//g')
@@ -47,75 +72,34 @@ jobs:
       run: |
         mv depends.tar.gz prcycoin.tar.gz $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
-        path: ${{ env.ARTIFACT_DIR }}
-  build-linux:
-    name: Build for Linux
-    needs: create-source-distribution
-    runs-on: ubuntu-18.04
-    env:
-      ARTIFACT_DIR: prcycoin-linux
-      TEST_LOG_ARTIFACT_DIR: test-logs
-    steps:
-    - name: Getting Source
-      uses: actions/download-artifact@v4.1.7
-      with:
-        name: ${{ env.SOURCE_ARTIFACT }}
-    - name: Extract Archives
-      run: |
-        tar -xzf prcycoin.tar.gz --strip-components=1
-      working-directory: ${{ env.SOURCE_ARTIFACT }}
-    - name: Set Env
-      shell: bash
-      run: |
-        export VERSION=$(cat $SOURCE_ARTIFACT/version.txt | sed 's/[^0-9,.]//g')
-        echo "VERSION=${VERSION}" >> $GITHUB_ENV
-    - name: Append Commit Hash to Development Builds
-      if: "!contains(github.ref, 'master')"
-      shell: bash
-      run: |
-        export VERSION=${{ env.VERSION }}-${GITHUB_SHA::7}
-        echo "VERSION=${VERSION}" >> $GITHUB_ENV
-    # May need qt and protobuf to configure qt and include prcycoin-qt.1 in distribution
-    - name: Install Required Packages
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libssl1.0-dev libevent-dev libboost-all-dev
-        sudo apt-get install -y libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler libqrencode-dev
-        sudo add-apt-repository ppa:pivx/pivx
-        sudo apt-get update
-        sudo apt-get install -y libdb4.8-dev libdb4.8++-dev
-    - name: Build PRCY
-      run: |
-        ./autogen.sh
-        ./configure --disable-jni --disable-tests --disable-gui-tests --disable-bench --enable-upnp-default
-        make -j$(nproc)
-      working-directory: ${{ env.SOURCE_ARTIFACT }}
-    - name: Prepare Files for Artifact
-      run: |
-        mkdir -p $ARTIFACT_DIR
-        strip $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt}
-        chmod +x $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt}
-        mv $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt} $ARTIFACT_DIR
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v1
-      with:
-        name: prcycoin-v${{ env.VERSION }}-linux
         path: ${{ env.ARTIFACT_DIR }}
   build-x86_64-linux:
     name: Build for x86 Linux 64bit
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
     env:
       ARTIFACT_DIR: prcycoin-x86_64-linux
       TEST_LOG_ARTIFACT_DIR: test-logs
     steps:
+    - name: Prepare container (ubuntu:20.04 base image)
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y \
+          sudo ca-certificates curl wget git \
+          build-essential g++ make autoconf automake libtool pkg-config cmake bison \
+          python3 python3-setuptools patch xz-utils bzip2 unzip zip bsdmainutils file \
+          clang llvm imagemagick gettext \
+          libtinfo5 zlib1g-dev libbz2-dev xorriso
     - name: Getting Source
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
+        path: ${{ env.SOURCE_ARTIFACT }}
     - name: Extract Archives
       run: |
         tar -xzf depends.tar.gz
@@ -152,21 +136,33 @@ jobs:
         chmod +x $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt}
         mv $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v6
       with:
         name: prcycoin-v${{ env.VERSION }}-x86_64-linux
         path: ${{ env.ARTIFACT_DIR }}
   build-win64:
     name: Build for Win64
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
     env:
       ARTIFACT_DIR: prcycoin-win64
     steps:
+    - name: Prepare container (ubuntu:20.04 base image)
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y \
+          sudo ca-certificates curl wget git \
+          build-essential g++ make autoconf automake libtool pkg-config cmake bison \
+          python3 python3-setuptools patch xz-utils bzip2 unzip zip bsdmainutils file \
+          clang llvm imagemagick gettext \
+          libtinfo5 zlib1g-dev libbz2-dev xorriso
     - name: Getting Source
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
+        path: ${{ env.SOURCE_ARTIFACT }}
     - name: Extract Archives
       run: |
         tar -xzf depends.tar.gz
@@ -207,22 +203,34 @@ jobs:
         strip $SOURCE_ARTIFACT/src/{prcycoin-cli.exe,prcycoin-tx.exe,prcycoind.exe,qt/prcycoin-qt.exe}
         mv $SOURCE_ARTIFACT/{prcycoin-*.exe,src/prcycoin-cli.exe,src/prcycoin-tx.exe,src/prcycoind.exe,src/qt/prcycoin-qt.exe} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v6
       with:
         name: prcycoin-v${{ env.VERSION }}-win64
         path: ${{ env.ARTIFACT_DIR }}
   build-osx64:
     name: Build for MacOSX
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
     env:
       ARTIFACT_DIR: prcycoin-macosx
       SDK_URL: https://bitcoincore.org/depends-sources/sdks
     steps:
+    - name: Prepare container (ubuntu:20.04 base image)
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y \
+          sudo ca-certificates curl wget git \
+          build-essential g++ make autoconf automake libtool pkg-config cmake bison \
+          python3 python3-setuptools patch xz-utils bzip2 unzip zip bsdmainutils file \
+          clang llvm imagemagick gettext \
+          libtinfo5 zlib1g-dev libbz2-dev xorriso
     - name: Getting Source
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
+        path: ${{ env.SOURCE_ARTIFACT }}
     - name: Extract Archives
       run: |
         tar -xzf depends.tar.gz
@@ -232,8 +240,8 @@ jobs:
       shell: bash
       run: |
         export VERSION=$(cat $SOURCE_ARTIFACT/version.txt | sed 's/[^0-9,.]//g')
-        export XCODE_VERSION=11.3.1
-        export XCODE_BUILD_ID=11C505
+        export XCODE_VERSION=12.1
+        export XCODE_BUILD_ID=12A7403
         echo "VERSION=${VERSION}" >> $GITHUB_ENV
         echo "XCODE_VERSION=${XCODE_VERSION}" >> $GITHUB_ENV
         echo "XCODE_BUILD_ID=${XCODE_BUILD_ID}" >> $GITHUB_ENV
@@ -276,21 +284,33 @@ jobs:
         mkdir -p $ARTIFACT_DIR
         mv $SOURCE_ARTIFACT/{*.dmg,src/prcycoin-cli,src/prcycoin-tx,src/prcycoind,src/qt/prcycoin-qt} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v6
       with:
         name: prcycoin-v${{ env.VERSION }}-macosx
         path: ${{ env.ARTIFACT_DIR }}
   build-aarch64-linux:
     name: Build for ARM Linux 64bit
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
     env:
       ARTIFACT_DIR: prcycoin-aarch64-linux
     steps:
+    - name: Prepare container (ubuntu:20.04 base image)
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y \
+          sudo ca-certificates curl wget git \
+          build-essential g++ make autoconf automake libtool pkg-config cmake bison \
+          python3 python3-setuptools patch xz-utils bzip2 unzip zip bsdmainutils file \
+          clang llvm imagemagick gettext \
+          libtinfo5 zlib1g-dev libbz2-dev xorriso
     - name: Getting Source
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
+        path: ${{ env.SOURCE_ARTIFACT }}
     - name: Extract Archives
       run: |
         tar -xzf depends.tar.gz
@@ -326,21 +346,33 @@ jobs:
         chmod +x $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt}
         mv $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v6
       with:
         name: prcycoin-v${{ env.VERSION }}-aarch64-linux
         path: ${{ env.ARTIFACT_DIR }}
   build-arm-linux-gnueabihf:
     name: Build for ARM Linux 32bit
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
     env:
       ARTIFACT_DIR: prcycoin-arm32
     steps:
+    - name: Prepare container (ubuntu:20.04 base image)
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y \
+          sudo ca-certificates curl wget git \
+          build-essential g++ make autoconf automake libtool pkg-config cmake bison \
+          python3 python3-setuptools patch xz-utils bzip2 unzip zip bsdmainutils file \
+          clang llvm imagemagick gettext \
+          libtinfo5 zlib1g-dev libbz2-dev xorriso
     - name: Getting Source
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
+        path: ${{ env.SOURCE_ARTIFACT }}
     - name: Extract Archives
       run: |
         tar -xzf depends.tar.gz
@@ -376,21 +408,33 @@ jobs:
         chmod +x $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt}
         mv $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind,qt/prcycoin-qt} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v6
       with:
         name: prcycoin-v${{ env.VERSION }}-arm32
         path: ${{ env.ARTIFACT_DIR }}
   build-riscv64-linux-gnu:
     name: Build for RISC-V 64-bit
     needs: create-source-distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
     env:
       ARTIFACT_DIR: prcycoin-riscv64
     steps:
+    - name: Prepare container (ubuntu:20.04 base image)
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y \
+          sudo ca-certificates curl wget git \
+          build-essential g++ make autoconf automake libtool pkg-config cmake bison \
+          python3 python3-setuptools patch xz-utils bzip2 unzip zip bsdmainutils file \
+          clang llvm imagemagick gettext \
+          libtinfo5 zlib1g-dev libbz2-dev xorriso
     - name: Getting Source
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v7
       with:
         name: ${{ env.SOURCE_ARTIFACT }}
+        path: ${{ env.SOURCE_ARTIFACT }}
     - name: Extract Archives
       run: |
         tar -xzf depends.tar.gz
@@ -426,7 +470,7 @@ jobs:
         chmod +x $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind}
         mv $SOURCE_ARTIFACT/src/{prcycoin-cli,prcycoin-tx,prcycoind} $ARTIFACT_DIR
     - name: Upload Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v6
       with:
         name: prcycoin-v${{ env.VERSION }}-riscv64
         path: ${{ env.ARTIFACT_DIR }}


### PR DESCRIPTION
The hosted ubuntu-20.04 runner was retired and the v1 artifact service shut down, leaving the build factory unable to run. Restore it:

- run all jobs in an ubuntu:20.04 container on ubuntu-latest (same GCC 9 / glibc 2.31 toolchain as the last green builds), with a prepare step for the tools the hosted image provided (incl. libtinfo5, needed by the prebuilt darwin clang)
- update actions to node24 releases: checkout@v5, upload-artifact@v6, download-artifact@v7 (v1 uploads are incompatible with v4+ downloads)
- default run steps to bash: container jobs default to sh, which broke the brace expansions in the packaging steps
- generate version.txt from configure.ac; the file was removed in "build: delete version.txt" but the workflows still read it
- fix macOS SDK pin to Xcode 12.1-12A7403 to match depends/hosts/darwin.mk
- add workflow_dispatch trigger for manual runs
- drop the ubuntu-18.04 build-linux job (libssl1.0-dev/libdb4.8 are no longer installable; it duplicated the depends-based x86_64 build)